### PR TITLE
All operators accept references and owned values.

### DIFF
--- a/src/circuit/operator/inspect.rs
+++ b/src/circuit/operator/inspect.rs
@@ -1,7 +1,7 @@
 //! Defines a sink operator that inspects every element of its input stream by applying a
 //! user-provided callback to it.
 
-use crate::circuit::operator_traits::{Operator, SinkRefOperator};
+use crate::circuit::operator_traits::{Operator, SinkOperator};
 use std::marker::PhantomData;
 
 /// Sink operator that consumes a stream of values of type `T` and
@@ -34,7 +34,7 @@ where
     fn stream_end(&mut self) {}
 }
 
-impl<T, F> SinkRefOperator<T> for Inspect<T, F>
+impl<T, F> SinkOperator<T> for Inspect<T, F>
 where
     T: 'static,
     F: FnMut(&T) + 'static,

--- a/src/circuit/operator/map.rs
+++ b/src/circuit/operator/map.rs
@@ -1,6 +1,6 @@
 //! Operator that applies an arbitrary function to its input.
 
-use crate::circuit::operator_traits::{Operator, UnaryRefOperator};
+use crate::circuit::operator_traits::{Operator, UnaryOperator};
 
 /// Map operator.
 ///
@@ -26,7 +26,7 @@ where
     fn stream_end(&mut self) {}
 }
 
-impl<T1, T2, F> UnaryRefOperator<T1, T2> for Map<F>
+impl<T1, T2, F> UnaryOperator<T1, T2> for Map<F>
 where
     F: Fn(&T1) -> T2 + 'static,
 {

--- a/src/circuit/operator/map2.rs
+++ b/src/circuit/operator/map2.rs
@@ -1,6 +1,6 @@
 //! Binary operator that applies an arbitrary binary function to its inputs.
 
-use crate::circuit::operator_traits::{BinaryRefRefOperator, Operator};
+use crate::circuit::operator_traits::{BinaryOperator, Operator};
 
 /// Binary map operator.
 ///
@@ -26,7 +26,7 @@ where
     fn stream_end(&mut self) {}
 }
 
-impl<T1, T2, T3, F> BinaryRefRefOperator<T1, T2, T3> for Map2<F>
+impl<T1, T2, T3, F> BinaryOperator<T1, T2, T3> for Map2<F>
 where
     F: Fn(&T1, &T2) -> T3 + 'static,
 {


### PR DESCRIPTION
We refactor the definition of operator traits: instead of having two
flavors of all traits that accept inputs by reference and by value, we
now define a single trait for each operator arity (unary, binary, source)
with two separate methods that take references and owned values
respectively.  By default the latter simply delegates to the former, but
the implementer can also write a separate implementation optimized for
by-value calls.

The new design avoids redundant cloning in scenarios where the operator
prefers owned values, but there is no feasible schedule that allows this.
Instead of being forced to clone inputs, the scheduler can simply call
the less efficient by-reference method.

The `Operator` trait has been extended with a new method
`prefer_owned_input(&self)->bool`, which allows the operator to
express its preference to the scheduler.  However, we do not yet have a
scheduler implementation that takes advantage of this.

Possible additional fine tuning that I have not done:

- Binary operators could have two additional methods that take one of
  the arguments by value and the other by reference.  Operators would
  then be able to express preferences per stream and not per entire
  operator.

- Operators could express preferences on a scale rather than as binary
  values.  This way the scheduler could prioritize operators that
  want to consume owned values "the most".