### PR TITLE
API to kill a circuit.

### DIFF
--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -20,4 +20,4 @@ pub mod schedule;
 pub mod trace;
 
 pub use circuit_builder::{Circuit, FeedbackConnector, GlobalNodeId, NodeId, Root, Stream};
-pub use runtime::{LocalStore, LocalStoreMarker, Runtime};
+pub use runtime::{LocalStore, LocalStoreMarker, Runtime, RuntimeHandle};

--- a/src/circuit/operator/communication/exchange.rs
+++ b/src/circuit/operator/communication/exchange.rs
@@ -667,7 +667,7 @@ mod tests {
                 });
 
                 for _ in 1..ROUNDS {
-                    root.step();
+                    root.step().unwrap();
                 }
             });
 


### PR DESCRIPTION
Add the `RuntimeHandle::kill()` API that forces all workers to exit
asap.  Any operators already running are evaluated to completion,
after which the worker thread terminates even if the circuit has
not been fully evaluated for the current clock cycle.

The implementation relies on two thread-local variables in each worker
thread: a Boolean flag that indicates that the worker must exit asap,
and a parker used to wake up the thread if it is blocked waiting
for an operator to become ready.  Schedulers for all subcircuits
must check the flag before evaluating the next operator and must
use the parker when waiting (as opposed to creating their own
parkers or using other blocking primitives).  The latter guarantees
that the `kill` method is able to wake up all blocked workers.