### PR TITLE
Ownership-aware scheduling.

### DIFF
--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -19,5 +19,7 @@ pub mod operator_traits;
 pub mod schedule;
 pub mod trace;
 
-pub use circuit_builder::{Circuit, FeedbackConnector, GlobalNodeId, NodeId, Root, Stream};
+pub use circuit_builder::{
+    Circuit, FeedbackConnector, GlobalNodeId, NodeId, OwnershipPreference, Root, Stream,
+};
 pub use runtime::{LocalStore, LocalStoreMarker, Runtime, RuntimeHandle};

--- a/src/circuit/operator/generator.rs
+++ b/src/circuit/operator/generator.rs
@@ -44,7 +44,7 @@ where
 
 impl<T, F> SourceOperator<T> for Generator<T, F>
 where
-    F: Fn(&mut T) + 'static,
+    F: FnMut(&mut T) + 'static,
     T: Data,
 {
     fn eval(&mut self) -> T {

--- a/src/circuit/operator/integrate.rs
+++ b/src/circuit/operator/integrate.rs
@@ -1,0 +1,174 @@
+use crate::{
+    algebra::{AddAssignByRef, AddByRef, HasZero},
+    circuit::{
+        operator::{Plus, Z1},
+        Circuit, OwnershipPreference, Stream,
+    },
+};
+use std::ops::Add;
+
+impl<P, D> Stream<Circuit<P>, D>
+where
+    P: Clone + 'static,
+    D: Add<Output = D> + AddByRef + AddAssignByRef + Clone + HasZero + 'static,
+{
+    /// Integrate the input stream.
+    ///
+    /// Computes the sum of values in the input stream.
+    /// The first stream in the return tuple contains the value of the integral
+    /// after the current clock cycle.  The second stream contains the value of the
+    /// integral at the previous clock cycle, i.e., the sum of all inputs except
+    /// the last one.  The latter can equivalently be obtained by applying the delay
+    /// operator [`Z1`] to the integral, but this function avoids the extra storage
+    /// overhead and is the preferred way to perform delayed integration.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use dbsp::circuit::{
+    /// #     operator::Generator,
+    /// #     Root,
+    /// # };
+    /// let root = Root::build(move |circuit| {
+    ///     // Generate a stream of 1's.
+    ///     let stream = circuit.add_source(Generator::new(1, |n: &mut usize| {}));
+    ///     // Integrate the stream.
+    ///     let (sum, delayed_sum) = stream.integrate_core();
+    /// #   let mut counter1 = 0;
+    /// #   sum.inspect(move |n| { counter1 += 1; assert_eq!(*n, counter1) });
+    /// #   let mut counter2 = 0;
+    /// #   delayed_sum.inspect(move |n| { assert_eq!(*n, counter2); counter2 += 1; });
+    /// })
+    /// .unwrap();
+    ///
+    /// # for _ in 0..5 {
+    /// #     root.step().unwrap();
+    /// # }
+    /// ```
+    ///
+    /// Streams in the above example will contain the following values:
+    ///
+    /// ```text
+    /// stream:      1, 1, 1, 1, 1, ...
+    /// sum:         1, 2, 3, 4, 5, ...
+    /// delayed_sum: 0, 1, 2, 3, 4, ...
+    /// ```
+    pub fn integrate_core(&self) -> (Stream<Circuit<P>, D>, Stream<Circuit<P>, D>) {
+        // Integration circuit:
+        //
+        // ```
+        //           ┌───┐
+        //    ──────►│   ├─────►
+        //           │ + │
+        //      ┌───►│   ├────┐
+        //      │    └───┘    │
+        //      │             │
+        //      │    ┌───┐    │
+        //      │    │   │    │
+        //      └────┤z-1├────┘
+        //           │   │
+        //           └───┘
+        // ```
+        let (z, feedback) = self.circuit().add_feedback(Z1::new(D::zero()));
+        let adder = self.circuit().add_binary_operator_with_preference(
+            Plus::new(),
+            &z,
+            self,
+            OwnershipPreference::STRONGLY_PREFER_OWNED,
+            OwnershipPreference::PREFER_OWNED,
+        );
+        feedback.connect_with_preference(&adder, OwnershipPreference::STRONGLY_PREFER_OWNED);
+        (adder, z)
+    }
+
+    /// Integrate the input stream.
+    ///
+    /// The output stream contains the sum of all values in the input stream.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// input stream: 1, 1, 1, 1, ...
+    /// outpus stream 0, 1, 2, 3, ...
+    /// ```
+    pub fn integrate(&self) -> Stream<Circuit<P>, D> {
+        self.integrate_core().0
+    }
+
+    /// Delayed integration.
+    ///
+    /// The output stream contains the sum of all values in the input stream
+    /// excluding the last clock cycle.
+    ///
+    /// # Examples
+    ///
+    /// ```text
+    /// input stream: 1, 1, 1, 1, ...
+    /// outpus stream 0, 1, 2, 3, ...
+    /// ```
+    pub fn integrate_delayed(&self) -> Stream<Circuit<P>, D> {
+        self.integrate_core().1
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        algebra::{finite_map::FiniteMap, zset::ZSetHashMap},
+        circuit::{operator::Generator, Root},
+    };
+
+    #[test]
+    fn scalar_integrate() {
+        let root = Root::build(move |circuit| {
+            let source = circuit.add_source(Generator::new(1, |_: &mut usize| {}));
+            let mut counter = 0;
+            source.integrate().inspect(move |n| {
+                counter += 1;
+                assert_eq!(*n, counter);
+            });
+        })
+        .unwrap();
+
+        for _ in 0..100 {
+            root.step().unwrap();
+        }
+    }
+
+    #[test]
+    fn zset_integrate() {
+        let root = Root::build(move |circuit| {
+            let mut counter1 = 0;
+            let source = circuit.add_source(Generator::new(
+                ZSetHashMap::new(),
+                move |s: &mut ZSetHashMap<usize, isize>| {
+                    s.increment(&counter1, 1);
+                    counter1 += 1;
+                },
+            ));
+
+            let (integral, integral_delayed) = source.integrate_core();
+            let mut counter2 = 0;
+            integral.inspect(move |s| {
+                for i in 0..counter2 {
+                    assert_eq!(s.lookup(&i), (counter2 - i) as isize);
+                }
+                counter2 += 1;
+                assert_eq!(s.lookup(&counter2), 0);
+            });
+            let mut counter3 = 0;
+            integral_delayed.inspect(move |s| {
+                for i in 1..counter3 {
+                    assert_eq!(s.lookup(&(i - 1)), (counter3 - i) as isize);
+                }
+                counter3 += 1;
+                assert_eq!(s.lookup(&(counter3 - 1)), 0);
+            });
+        })
+        .unwrap();
+
+        for _ in 0..100 {
+            root.step().unwrap();
+        }
+    }
+}

--- a/src/circuit/operator/mod.rs
+++ b/src/circuit/operator/mod.rs
@@ -9,6 +9,9 @@ pub use apply::Apply;
 mod apply2;
 pub use apply2::Apply2;
 
+mod plus;
+pub use plus::Plus;
+
 mod repeat;
 pub use repeat::Repeat;
 
@@ -20,5 +23,7 @@ pub use nested_source::NestedSource;
 
 mod generator;
 pub use generator::Generator;
+
+mod integrate;
 
 pub mod communication;

--- a/src/circuit/operator/nested_source.rs
+++ b/src/circuit/operator/nested_source.rs
@@ -55,9 +55,10 @@ where
     }
 
     fn clock_start(&mut self) {
-        self.val = unsafe { self.input_stream.get() }
-            .clone()
-            .unwrap_or_default();
+        self.val = match unsafe { self.input_stream.try_take() }.unwrap_or_default() {
+            Cow::Owned(v) => v,
+            Cow::Borrowed(v) => v.clone(),
+        }
     }
 
     fn clock_end(&mut self) {

--- a/src/circuit/operator/plus.rs
+++ b/src/circuit/operator/plus.rs
@@ -1,0 +1,201 @@
+//! Binary plus operator.
+
+use crate::{
+    algebra::{AddAssignByRef, AddByRef},
+    circuit::{
+        operator_traits::{BinaryOperator, Operator},
+        Circuit, OwnershipPreference, Stream,
+    },
+};
+use std::{borrow::Cow, marker::PhantomData, ops::Add};
+
+impl<P, D> Stream<Circuit<P>, D>
+where
+    P: Clone + 'static,
+    D: Add<Output = D> + AddByRef + AddAssignByRef + Clone + 'static,
+{
+    /// Apply the [`Plus`] operator to `self` and `other`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use dbsp::circuit::{
+    /// #     operator::Generator,
+    /// #     Root,
+    /// # };
+    /// let root = Root::build(move |circuit| {
+    ///     // Stream of non-negative values: 0, 1, 2, ...
+    ///     let source1 = circuit.add_source(Generator::new(0, |n: &mut isize| *n += 1));
+    ///     // Stream of non-positive values: 0, -1, -2, ...
+    ///     let source2 = circuit.add_source(Generator::new(0, |n: &mut isize| *n -= 1));
+    ///     // Compute pairwise sums of values in the stream; the output stream will contain zeros.
+    ///     source1.plus(&source2).inspect(|n| assert_eq!(*n, 0));
+    /// })
+    /// .unwrap();
+    ///
+    /// # for _ in 0..5 {
+    /// #     root.step().unwrap();
+    /// # }
+    /// ```
+    pub fn plus(&self, other: &Stream<Circuit<P>, D>) -> Stream<Circuit<P>, D> {
+        self.circuit().add_binary_operator(Plus::new(), self, other)
+    }
+}
+
+/// Operator that computes the sum of values in its two input streams at each timestamp.
+pub struct Plus<D> {
+    phantom: PhantomData<D>,
+}
+
+impl<D> Plus<D> {
+    pub const fn new() -> Self {
+        Self {
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<D> Operator for Plus<D>
+where
+    D: 'static,
+{
+    fn name(&self) -> Cow<'static, str> {
+        Cow::from("Plus")
+    }
+
+    fn clock_start(&mut self) {}
+    fn clock_end(&mut self) {}
+}
+
+impl<D> BinaryOperator<D, D, D> for Plus<D>
+where
+    D: Add<Output = D> + AddByRef + AddAssignByRef + Clone + 'static,
+{
+    fn eval(&mut self, i1: &D, i2: &D) -> D {
+        i1.add_by_ref(i2)
+    }
+
+    fn eval_owned_and_ref(&mut self, mut i1: D, i2: &D) -> D {
+        i1.add_assign_by_ref(i2);
+        i1
+    }
+
+    fn eval_ref_and_owned(&mut self, i1: &D, mut i2: D) -> D {
+        i2.add_assign_by_ref(i1);
+        i2
+    }
+
+    fn eval_owned(&mut self, i1: D, i2: D) -> D {
+        i1 + i2
+    }
+
+    fn input_preference(&self) -> (OwnershipPreference, OwnershipPreference) {
+        (
+            OwnershipPreference::PREFER_OWNED,
+            OwnershipPreference::PREFER_OWNED,
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        algebra::{finite_map::FiniteMap, zset::ZSetHashMap},
+        circuit::{
+            operator::{Generator, Inspect},
+            Circuit, OwnershipPreference, Root,
+        },
+    };
+
+    #[test]
+    fn scalar_plus() {
+        let root = Root::build(move |circuit| {
+            let source1 = circuit.add_source(Generator::new(0, |n: &mut usize| *n += 1));
+            let source2 = circuit.add_source(Generator::new(100, |n: &mut usize| *n -= 1));
+            source1.plus(&source2).inspect(|n| assert_eq!(*n, 100));
+        })
+        .unwrap();
+
+        for _ in 0..100 {
+            root.step().unwrap();
+        }
+    }
+
+    #[test]
+    fn zset_plus() {
+        let build_circuit = |circuit: &Circuit<()>| {
+            let source1 = circuit.add_source(Generator::new(
+                ZSetHashMap::new(),
+                |s: &mut ZSetHashMap<usize, isize>| s.increment(&5, 1),
+            ));
+            let source2 = circuit.add_source(Generator::new(
+                ZSetHashMap::new(),
+                |s: &mut ZSetHashMap<usize, isize>| s.increment(&5, -1),
+            ));
+            source1
+                .plus(&source2)
+                .inspect(|s| assert_eq!(s, &ZSetHashMap::new()));
+            (source1, source2)
+        };
+
+        // Allow `Plus` to consume both streams by value.
+        let root = Root::build(move |circuit| {
+            build_circuit(circuit);
+        })
+        .unwrap();
+
+        for _ in 0..100 {
+            root.step().unwrap();
+        }
+
+        // Only consume source2 by value.
+        let root = Root::build(move |circuit| {
+            let (source1, _source2) = build_circuit(circuit);
+            circuit.add_sink_with_preference(
+                Inspect::new(|_| {}),
+                &source1,
+                OwnershipPreference::STRONGLY_PREFER_OWNED,
+            );
+        })
+        .unwrap();
+
+        for _ in 0..100 {
+            root.step().unwrap();
+        }
+
+        // Only consume source1 by value.
+        let root = Root::build(move |circuit| {
+            let (_source1, source2) = build_circuit(circuit);
+            circuit.add_sink_with_preference(
+                Inspect::new(|_| {}),
+                &source2,
+                OwnershipPreference::STRONGLY_PREFER_OWNED,
+            );
+        })
+        .unwrap();
+
+        for _ in 0..100 {
+            root.step().unwrap();
+        }
+
+        // Consume both streams by reference.
+        let root = Root::build(move |circuit| {
+            let (source1, source2) = build_circuit(circuit);
+            circuit.add_sink_with_preference(
+                Inspect::new(|_| {}),
+                &source1,
+                OwnershipPreference::STRONGLY_PREFER_OWNED,
+            );
+            circuit.add_sink_with_preference(
+                Inspect::new(|_| {}),
+                &source2,
+                OwnershipPreference::STRONGLY_PREFER_OWNED,
+            );
+        })
+        .unwrap();
+
+        for _ in 0..100 {
+            root.step().unwrap();
+        }
+    }
+}

--- a/src/circuit/operator/z1.rs
+++ b/src/circuit/operator/z1.rs
@@ -1,7 +1,8 @@
 //! z^-1 operator delays its input by one timestamp.
 
-use crate::circuit::operator_traits::{
-    Operator, StrictOperator, StrictUnaryOperator, UnaryOperator,
+use crate::circuit::{
+    operator_traits::{Operator, StrictOperator, StrictUnaryOperator, UnaryOperator},
+    OwnershipPreference,
 };
 use std::{borrow::Cow, mem::swap};
 
@@ -57,9 +58,6 @@ where
     fn clock_end(&mut self) {
         self.reset();
     }
-    fn prefer_owned_input(&self) -> bool {
-        true
-    }
 }
 
 impl<T> UnaryOperator<T, T> for Z1<T>
@@ -75,6 +73,10 @@ where
     fn eval_owned(&mut self, mut i: T) -> T {
         swap(&mut self.val, &mut i);
         i
+    }
+
+    fn input_preference(&self) -> OwnershipPreference {
+        OwnershipPreference::PREFER_OWNED
     }
 }
 
@@ -99,6 +101,10 @@ where
 
     fn eval_strict_owned(&mut self, i: T) {
         self.val = i;
+    }
+
+    fn input_preference(&self) -> OwnershipPreference {
+        OwnershipPreference::PREFER_OWNED
     }
 }
 

--- a/src/circuit/schedule/mod.rs
+++ b/src/circuit/schedule/mod.rs
@@ -1,6 +1,6 @@
 //! The scheduling framework controls the execution of a circuit at runtime.
 
-use super::{trace::SchedulerEvent, Circuit};
+use super::{trace::SchedulerEvent, Circuit, GlobalNodeId};
 
 mod static_scheduler;
 pub use static_scheduler::StaticScheduler;
@@ -11,6 +11,14 @@ pub use dynamic_scheduler::DynamicScheduler;
 /// Scheduler errors.
 #[derive(Debug)]
 pub enum Error {
+    /// `origin` node has more than one strong successors who insist on consuming its output by value
+    /// (`OwnershipPreference::STRONGLY_PREFER_OWNED` or higher).
+    OwnershipConflict {
+        origin: GlobalNodeId,
+        consumers: Vec<GlobalNodeId>,
+    },
+    /// Ownership constraints introduce a cycle in the circuit graph.
+    CyclicCircuit { node_id: GlobalNodeId },
     /// Execution of the circuit interrupted by the user (via
     /// [`RuntimeHandle::kill`](`crate::circuit::RuntimeHandle::kill`)).
     Killed,
@@ -25,13 +33,16 @@ pub enum Error {
 /// evaluated before feed input to it.  In addition, the scheduler must wait for an async
 /// operator to be in a ready state before evaluating it
 /// (see [`Operator::is_async`](`crate::circuit::operator_traits::Operator`)).
-pub trait Scheduler {
+pub trait Scheduler
+where
+    Self: Sized,
+{
     /// Create a scheduler for a circuit.
     ///
     /// This method is invoked at circuit construction time to perform any required
     /// preparatory computation, e.g., compute a complete static schedule or build
     /// data structures needed for dynamic scheduling.
-    fn prepare<P>(circuit: &Circuit<P>) -> Self
+    fn prepare<P>(circuit: &Circuit<P>) -> Result<Self, Error>
     where
         P: Clone + 'static;
 
@@ -67,15 +78,15 @@ pub(crate) struct IterativeExecutor<F, S> {
 }
 
 impl<F, S> IterativeExecutor<F, S> {
-    pub(crate) fn new<P>(circuit: &Circuit<P>, termination_check: F) -> Self
+    pub(crate) fn new<P>(circuit: &Circuit<P>, termination_check: F) -> Result<Self, Error>
     where
         P: Clone + 'static,
         S: Scheduler,
     {
-        Self {
+        Ok(Self {
             termination_check,
-            scheduler: <S as Scheduler>::prepare(circuit),
-        }
+            scheduler: <S as Scheduler>::prepare(circuit)?,
+        })
     }
 }
 
@@ -110,14 +121,15 @@ pub(crate) struct OnceExecutor<S> {
 impl<S> OnceExecutor<S>
 where
     S: Scheduler,
+    Self: Sized,
 {
-    pub(crate) fn new<P>(circuit: &Circuit<P>) -> Self
+    pub(crate) fn new<P>(circuit: &Circuit<P>) -> Result<Self, Error>
     where
         P: Clone + 'static,
     {
-        Self {
-            scheduler: <S as Scheduler>::prepare(circuit),
-        }
+        Ok(Self {
+            scheduler: <S as Scheduler>::prepare(circuit)?,
+        })
     }
 }
 
@@ -128,5 +140,113 @@ where
 {
     fn run(&self, circuit: &Circuit<P>) -> Result<(), Error> {
         self.scheduler.step(circuit)
+    }
+}
+
+/// Some useful tools for developing schedulers.
+mod util {
+
+    use crate::circuit::{schedule::Error, Circuit, GlobalNodeId, NodeId, OwnershipPreference};
+    use petgraph::graphmap::DiGraphMap;
+    use std::{collections::HashMap, ops::Deref};
+
+    /// Dump circuit topology as a graph.
+    pub(crate) fn circuit_graph<P>(circuit: &Circuit<P>) -> DiGraphMap<NodeId, ()> {
+        let mut g = DiGraphMap::<NodeId, ()>::new();
+
+        for node_id in circuit.node_ids().into_iter() {
+            g.add_node(node_id);
+        }
+
+        for edge in circuit.edges().deref().iter() {
+            if let Some(from) = edge.from {
+                g.add_edge(from, edge.to, ());
+            }
+        }
+
+        g
+    }
+
+    /// Helper function used by schedulers to enforce ownership preferences.
+    ///
+    /// Individual schedulers can implement their own algorithms to enforce (or ignore)
+    /// ownership preferences.  This helper function can optionally used by schedulers that
+    /// wish to implement one particular approach.  The idea is to treat **strong** ownership
+    /// preferences (`OwnershipPreference::STRONGLY_PREFER_OWNED` and above) as scheduling constraints:
+    /// assuming an operator has exactly one successor with a strong ownership preference
+    /// ("strong successor"), we can enforce this preference by scheduling this successor last.
+    /// This scheduling constraint can in turn be enforced by adding a dependency edge from
+    /// all other successors to the strong successor node to the circuit graph.  This function
+    /// computes the set of dependency edges needed to enforce all such constraints in the
+    /// circuit.
+    ///
+    /// # Caveat
+    ///
+    /// The additional edges computed by this function can introduce cycles to the circuit
+    /// graph making it unschedulable.  Schedulers must check for cycles before adding these
+    /// constraints and either fail or drop some of the constraints to eliminate cycles.
+    ///
+    /// (Current scheduler implementations fail if there is a cycle).
+    ///
+    /// # Errors
+    ///
+    /// The function fails with [`Error::OwnershipConflict`] if the circuit has at least one
+    /// node with multiple strong successors.
+    pub(crate) fn ownership_constraints<P>(
+        circuit: &Circuit<P>,
+    ) -> Result<Vec<(NodeId, NodeId)>, Error> {
+        // Compute successors of each node in the circuit.  Note: we index successors by origin
+        // id, not local node id, since the former uniquely identifies a stream, but the latter
+        // doesn't, since a subcircuit node can have multiple output streams.
+        let num_nodes = circuit.num_nodes();
+        let mut successors: HashMap<GlobalNodeId, Vec<(NodeId, Option<OwnershipPreference>)>> =
+            HashMap::with_capacity(num_nodes);
+
+        for edge in circuit.edges().deref().iter() {
+            successors
+                .entry(edge.origin.clone())
+                .or_insert_with(Vec::new)
+                .push((edge.to, edge.ownership_preference));
+        }
+
+        let mut constraints = Vec::new();
+
+        for (origin, succ) in successors.into_iter() {
+            // Find all strong successors of a node.
+            let strong_successors: Vec<_> = succ
+                .iter()
+                .enumerate()
+                .filter(|(_i, (_, pref))| {
+                    pref.is_some() && pref.unwrap() >= OwnershipPreference::STRONGLY_PREFER_OWNED
+                })
+                .collect();
+
+            // Declare conflict if there's more than one strong successor.
+            if strong_successors.len() > 1 {
+                return Err(Error::OwnershipConflict {
+                    origin,
+                    consumers: strong_successors
+                        .into_iter()
+                        .map(|(_, (suc, _))| GlobalNodeId::child_of(circuit, *suc))
+                        .collect(),
+                });
+            };
+
+            // No strong successors -- nothing to do for this node.
+            if strong_successors.is_empty() {
+                continue;
+            }
+
+            // A unique strong successor found; add edges from all other successors to it.
+            let strong_successor_index = strong_successors[0].0;
+            for (i, successor) in succ.iter().enumerate() {
+                // Ignore dependency edges.
+                if i != strong_successor_index && successor.1.is_some() {
+                    constraints.push((successor.0, succ[strong_successor_index].0));
+                }
+            }
+        }
+
+        Ok(constraints)
     }
 }

--- a/src/circuit/trace.rs
+++ b/src/circuit/trace.rs
@@ -17,14 +17,14 @@
 
 use std::{borrow::Cow, fmt, fmt::Display, hash::Hash};
 
-use super::{GlobalNodeId, NodeId};
+use super::{GlobalNodeId, NodeId, OwnershipPreference};
 pub use trace_monitor::TraceMonitor;
 
 /// Type of edge in a circuit graph.
 #[derive(Debug, Eq, PartialEq, Clone, Hash)]
 pub enum EdgeKind {
     /// A stream edge indicates that there is a stream that connects two operators.
-    Stream,
+    Stream(OwnershipPreference),
     /// A dependency edge indicates that the source operator must be evaluated before
     /// the destination.
     Dependency,
@@ -104,11 +104,11 @@ impl Display for CircuitEvent {
                 )
             }
             Self::Edge {
-                kind: EdgeKind::Stream,
+                kind: EdgeKind::Stream(preference),
                 from,
                 to,
             } => {
-                write!(f, "Stream({} -> {})", from, to)
+                write!(f, "Stream({} -> [{}]{})", from, preference, to)
             }
             Self::Edge {
                 kind: EdgeKind::Dependency,
@@ -144,9 +144,13 @@ impl CircuitEvent {
     }
 
     /// Create a [`CircuitEvent::Edge`] event instance.
-    pub fn stream(from: GlobalNodeId, to: GlobalNodeId) -> Self {
+    pub fn stream(
+        from: GlobalNodeId,
+        to: GlobalNodeId,
+        ownership_preference: OwnershipPreference,
+    ) -> Self {
         Self::Edge {
-            kind: EdgeKind::Stream,
+            kind: EdgeKind::Stream(ownership_preference),
             from,
             to,
         }


### PR DESCRIPTION
Background
----------

A stream in a circuit can be connected to multiple consumers.  It is
therefore generally impossible to provide each consumer with an owned
copy of the data without cloning it.  At the same time, many operators
can be more efficient when working with owned inputs.  For instance,
when computing a sum of two z-sets, if one of the input z-sets is owned
we can just add values from the other z-set to it without cloning the
first z-set.  If both inputs are owned then we additionally do not need
to clone key/value pairs when inserting them.  Furthermore, the
implementation can choose to add the contents of the smaller z-set to
the larger one.

Ownership-aware scheduling
--------------------------

To leverage such optimizations, we adopt the best-effort approach:
operators consume streaming data by-value when possible while falling
back to pass-by-reference otherwise.  In a synchronous circuit, each
operator reads its input stream precisely once in each clock cycle.  It
is therefore possible to determine the last consumer at each clock cycle
and give it the owned value from the channel.  It is furthermore
possible for the scheduler to schedule operators that strongly prefer
owned values last.

We capture ownership preferences at two levels.  First, each individual
operator that consumes one or more streams exposes its preferences on a
per-stream basis via an API method (e.g.,
`[UnaryOperator::input_preference]`).  The [`Circuit`] API allows the
circuit builder to override these preferences when instantiating an
operator, taking into account circuit topology and workload.  We express
preference as a numeric value.

These preferences are associated with each edge in the circuit graph.
The schedulers (both static and dynamic)  have been extended to
implement a limited form of ownership-aware scheduling.  They only
consider strong preferences (`OwnershipPreference::require_owned` and
stronger) and model them as hard constraints that must be satisfied for
the circuit to be schedulable.  Weaker preferences are ignored.

New operators
-------------

This commit also adds new operators needed to test ownership-aware
scheduling:
- Binary plus
- Integrator

We also start adding convenience APIs for instantiating operators using
extension traits, so that instead of
`Circuit::add_unary_operator(Inspect::new(|x| ...), stream)` one can
just write `stream.inspect(|x| ...)`.

Issues and limitations
----------------------

The above changes make the `enter` API potentially dangerous.  There is
nothing preventing the child circuit to read from the entered stream
multiple times, thus removing the value from the stream while it is
still needed by other consumers.  We will address this in an upcoming
PR.

The new scheduling policy could also do with more testing.