### PR TITLE
Operators over streams: Z1, integrate.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ Copyright (c) 2021 VMware, Inc
 
 extern crate num;
 
+mod shared_ref;
+pub use shared_ref::SharedRef;
 pub mod algebra;
 pub mod circuit;
 pub mod operator;

--- a/src/operator/adapter.rs
+++ b/src/operator/adapter.rs
@@ -1,0 +1,177 @@
+//! Adapter operators wrap around regular operators and decapsulate
+//! inputs wrapped in shared references.
+//!
+//! Adapters in this module allow existing operators such as `Plus<T>`
+//! to be applied to streams that carry data of type `Ref<T>`, where
+//! `Ref` is any type that implements trait [`SharedRef`](`crate::SharedRef`).
+//! The adapter tries to extract an owned value from `Ref` if possible
+//! and borrows the value otherwise before invoking the inner operator.
+//! We provide these generic adapters so we do not need to generalize the
+//! implementation of individual operators to handle shared references.
+//!
+//! For good measure, the adapter also optionally wraps the output of
+//! the inner operator in `Ref` or converts it to any other type that
+//! implements `From<T>`.  This isn't strictly necessary, as the same
+//! can be achieved by chaining the operator with a simple transformer
+//! operator.
+
+use std::{borrow::Cow, marker::PhantomData};
+
+use crate::{
+    circuit::{
+        operator_traits::{BinaryOperator, Operator, UnaryOperator},
+        OwnershipPreference, Scope,
+    },
+    SharedRef,
+};
+
+/// Unary operator adapter unwraps input values of type
+/// `I` wrapped in a shared reference.  See
+/// [module-level documentation](`crate::operator::adapter`) for details.
+pub struct UnaryOperatorAdapter<I, O, Op> {
+    op: Op,
+    _types: PhantomData<(I, O)>,
+}
+
+impl<I, O, Op> Operator for UnaryOperatorAdapter<I, O, Op>
+where
+    Op: Operator,
+    I: 'static,
+    O: 'static,
+{
+    fn name(&self) -> Cow<'static, str> {
+        self.op.name()
+    }
+    fn clock_start(&mut self, scope: Scope) {
+        self.op.clock_start(scope);
+    }
+    fn clock_end(&mut self, scope: Scope) {
+        self.op.clock_end(scope);
+    }
+    fn is_async(&self) -> bool {
+        self.op.is_async()
+    }
+    fn ready(&self) -> bool {
+        self.op.ready()
+    }
+    fn register_ready_callback<F>(&mut self, cb: F)
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        self.op.register_ready_callback(cb);
+    }
+}
+
+impl<RI, I, RO, O, Op> UnaryOperator<RI, RO> for UnaryOperatorAdapter<I, O, Op>
+where
+    Op: UnaryOperator<I, O>,
+    RI: SharedRef<I>,
+    I: 'static,
+    RO: From<O>,
+    O: 'static,
+{
+    fn eval(&mut self, input: &RI) -> RO {
+        RO::from(self.op.eval(input.borrow()))
+    }
+
+    fn eval_owned(&mut self, input: RI) -> RO {
+        RO::from(match input.try_into_owned() {
+            Ok(v) => self.op.eval_owned(v),
+            Err(v) => self.op.eval(v.borrow()),
+        })
+    }
+
+    fn input_preference(&self) -> OwnershipPreference {
+        self.op.input_preference()
+    }
+}
+
+/// Binary operator adapter unwraps input values of types
+/// `I1` and `I2` wrapped in shared references.  See
+/// [module-level documentation](`crate::operator::adapter`) for details.
+pub struct BinaryOperatorAdapter<I1, I2, O, Op> {
+    op: Op,
+    _types: PhantomData<(I1, I2, O)>,
+}
+
+impl<I1, I2, O, Op> BinaryOperatorAdapter<I1, I2, O, Op> {
+    pub fn new(op: Op) -> Self {
+        Self {
+            op,
+            _types: PhantomData,
+        }
+    }
+}
+
+impl<I1, I2, O, Op> Operator for BinaryOperatorAdapter<I1, I2, O, Op>
+where
+    Op: Operator,
+    I1: 'static,
+    I2: 'static,
+    O: 'static,
+{
+    fn name(&self) -> Cow<'static, str> {
+        self.op.name()
+    }
+    fn clock_start(&mut self, scope: Scope) {
+        self.op.clock_start(scope);
+    }
+    fn clock_end(&mut self, scope: Scope) {
+        self.op.clock_end(scope);
+    }
+    fn is_async(&self) -> bool {
+        self.op.is_async()
+    }
+    fn ready(&self) -> bool {
+        self.op.ready()
+    }
+    fn register_ready_callback<F>(&mut self, cb: F)
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        self.op.register_ready_callback(cb);
+    }
+}
+
+impl<RI1, I1, RI2, I2, RO, O, Op> BinaryOperator<RI1, RI2, RO>
+    for BinaryOperatorAdapter<I1, I2, O, Op>
+where
+    Op: BinaryOperator<I1, I2, O>,
+    RI1: SharedRef<I1>,
+    RI2: SharedRef<I2>,
+    I1: 'static,
+    I2: 'static,
+    RO: From<O>,
+    O: 'static,
+{
+    fn eval(&mut self, left: &RI1, right: &RI2) -> RO {
+        RO::from(self.op.eval(left.borrow(), right.borrow()))
+    }
+
+    fn eval_owned(&mut self, left: RI1, right: RI2) -> RO {
+        RO::from(match (left.try_into_owned(), right.try_into_owned()) {
+            (Ok(v1), Ok(v2)) => self.op.eval_owned(v1, v2),
+            (Ok(v1), Err(v2)) => self.op.eval_owned_and_ref(v1, v2.borrow()),
+            (Err(v1), Ok(v2)) => self.op.eval_ref_and_owned(v1.borrow(), v2),
+            (Err(v1), Err(v2)) => self.op.eval(v1.borrow(), v2.borrow()),
+        })
+    }
+
+    fn eval_owned_and_ref(&mut self, left: RI1, right: &RI2) -> RO {
+        RO::from(match left.try_into_owned() {
+            Ok(v) => self.op.eval_owned_and_ref(v, right.borrow()),
+            Err(v) => self.op.eval(v.borrow(), right.borrow()),
+        })
+    }
+
+    fn eval_ref_and_owned(&mut self, left: &RI1, right: RI2) -> RO {
+        RO::from(match right.try_into_owned() {
+            Ok(v) => self.op.eval_ref_and_owned(left.borrow(), v),
+            Err(v) => self.op.eval(left.borrow(), v.borrow()),
+        })
+    }
+
+    fn input_preference(&self) -> (OwnershipPreference, OwnershipPreference) {
+        self.op.input_preference()
+    }
+}

--- a/src/operator/integrate.rs
+++ b/src/operator/integrate.rs
@@ -1,9 +1,9 @@
 use crate::{
     algebra::{AddAssignByRef, AddByRef, HasZero},
     circuit::{Circuit, OwnershipPreference, Stream},
-    operator::{Plus, Z1},
+    operator::{BinaryOperatorAdapter, Plus, Z1Nested, Z1},
 };
-use std::ops::Add;
+use std::{ops::Add, rc::Rc};
 
 /// Struct returned by the [`Stream::integrate`] operation.
 ///
@@ -34,6 +34,43 @@ impl<P, I> StreamIntegral<P, I> {
         current: Stream<Circuit<P>, I>,
         delayed: Stream<Circuit<P>, I>,
         export: Stream<P, I>,
+        input: Stream<Circuit<P>, I>,
+    ) -> Self {
+        Self {
+            current,
+            delayed,
+            export,
+            input,
+        }
+    }
+}
+
+/// Struct returned by the [`Stream::integrate_nested`] operation.
+///
+/// This struct bundles the four output streams produced by the
+/// `integrate_nested` method. Below, we denote `stream[i,j]` the value of
+/// `stream` at time `[i,j]`, where `i` is the parent timestamp, and `j` is the
+/// child timestamp.
+///
+/// * `current` - the current value of the integral: `current[i,j] =
+///   sum(input[k,j]), k<=i`.
+/// * `delayed` - the previous value of the integral: `delayed[i,j] =
+///   sum(input[k,j]), k<i`.
+/// * `export` - stream exported to the parent circuit that contains the final
+///   value of the integral at the end of the nested clock epoch.
+/// * `input` - reference to the input stream.
+pub struct NestedStreamIntegral<P, I> {
+    pub current: Stream<Circuit<P>, Rc<I>>,
+    pub delayed: Stream<Circuit<P>, Rc<I>>,
+    pub export: Stream<P, Rc<I>>,
+    pub input: Stream<Circuit<P>, I>,
+}
+
+impl<P, I> NestedStreamIntegral<P, I> {
+    fn new(
+        current: Stream<Circuit<P>, Rc<I>>,
+        delayed: Stream<Circuit<P>, Rc<I>>,
+        export: Stream<P, Rc<I>>,
         input: Stream<Circuit<P>, I>,
     ) -> Self {
         Self {
@@ -123,15 +160,62 @@ where
         feedback.connect_with_preference(&adder, OwnershipPreference::STRONGLY_PREFER_OWNED);
         StreamIntegral::new(adder, z.local, z.export, self.clone())
     }
+
+    /// Integrate stream of streams.
+    ///
+    /// Computes the sum of nested streams, i.e., rather than integrating values
+    /// in each nested stream, this function sums up entire input streams
+    /// across all parent timestamps, where the sum of streams is defined as
+    /// a stream of point-wise sums of their elements: `integral[i,j] =
+    /// sum(input[k,j]), k<=i`, where `stream[i,j]` is the value of `stream`
+    /// at time `[i,j]`, `i` is the parent timestamp, and `j` is the child
+    /// timestamp.
+    ///
+    /// Yields the sum element-by-element as the input stream is fed to the
+    /// integral.
+    ///
+    /// # Examples
+    ///
+    /// Input stream (one row per parent timestamps):
+    ///
+    /// ```text
+    /// 1 2 3 4
+    /// 1 1 1 1 1
+    /// 2 2 2 0 0
+    /// ```
+    ///
+    /// Integral:
+    ///
+    /// ```text
+    /// 1 2 3 4
+    /// 2 3 4 5 1
+    /// 4 5 6 5 1
+    /// ```
+    pub fn integrate_nested(&self) -> NestedStreamIntegral<P, D> {
+        let (z, feedback) = self
+            .circuit()
+            .add_feedback_with_export(Z1Nested::new(Rc::new(D::zero())));
+        let adder = self.circuit().add_binary_operator_with_preference(
+            <BinaryOperatorAdapter<D, D, D, _>>::new(Plus::new()),
+            &z.local,
+            self,
+            OwnershipPreference::STRONGLY_PREFER_OWNED,
+            OwnershipPreference::PREFER_OWNED,
+        );
+        feedback.connect_with_preference(&adder, OwnershipPreference::STRONGLY_PREFER_OWNED);
+        NestedStreamIntegral::new(adder, z.local, z.export, self.clone())
+    }
 }
 
 #[cfg(test)]
 mod test {
     use crate::{
         algebra::{FiniteMap, MapBuilder, ZSetHashMap},
-        circuit::Root,
-        operator::Generator,
+        circuit::{trace::TraceMonitor, Root},
+        operator::{Generator, Z1},
     };
+
+    use std::sync::{Arc, Mutex};
 
     #[test]
     fn scalar_integrate() {
@@ -183,6 +267,67 @@ mod test {
         .unwrap();
 
         for _ in 0..100 {
+            root.step().unwrap();
+        }
+    }
+
+    #[rustfmt::skip]
+    //            ┌───────────────────────────────────────────────────────────────────────────────────┐
+    //            │                                                                                   │
+    //            │                           3,2,1,0,0,0                     3,2,1,0,                │
+    //            │                           4,3,2,1,0,0                     7,5,3,1,0,              │
+    //            │                    ┌───┐  2,1,0,0,0,0                     9,6,3,1,0,              │
+    //  3,4,2,5   │                    │   │  5,4,3,2,1,0                     14,10,6,3,1,0           │ 6,16,19,34
+    // ───────────┼──►delta0──────────►│ + ├──────────┬─────►integrate_nested───────────────integrate─┼─────────────►
+    //            │          3,0,0,0,0 │   │          │                                               │
+    //            │          4,0,0,0,0 └───┘          ▼                                               │
+    //            │          2,0,0,0,0   ▲    ┌──┐   ┌───┐                                            │
+    //            │          5,0,0,0,0   └────┤-1│◄──|z-1|                                            │
+    //            │                           └──┘   └───┘                                            │
+    //            │                                                                                   │
+    //            └───────────────────────────────────────────────────────────────────────────────────┘
+    #[test]
+    fn scalar_integrate_nested() {
+        let root = Root::build(move |circuit| {
+            TraceMonitor::attach(
+                Arc::new(Mutex::new(TraceMonitor::new_panic_on_error())),
+                circuit,
+                "monitor",
+            );
+
+            let mut input = vec![3, 4, 2, 5].into_iter();
+
+            let mut expected_counters = vec![
+                3, 2, 1, 0,
+                4, 3, 2, 1, 0,
+                2, 1, 0, 0, 0,
+                5, 4, 3, 2, 1, 0
+            ].into_iter();
+            let mut expected_integrals = vec![
+                3,  2,  1, 0,
+                7,  5,  3, 1, 0,
+                9,  6,  3, 1, 0,
+                14, 10, 6, 3, 1, 0
+            ].into_iter();
+            let mut expected_outer_integrals = vec![6, 16, 19, 34].into_iter();
+
+            let source = circuit.add_source(Generator::new(move || input.next().unwrap()));
+            let integral = circuit.iterate_with_condition(|child| {
+                let source = source.delta0(&child);
+                let (z, feedback) = child.add_feedback(Z1::new(0));
+                let plus = source.plus(&z.apply(|n| if *n > 0 { *n-1 } else { *n }));
+                plus.inspect(move |n| assert_eq!(*n, expected_counters.next().unwrap()));
+                feedback.connect(&plus);
+                let integral = plus.integrate_nested();
+                integral.current.inspect(move |n| assert_eq!(**n, expected_integrals.next().unwrap()));
+                Ok((integral.current.condition(|n| **n == 0), integral.current.apply(|rc| **rc).integrate().export))
+            })
+            .unwrap();
+            integral.inspect(move |n| assert_eq!(*n, expected_outer_integrals.next().unwrap()))
+        })
+        .unwrap();
+
+        for _ in 0..4 {
             root.step().unwrap();
         }
     }

--- a/src/operator/mod.rs
+++ b/src/operator/mod.rs
@@ -1,5 +1,8 @@
 //! Some basic operators.
 
+pub mod adapter;
+pub use adapter::{BinaryOperatorAdapter, UnaryOperatorAdapter};
+
 pub(crate) mod inspect;
 pub use inspect::Inspect;
 
@@ -13,7 +16,7 @@ mod plus;
 pub use plus::Plus;
 
 mod z1;
-pub use z1::Z1;
+pub use z1::{Z1Nested, Z1};
 
 mod generator;
 pub use generator::Generator;

--- a/src/operator/z1.rs
+++ b/src/operator/z1.rs
@@ -14,6 +14,8 @@ use std::{borrow::Cow, mem::swap};
 /// value is typically the neutral element of a monoid (e.g., 0 for addition
 /// or 1 for multiplication).
 ///
+/// It is a strict operator.
+///
 /// # Examples
 ///
 /// ```text
@@ -25,8 +27,6 @@ use std::{borrow::Cow, mem::swap};
 ///   3  |   8   |   7
 ///         ...
 /// ```
-///
-/// It is a strict operator
 pub struct Z1<T> {
     zero: T,
     val: T,
@@ -110,47 +110,211 @@ where
     }
 }
 
-#[test]
-fn sum_circuit() {
-    let mut z1 = Z1::new(0);
+/// z^-1 operator over streams of streams.
+///
+/// The operator stores a complete nested stream consumed at the last iteration
+/// of the parent clock and outputs it at the next parent clock cycle
+/// It outputs a stream of zeros value in the first parent clock tick.
+///
+/// It is a strict operator.
+///
+/// # Examples
+///
+/// Input (one row per parent timestamps):
+///
+/// ```text
+/// 1 2 3 4
+/// 1 1 1 1 1
+/// 2 2 2 0 0
+/// ```
+///
+/// Output:
+///
+/// ```text
+/// 0 0 0 0
+/// 1 2 3 4 0
+/// 1 1 1 1 1
+/// ```
+pub struct Z1Nested<T> {
+    zero: T,
+    timestamp: usize,
+    val: Vec<T>,
+}
 
-    let expected_result = vec![0, 1, 2, 0, 4, 5];
+impl<T> Z1Nested<T>
+where
+    T: Clone,
+{
+    pub fn new(zero: T) -> Self {
+        Self {
+            zero,
+            timestamp: 0,
+            val: vec![],
+        }
+    }
 
-    // Test `UnaryOperator` API.
-    let mut res = Vec::new();
-    z1.clock_start(0);
-    res.push(z1.eval(&1));
-    res.push(z1.eval(&2));
-    res.push(z1.eval(&3));
-    z1.clock_end(0);
+    fn reset(&mut self) {
+        self.timestamp = 0;
+        self.val = vec![];
+    }
+}
 
-    z1.clock_start(0);
-    res.push(z1.eval_owned(4));
-    res.push(z1.eval_owned(5));
-    res.push(z1.eval_owned(6));
-    z1.clock_end(0);
+impl<T> Operator for Z1Nested<T>
+where
+    T: Clone + 'static,
+{
+    fn name(&self) -> Cow<'static, str> {
+        Cow::from("Z^-1 (nested)")
+    }
 
-    assert_eq!(res, expected_result);
+    fn clock_start(&mut self, scope: Scope) {
+        if scope == 0 {
+            self.val.truncate(self.timestamp);
+        }
+        self.timestamp = 0;
+    }
 
-    // Test `StrictUnaryOperator` API.
-    let mut res = Vec::new();
-    z1.clock_start(0);
-    res.push(z1.get_output());
-    z1.eval_strict(&1);
-    res.push(z1.get_output());
-    z1.eval_strict(&2);
-    res.push(z1.get_output());
-    z1.eval_strict(&3);
-    z1.clock_end(0);
+    fn clock_end(&mut self, scope: Scope) {
+        if scope > 0 {
+            self.reset();
+        }
+    }
+}
 
-    z1.clock_start(0);
-    res.push(z1.get_output());
-    z1.eval_strict_owned(4);
-    res.push(z1.get_output());
-    z1.eval_strict_owned(5);
-    res.push(z1.get_output());
-    z1.eval_strict_owned(6);
-    z1.clock_end(0);
+impl<T> StrictOperator<T> for Z1Nested<T>
+where
+    T: Clone + 'static,
+{
+    fn get_output(&mut self) -> T {
+        if self.timestamp >= self.val.len() {
+            assert_eq!(self.timestamp, self.val.len());
+            self.val.push(self.zero.clone());
+        }
 
-    assert_eq!(res, expected_result);
+        let mut zero = self.zero.clone();
+        swap(
+            unsafe { self.val.get_unchecked_mut(self.timestamp) },
+            &mut zero,
+        );
+        zero
+    }
+}
+
+impl<T> StrictUnaryOperator<T, T> for Z1Nested<T>
+where
+    T: Clone + 'static,
+{
+    fn eval_strict(&mut self, i: &T) {
+        assert!(self.timestamp < self.val.len());
+
+        self.val[self.timestamp] = i.clone();
+        self.timestamp += 1;
+    }
+
+    fn eval_strict_owned(&mut self, i: T) {
+        assert!(self.timestamp < self.val.len());
+
+        self.val[self.timestamp] = i;
+        self.timestamp += 1;
+    }
+
+    fn input_preference(&self) -> OwnershipPreference {
+        OwnershipPreference::PREFER_OWNED
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        circuit::operator_traits::{Operator, StrictOperator, StrictUnaryOperator, UnaryOperator},
+        operator::{Z1Nested, Z1},
+    };
+
+    #[test]
+    fn z1_test() {
+        let mut z1 = Z1::new(0);
+
+        let expected_result = vec![0, 1, 2, 0, 4, 5];
+
+        // Test `UnaryOperator` API.
+        let mut res = Vec::new();
+        z1.clock_start(0);
+        res.push(z1.eval(&1));
+        res.push(z1.eval(&2));
+        res.push(z1.eval(&3));
+        z1.clock_end(0);
+
+        z1.clock_start(0);
+        res.push(z1.eval_owned(4));
+        res.push(z1.eval_owned(5));
+        res.push(z1.eval_owned(6));
+        z1.clock_end(0);
+
+        assert_eq!(res, expected_result);
+
+        // Test `StrictUnaryOperator` API.
+        let mut res = Vec::new();
+        z1.clock_start(0);
+        res.push(z1.get_output());
+        z1.eval_strict(&1);
+        res.push(z1.get_output());
+        z1.eval_strict(&2);
+        res.push(z1.get_output());
+        z1.eval_strict(&3);
+        z1.clock_end(0);
+
+        z1.clock_start(0);
+        res.push(z1.get_output());
+        z1.eval_strict_owned(4);
+        res.push(z1.get_output());
+        z1.eval_strict_owned(5);
+        res.push(z1.get_output());
+        z1.eval_strict_owned(6);
+        z1.clock_end(0);
+
+        assert_eq!(res, expected_result);
+    }
+
+    #[test]
+    fn z1_nested_test() {
+        let mut z1 = Z1Nested::new(0);
+
+        // Test `StrictUnaryOperator` API.
+        let mut res = Vec::new();
+        z1.clock_start(0);
+        res.push(z1.get_output());
+        z1.eval_strict(&1);
+        res.push(z1.get_output());
+        z1.eval_strict(&2);
+        res.push(z1.get_output());
+        z1.eval_strict(&3);
+        z1.clock_end(0);
+        assert_eq!(res.as_slice(), &[0, 0, 0]);
+
+        let mut res = Vec::new();
+
+        z1.clock_start(0);
+        res.push(z1.get_output());
+        z1.eval_strict_owned(4);
+        res.push(z1.get_output());
+        z1.eval_strict_owned(5);
+        z1.clock_end(0);
+
+        assert_eq!(res.as_slice(), &[1, 2]);
+
+        let mut res = Vec::new();
+
+        z1.clock_start(0);
+        res.push(z1.get_output());
+        z1.eval_strict_owned(6);
+        res.push(z1.get_output());
+        z1.eval_strict_owned(7);
+        res.push(z1.get_output());
+        z1.eval_strict_owned(8);
+        res.push(z1.get_output());
+        z1.eval_strict_owned(9);
+        z1.clock_end(0);
+
+        assert_eq!(res.as_slice(), &[4, 5, 0, 0]);
+    }
 }

--- a/src/shared_ref.rs
+++ b/src/shared_ref.rs
@@ -1,0 +1,31 @@
+//! Shared reference trait.
+
+use std::{borrow::Borrow, rc::Rc};
+
+/// A trait that generalizes shared pointers like `Rc` and `Arc`.
+///
+/// The holder of a shared reference can extract an owned copy
+/// of the reference object from it if there are no other references
+/// to the same object (the refcount is 0).
+pub trait SharedRef<T>: Borrow<T> + Clone + Sized {
+    /// Try to extract the owned value from `self`.
+    ///
+    /// If `self` is the last reference to the object, returns
+    /// the object; otherwise, returns `Err(self)`.
+    fn try_into_owned(self) -> Result<T, Self>;
+}
+
+impl<T> SharedRef<T> for T
+where
+    T: Clone,
+{
+    fn try_into_owned(self) -> Result<T, Self> {
+        Ok(self)
+    }
+}
+
+impl<T> SharedRef<T> for Rc<T> {
+    fn try_into_owned(self) -> Result<T, Self> {
+        Rc::try_unwrap(self)
+    }
+}


### PR DESCRIPTION
Versions of z^-1 and integrator that work on streams rather than
individual values.  Mathematically, these are identical to regular `Z1`
and `integrate` operators, but implementation-wise these operators
consume the inputs value-by-value as the (conceptually infinite) input
stream gets generated.

This commit also introduces an adapter mechanism that makes it easy to
wrap values in streams in shared references (`Rc`, `Arc`, `Intern`,
etc).  Adapter operators encapsulate regular operators, which do not need
to know about such references, and take care of unwrapping inputs and
wrapping outputs.  This mechanism allows shared values to be stored
(read-only) in multiple operators without memory bloat.  We introduce
this capability now since it will be useful in  combination with the new
`integrate_nested` operator.  Consider the following circuit, that will
arise in the implementation of nested incremental join:

```
       integrate_nested
      ┌───────────────┐
      │               │
      │     ┌───┐     │
      │     │   │     │
──────┼─────┤ + ├───┬─┼─ Z ─────►
      │     │   │   │ │
      │     └───┘   │ │
      │       ▲     │ │
      │       │     │ │
      │ ZNested ◄───┘ │
      │               │
      └───────────────┘
```

Here the `ZNested` that is part of the nested integrator stores a vector
of Z-sets, one per nested timestamp.  The "regular" `Z` operator
(\lift(Z)) contains a copy of the second-last element of the vector.