### PR TITLE
Stream caching.

### DIFF
--- a/src/circuit/cache.rs
+++ b/src/circuit/cache.rs
@@ -1,0 +1,90 @@
+//! Circuit cache.
+//!
+//! # Background
+//!
+//! We use a form of caching to reuse previously constructed fragments of the
+//! circuit. For instance, a
+//! [`stream.integrate()`](`crate::circuit::Stream::integrate`) call creates a
+//! feedback loop with an adder and a `z^-1` operator.  The output of this
+//! circuit is cached, so that the next identical call will return the same
+//! stream without creating a new copy of the same operators.  Stream integral
+//! is one example of a derived stream.  Others include
+//! [nested integral](`crate::circuit::Stream::integrate_nested`), [delayed
+//! stream](`crate::circuit::Stream::delay`), etc.  Caching allows simplifying
+//! high-level APIs like nested incremental join that combine several derived
+//! streams.  Without caching, such methods would have to either construct all
+//! derived streams internally, potentially creating duplicate operators and
+//! thus wasting CPU and memory or take multiple derived streams as input, which
+//! would require the caller to track these derivatives manually.
+//!
+//! # API
+//!
+//! This module provides a low-level mechanism that individual operators use to
+//! perform operator-specific caching.  The mechanism consists of a key-value
+//! store associated with each circuit.  We use `TypedMap`, which supports
+//! multiple key and value types, for the store.  An operator registers a new
+//! key type and associated value type using the [`circuit_cache_key`] macro,
+//! e.g.,
+//!
+//! ```ignore
+//! circuit_cache_key!(IntegralId<C, D>(NodeId => Stream<C, D>));
+//! ```
+//!
+//! declares a mapping from `NodeId` to `Stream` used by the
+//! [`Stream::integrate`](`crate::circuit::Stream::integrate`) method to cache
+//! the output of the integrator.  Internally, the method first performs a map
+//! lookup and returns the cached stream, if one exists; otherwise it
+//! instantiates the integration circuit and stores its output stream in the
+//! cache before returning it to the caller.
+
+use typedmap::TypedMap;
+
+pub struct CircuitStoreMarker;
+
+/// Per-circuit cache.
+pub type CircuitCache = TypedMap<CircuitStoreMarker>;
+
+/// Declare an anonymous struct type to be used as a key in the cache and
+/// associated value type.
+///
+/// # Example
+///
+/// ```ignore
+/// circuit_cache_key!(IntegralId<C, D>(NodeId => Stream<C, D>));
+/// ```
+///
+/// declares `struct IntegralId(NodeId)` key type with associated value type
+/// `Stream<C, D>`.
+#[macro_export]
+macro_rules! circuit_cache_key {
+    ($constructor:ident<$($typearg:ident),*>($key_type:ty => $val_type:ty)) => {
+        pub struct $constructor<$($typearg: 'static),*>(pub $key_type, std::marker::PhantomData<($($typearg),*)>);
+
+        impl<$($typearg),*> $constructor<$($typearg),*> {
+            pub fn new(key: $key_type) -> Self {
+                Self(key, std::marker::PhantomData)
+            }
+        }
+
+        impl<$($typearg),*> std::hash::Hash for $constructor<$($typearg),*> {
+            fn hash<H>(&self, state: &mut H)
+                where
+                    H: std::hash::Hasher
+                    {
+                        self.0.hash(state);
+                    }
+        }
+
+        impl<$($typearg),*> PartialEq for $constructor<$($typearg),*> {
+            fn eq(&self, other: &Self) -> bool {
+                self.0.eq(&other.0)
+            }
+        }
+
+        impl<$($typearg),*> Eq for $constructor<$($typearg),*> {}
+
+        impl<$($typearg: 'static),*> typedmap::TypedMapKey<$crate::circuit::cache::CircuitStoreMarker> for $constructor<$($typearg),*> {
+            type Value = $val_type;
+        }
+    }
+}

--- a/src/circuit/circuit_builder.rs
+++ b/src/circuit/circuit_builder.rs
@@ -43,17 +43,22 @@ use std::{
     rc::Rc,
 };
 
-use crate::circuit::{
-    operator_traits::{
-        BinaryOperator, Data, ImportOperator, NaryOperator, SinkOperator, SourceOperator,
-        StrictUnaryOperator, UnaryOperator,
+use crate::{
+    circuit::{
+        cache::CircuitCache,
+        operator_traits::{
+            BinaryOperator, Data, ImportOperator, NaryOperator, SinkOperator, SourceOperator,
+            StrictUnaryOperator, UnaryOperator,
+        },
+        schedule::{
+            DynamicScheduler, Error as SchedulerError, Executor, IterativeExecutor, OnceExecutor,
+            Scheduler,
+        },
+        trace::{CircuitEvent, SchedulerEvent},
     },
-    schedule::{
-        DynamicScheduler, Error as SchedulerError, Executor, IterativeExecutor, OnceExecutor,
-        Scheduler,
-    },
-    trace::{CircuitEvent, SchedulerEvent},
+    circuit_cache_key,
 };
+use typedmap::TypedMap;
 
 /// Value stored in the stream.
 struct StreamValue<D> {
@@ -154,6 +159,29 @@ impl<P, D> Stream<Circuit<P>, D> {
             circuit,
             val: Rc::new(UnsafeCell::new(StreamValue::empty())),
         }
+    }
+
+    /// Export stream to the parent circuit.
+    ///
+    /// Creates a stream in the parent circuit that contains the last value in
+    /// `self` when the child circuit terminates.
+    ///
+    /// This method currently only works for streams connected to a feedback
+    /// `Z1` operator and will panic for other streams.
+    pub fn export(&self) -> Stream<P, D>
+    where
+        P: Clone + 'static,
+        D: 'static,
+    {
+        if let Some(export) = self
+            .circuit()
+            .cache()
+            .get(&ExportId::new(self.local_node_id()))
+        {
+            return export.clone();
+        };
+
+        unimplemented!();
     }
 }
 
@@ -494,6 +522,8 @@ impl Edge {
     }
 }
 
+circuit_cache_key!(ExportId<C, D>(NodeId => Stream<C, D>));
+
 /// A circuit consists of nodes and edges.  An edge from
 /// node1 to node2 indicates that the output stream of node1
 /// is connected to an input of node2.
@@ -506,6 +536,7 @@ struct CircuitInner<P> {
     edges: Vec<Edge>,
     circuit_event_handlers: CircuitEventHandlers,
     scheduler_event_handlers: SchedulerEventHandlers,
+    store: CircuitCache,
 }
 
 impl<P> CircuitInner<P> {
@@ -524,6 +555,7 @@ impl<P> CircuitInner<P> {
             edges: Vec::new(),
             circuit_event_handlers,
             scheduler_event_handlers,
+            store: TypedMap::new(),
         }
     }
 
@@ -857,6 +889,15 @@ where
     /// Returns the parent circuit of `self`.
     pub fn parent(&self) -> P {
         self.inner().parent.clone()
+    }
+
+    /// Returns a reference to the cache associated with the circuit.
+    ///
+    /// See [`cache`] module documentation for details.
+    pub(crate) fn cache(&self) -> RefMut<'_, CircuitCache> {
+        let circuit = self.inner_mut();
+
+        RefMut::map(circuit, |c| &mut c.store)
     }
 
     pub(crate) fn ready(&self, id: NodeId) -> bool {
@@ -2348,10 +2389,8 @@ mod tests {
                 result
             }));
             let integrator = source.integrate();
-            integrator.current.inspect(|n| println!("{}", n));
-            integrator
-                .current
-                .inspect(move |n| actual_output_clone.borrow_mut().push(*n));
+            integrator.inspect(|n| println!("{}", n));
+            integrator.inspect(move |n| actual_output_clone.borrow_mut().push(*n));
         })
         .unwrap();
 

--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -15,11 +15,13 @@ Copyright (c) $CURRENT_YEAR VMware, Inc
 pub mod circuit_builder;
 mod runtime;
 
+pub mod cache;
 pub mod operator_traits;
 pub mod schedule;
 pub mod trace;
 
 pub use circuit_builder::{
-    Circuit, FeedbackConnector, GlobalNodeId, NodeId, OwnershipPreference, Root, Scope, Stream,
+    Circuit, ExportId, ExportStream, FeedbackConnector, GlobalNodeId, NodeId, OwnershipPreference,
+    Root, Scope, Stream,
 };
 pub use runtime::{LocalStore, LocalStoreMarker, Runtime, RuntimeHandle};

--- a/src/circuit/runtime.rs
+++ b/src/circuit/runtime.rs
@@ -12,8 +12,6 @@ use std::{
 };
 use typedmap::{TypedDashMap, TypedMapKey};
 
-pub struct LocalStoreMarker;
-
 // Thread-local variables used by the termination protocol.
 thread_local! {
     // Parker that must be used by all schedulers within the worker
@@ -25,6 +23,8 @@ thread_local! {
     // and exit immediately returning `SchedulerError::Killed`.
     static KILL_SIGNAL: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
 }
+
+pub struct LocalStoreMarker;
 
 /// Local data store shared by all workers in a runtime.
 pub type LocalStore = TypedDashMap<LocalStoreMarker>;

--- a/src/operator/index.rs
+++ b/src/operator/index.rs
@@ -154,7 +154,6 @@ mod test {
             circuit.add_source(Generator::new(move || inputs.next().unwrap() ))
                    .index()
                    .integrate()
-                   .current
                    .inspect(move |fm: &FiniteHashMap<_, _>| assert_eq!(fm, &outputs.next().unwrap()));
         })
         .unwrap();
@@ -190,7 +189,6 @@ mod test {
             circuit.add_source(Generator::new(move || inputs.next().unwrap() ))
                    .index()
                    .integrate()
-                   .current
                    .inspect(move |fm: &FiniteHashMap<_, _>| assert_eq!(fm, &outputs.next().unwrap()));
         })
         .unwrap();

--- a/src/operator/integrate.rs
+++ b/src/operator/integrate.rs
@@ -1,86 +1,16 @@
 use crate::{
     algebra::{AddAssignByRef, AddByRef, HasZero},
-    circuit::{Circuit, OwnershipPreference, Stream},
-    operator::{BinaryOperatorAdapter, Plus, Z1Nested, Z1},
+    circuit::{Circuit, NodeId, OwnershipPreference, Stream},
+    circuit_cache_key,
+    operator::{
+        z1::{DelayedFeedback, DelayedNestedFeedback},
+        BinaryOperatorAdapter, Plus,
+    },
 };
 use std::{ops::Add, rc::Rc};
 
-/// Struct returned by the [`Stream::integrate`] operation.
-///
-/// This struct bundles the four output streams produced by the `integrate`
-/// method:
-///
-/// * `current` - the current value of the integral, i.e., the sum of all values
-///   in the stream since the last `clock_start` including the current clock
-///   cycle.
-/// * `delayed` - the previous value of the integral, i.e., the sum of all
-///   values in the stream since the last `clock_start` up to the previous clock
-///   cycle.
-/// * `export` - stream exported to the parent circuit that contains the final
-///   value of the integral at the end of the nested clock epoch.
-/// * `input` - value added to the integral at the last clock cycle.  This is
-///   just a reference to the input stream (the stream being integrated).  We
-///   bundle it here as it is often used together with other outputs, e.g., by
-///   the incremental join operator.
-pub struct StreamIntegral<P, I> {
-    pub current: Stream<Circuit<P>, I>,
-    pub delayed: Stream<Circuit<P>, I>,
-    pub export: Stream<P, I>,
-    pub input: Stream<Circuit<P>, I>,
-}
-
-impl<P, I> StreamIntegral<P, I> {
-    fn new(
-        current: Stream<Circuit<P>, I>,
-        delayed: Stream<Circuit<P>, I>,
-        export: Stream<P, I>,
-        input: Stream<Circuit<P>, I>,
-    ) -> Self {
-        Self {
-            current,
-            delayed,
-            export,
-            input,
-        }
-    }
-}
-
-/// Struct returned by the [`Stream::integrate_nested`] operation.
-///
-/// This struct bundles the four output streams produced by the
-/// `integrate_nested` method. Below, we denote `stream[i,j]` the value of
-/// `stream` at time `[i,j]`, where `i` is the parent timestamp, and `j` is the
-/// child timestamp.
-///
-/// * `current` - the current value of the integral: `current[i,j] =
-///   sum(input[k,j]), k<=i`.
-/// * `delayed` - the previous value of the integral: `delayed[i,j] =
-///   sum(input[k,j]), k<i`.
-/// * `export` - stream exported to the parent circuit that contains the final
-///   value of the integral at the end of the nested clock epoch.
-/// * `input` - reference to the input stream.
-pub struct NestedStreamIntegral<P, I> {
-    pub current: Stream<Circuit<P>, Rc<I>>,
-    pub delayed: Stream<Circuit<P>, Rc<I>>,
-    pub export: Stream<P, Rc<I>>,
-    pub input: Stream<Circuit<P>, I>,
-}
-
-impl<P, I> NestedStreamIntegral<P, I> {
-    fn new(
-        current: Stream<Circuit<P>, Rc<I>>,
-        delayed: Stream<Circuit<P>, Rc<I>>,
-        export: Stream<P, Rc<I>>,
-        input: Stream<Circuit<P>, I>,
-    ) -> Self {
-        Self {
-            current,
-            delayed,
-            export,
-            input,
-        }
-    }
-}
+circuit_cache_key!(IntegralId<C, D>(NodeId => Stream<C, D>));
+circuit_cache_key!(NestedIntegralId<C, D>(NodeId => Stream<C, Rc<D>>));
 
 impl<P, D> Stream<Circuit<P>, D>
 where
@@ -90,13 +20,6 @@ where
     /// Integrate the input stream.
     ///
     /// Computes the sum of values in the input stream.
-    /// The first stream in the return tuple contains the value of the integral
-    /// after the current clock cycle.  The second stream contains the value of
-    /// the integral at the previous clock cycle, i.e., the sum of all
-    /// inputs except the last one.  The latter can equivalently be obtained
-    /// by applying the delay operator [`Z1`] to the integral, but this
-    /// function avoids the extra storage overhead and is the preferred way
-    /// to perform delayed integration.
     ///
     /// # Examples
     ///
@@ -111,9 +34,9 @@ where
     ///     // Integrate the stream.
     ///     let integral = stream.integrate();
     /// #   let mut counter1 = 0;
-    /// #   integral.current.inspect(move |n| { counter1 += 1; assert_eq!(*n, counter1) });
+    /// #   integral.inspect(move |n| { counter1 += 1; assert_eq!(*n, counter1) });
     /// #   let mut counter2 = 0;
-    /// #   integral.delayed.inspect(move |n| { assert_eq!(*n, counter2); counter2 += 1; });
+    /// #   integral.delay().inspect(move |n| { assert_eq!(*n, counter2); counter2 += 1; });
     /// })
     /// .unwrap();
     ///
@@ -122,14 +45,21 @@ where
     /// # }
     /// ```
     ///
-    /// Streams in the above example will contain the following values:
+    /// The above example generates the following input/output mapping:
     ///
     /// ```text
-    /// input:   1, 1, 1, 1, 1, ...
-    /// current: 1, 2, 3, 4, 5, ...
-    /// delayed: 0, 1, 2, 3, 4, ...
+    /// input:  1, 1, 1, 1, 1, ...
+    /// output: 1, 2, 3, 4, 5, ...
     /// ```
-    pub fn integrate(&self) -> StreamIntegral<P, D> {
+    pub fn integrate(&self) -> Stream<Circuit<P>, D> {
+        if let Some(integral) = self
+            .circuit()
+            .cache()
+            .get(&IntegralId::new(self.local_node_id()))
+        {
+            return integral.clone();
+        }
+
         // Integration circuit:
         // ```
         //              input
@@ -149,16 +79,20 @@ where
         //              delayed
         //              export
         // ```
-        let (z, feedback) = self.circuit().add_feedback_with_export(Z1::new(D::zero()));
-        let adder = self.circuit().add_binary_operator_with_preference(
+        let feedback = DelayedFeedback::new(self.circuit());
+        let integral = self.circuit().add_binary_operator_with_preference(
             Plus::new(),
-            &z.local,
+            feedback.stream(),
             self,
             OwnershipPreference::STRONGLY_PREFER_OWNED,
             OwnershipPreference::PREFER_OWNED,
         );
-        feedback.connect_with_preference(&adder, OwnershipPreference::STRONGLY_PREFER_OWNED);
-        StreamIntegral::new(adder, z.local, z.export, self.clone())
+        feedback.connect(&integral);
+
+        self.circuit()
+            .cache()
+            .insert(IntegralId::new(self.local_node_id()), integral.clone());
+        integral
     }
 
     /// Integrate stream of streams.
@@ -191,19 +125,31 @@ where
     /// 2 3 4 5 1
     /// 4 5 6 5 1
     /// ```
-    pub fn integrate_nested(&self) -> NestedStreamIntegral<P, D> {
-        let (z, feedback) = self
+    pub fn integrate_nested(&self) -> Stream<Circuit<P>, Rc<D>> {
+        if let Some(integral) = self
             .circuit()
-            .add_feedback_with_export(Z1Nested::new(Rc::new(D::zero())));
-        let adder = self.circuit().add_binary_operator_with_preference(
+            .cache()
+            .get(&NestedIntegralId::new(self.local_node_id()))
+        {
+            return integral.clone();
+        }
+
+        let feedback = DelayedNestedFeedback::new(self.circuit(), Rc::new(D::zero()));
+        let integral = self.circuit().add_binary_operator_with_preference(
             <BinaryOperatorAdapter<D, D, D, _>>::new(Plus::new()),
-            &z.local,
+            feedback.stream(),
             self,
             OwnershipPreference::STRONGLY_PREFER_OWNED,
             OwnershipPreference::PREFER_OWNED,
         );
-        feedback.connect_with_preference(&adder, OwnershipPreference::STRONGLY_PREFER_OWNED);
-        NestedStreamIntegral::new(adder, z.local, z.export, self.clone())
+        feedback.connect(&integral);
+
+        self.circuit().cache().insert(
+            NestedIntegralId::new(self.local_node_id()),
+            integral.clone(),
+        );
+
+        integral
     }
 }
 
@@ -212,7 +158,7 @@ mod test {
     use crate::{
         algebra::{FiniteMap, MapBuilder, ZSetHashMap},
         circuit::{trace::TraceMonitor, Root},
-        operator::{Generator, Z1},
+        operator::{DelayedFeedback, Generator},
     };
 
     use std::sync::{Arc, Mutex};
@@ -222,7 +168,7 @@ mod test {
         let root = Root::build(move |circuit| {
             let source = circuit.add_source(Generator::new(|| 1));
             let mut counter = 0;
-            source.integrate().current.inspect(move |n| {
+            source.integrate().inspect(move |n| {
                 counter += 1;
                 assert_eq!(*n, counter);
             });
@@ -248,7 +194,7 @@ mod test {
 
             let integral = source.integrate();
             let mut counter2 = 0;
-            integral.current.inspect(move |s| {
+            integral.inspect(move |s| {
                 for i in 0..counter2 {
                     assert_eq!(s.lookup(&i), (counter2 - i) as isize);
                 }
@@ -256,7 +202,7 @@ mod test {
                 assert_eq!(s.lookup(&counter2), 0);
             });
             let mut counter3 = 0;
-            integral.delayed.inspect(move |s| {
+            integral.delay().inspect(move |s| {
                 for i in 1..counter3 {
                     assert_eq!(s.lookup(&(i - 1)), (counter3 - i) as isize);
                 }
@@ -308,17 +254,20 @@ mod test {
             let integral = circuit
                 .iterate_with_condition(|child| {
                     let source = source.delta0(&child);
-                    let (z, feedback) = child.add_feedback(Z1::new(0));
-                    let plus = source.plus(&z.apply(|n| if *n > 0 { *n - 1 } else { *n }));
+                    let feedback = DelayedFeedback::new(child);
+                    let plus =
+                        source.plus(
+                            &feedback
+                                .stream()
+                                .apply(|n| if *n > 0 { *n - 1 } else { *n }),
+                        );
                     plus.inspect(move |n| assert_eq!(*n, expected_counters.next().unwrap()));
                     feedback.connect(&plus);
                     let integral = plus.integrate_nested();
-                    integral
-                        .current
-                        .inspect(move |n| assert_eq!(**n, expected_integrals.next().unwrap()));
+                    integral.inspect(move |n| assert_eq!(**n, expected_integrals.next().unwrap()));
                     Ok((
-                        integral.current.condition(|n| **n == 0),
-                        integral.current.apply(|rc| **rc).integrate().export,
+                        integral.condition(|n| **n == 0),
+                        integral.apply(|rc| **rc).integrate().export(),
                     ))
                 })
                 .unwrap();

--- a/src/operator/mod.rs
+++ b/src/operator/mod.rs
@@ -16,13 +16,12 @@ mod plus;
 pub use plus::Plus;
 
 mod z1;
-pub use z1::{Z1Nested, Z1};
+pub use z1::{DelayedFeedback, Z1Nested, Z1};
 
 mod generator;
 pub use generator::Generator;
 
 mod integrate;
-pub use integrate::StreamIntegral;
 
 pub mod communication;
 

--- a/src/operator/z1.rs
+++ b/src/operator/z1.rs
@@ -1,10 +1,158 @@
 //! z^-1 operator delays its input by one timestamp.
 
-use crate::circuit::{
-    operator_traits::{Operator, StrictOperator, StrictUnaryOperator, UnaryOperator},
-    OwnershipPreference, Scope,
+use crate::{
+    algebra::HasZero,
+    circuit::{
+        operator_traits::{Operator, StrictOperator, StrictUnaryOperator, UnaryOperator},
+        Circuit, ExportId, ExportStream, FeedbackConnector, NodeId, OwnershipPreference, Scope,
+        Stream,
+    },
+    circuit_cache_key,
 };
 use std::{borrow::Cow, mem::swap};
+
+circuit_cache_key!(DelayedId<C, D>(NodeId => Stream<C, D>));
+circuit_cache_key!(NestedDelayedId<C, D>(NodeId => Stream<C, D>));
+
+/// Like [`FeedbackConnector`] but specialized for [`Z1`] feedback operator.
+///
+/// Use this API instead of the low-level [`Circuit::add_feedback`] API to
+/// create feedback loops with `Z1` operator.  In addition to being more
+/// concise, this API takes advantage of [caching](`crate::circuit::cache`).
+pub struct DelayedFeedback<P, D> {
+    feedback: FeedbackConnector<Circuit<P>, D, D, Z1<D>>,
+    output: Stream<Circuit<P>, D>,
+    export: Stream<P, D>,
+}
+
+impl<P, D> DelayedFeedback<P, D>
+where
+    P: Clone + 'static,
+    D: Clone + HasZero + 'static,
+{
+    /// Create a feedback loop with `Z1` operator.  Use [`Self::connect`] to
+    /// close the loop.
+    pub fn new(circuit: &Circuit<P>) -> Self {
+        let (ExportStream { local, export }, feedback) =
+            circuit.add_feedback_with_export(Z1::new(D::zero()));
+        Self {
+            feedback,
+            output: local,
+            export,
+        }
+    }
+
+    /// Output stream of the `Z1` operator.
+    pub fn stream(&self) -> &Stream<Circuit<P>, D> {
+        &self.output
+    }
+
+    /// Connect `input` stream to the input of the `Z1` operator.
+    pub fn connect(self, input: &Stream<Circuit<P>, D>) {
+        let Self {
+            feedback,
+            output,
+            export,
+        } = self;
+        let circuit = output.circuit().clone();
+
+        feedback.connect_with_preference(input, OwnershipPreference::STRONGLY_PREFER_OWNED);
+        circuit
+            .cache()
+            .insert(DelayedId::new(input.local_node_id()), output);
+        circuit
+            .cache()
+            .insert(ExportId::new(input.local_node_id()), export);
+    }
+}
+
+/// Like [`FeedbackConnector`] but specialized for [`Z1Nested`] feedback
+/// operator.
+///
+/// Use this API instead of the low-level [`circuit::add_feedback`] API to
+/// create feedback loops with `Z1Nested` operator.  In addition to being more
+/// concise, this API takes advantage of [caching](`crate::circuit::cache`).
+pub struct DelayedNestedFeedback<P, D> {
+    feedback: FeedbackConnector<Circuit<P>, D, D, Z1Nested<D>>,
+    output: Stream<Circuit<P>, D>,
+}
+
+impl<P, D> DelayedNestedFeedback<P, D>
+where
+    P: Clone + 'static,
+    D: Clone + 'static,
+{
+    /// Create a feedback loop with `Z1` operator.  Use [`Self::connect`] to
+    /// close the loop.
+    pub fn new(circuit: &Circuit<P>, zero: D) -> Self {
+        let (output, feedback) = circuit.add_feedback(Z1Nested::new(zero));
+        Self { feedback, output }
+    }
+
+    /// Output stream of the `Z1Nested` operator.
+    pub fn stream(&self) -> &Stream<Circuit<P>, D> {
+        &self.output
+    }
+
+    /// Connect `input` stream to the input of the `Z1Nested` operator.
+    pub fn connect(self, input: &Stream<Circuit<P>, D>) {
+        let Self { feedback, output } = self;
+        let circuit = output.circuit().clone();
+
+        feedback.connect_with_preference(input, OwnershipPreference::STRONGLY_PREFER_OWNED);
+        circuit
+            .cache()
+            .insert(NestedDelayedId::new(input.local_node_id()), output);
+    }
+}
+
+impl<P, D> Stream<Circuit<P>, D> {
+    /// Applies [`Z1`] operator to `self`.
+    pub fn delay(&self) -> Stream<Circuit<P>, D>
+    where
+        P: Clone + 'static,
+        D: Clone + HasZero + 'static,
+    {
+        if let Some(delayed) = self
+            .circuit()
+            .cache()
+            .get(&DelayedId::new(self.local_node_id()))
+        {
+            return delayed.clone();
+        }
+
+        let delayed = self.circuit().add_unary_operator(Z1::new(D::zero()), self);
+        self.circuit()
+            .cache()
+            .insert(DelayedId::new(self.local_node_id()), delayed.clone());
+
+        delayed
+    }
+
+    /// Applies [`Z1Nested`] operator to `self`.
+    pub fn nested_delay(&self) -> Stream<Circuit<P>, D>
+    where
+        P: Clone + 'static,
+        D: Clone + HasZero + 'static,
+    {
+        if let Some(delayed) = self
+            .circuit()
+            .cache()
+            .get(&NestedDelayedId::new(self.local_node_id()))
+        {
+            return delayed.clone();
+        }
+
+        let delayed = self
+            .circuit()
+            .add_unary_operator(Z1Nested::new(D::zero()), self);
+        self.circuit()
+            .cache()
+            .insert(NestedDelayedId::new(self.local_node_id()), delayed.clone());
+
+        delayed
+    }
+}
 
 /// z^-1 operator delays its input by one timestamp.
 ///
@@ -145,7 +293,7 @@ impl<T> Z1Nested<T>
 where
     T: Clone,
 {
-    pub fn new(zero: T) -> Self {
+    fn new(zero: T) -> Self {
         Self {
             zero,
             timestamp: 0,
@@ -178,6 +326,42 @@ where
         if scope > 0 {
             self.reset();
         }
+    }
+}
+
+impl<T> UnaryOperator<T, T> for Z1Nested<T>
+where
+    T: Clone + 'static,
+{
+    fn eval(&mut self, i: &T) -> T {
+        assert!(self.timestamp <= self.val.len());
+
+        if self.timestamp == self.val.len() {
+            self.val.push(self.zero.clone())
+        }
+
+        let mut res = i.clone();
+        swap(&mut self.val[self.timestamp], &mut res);
+
+        self.timestamp += 1;
+        res
+    }
+
+    fn eval_owned(&mut self, mut i: T) -> T {
+        assert!(self.timestamp <= self.val.len());
+
+        if self.timestamp == self.val.len() {
+            self.val.push(self.zero.clone())
+        }
+
+        swap(&mut self.val[self.timestamp], &mut i);
+        self.timestamp += 1;
+
+        i
+    }
+
+    fn input_preference(&self) -> OwnershipPreference {
+        OwnershipPreference::PREFER_OWNED
     }
 }
 
@@ -280,7 +464,39 @@ mod test {
     fn z1_nested_test() {
         let mut z1 = Z1Nested::new(0);
 
+        // Test `UnaryOperator` API.
+
+        z1.clock_start(1);
+
+        let mut res = Vec::new();
+        z1.clock_start(0);
+        res.push(z1.eval_owned(1));
+        res.push(z1.eval(&2));
+        res.push(z1.eval(&3));
+        z1.clock_end(0);
+        assert_eq!(res.as_slice(), &[0, 0, 0]);
+
+        let mut res = Vec::new();
+        z1.clock_start(0);
+        res.push(z1.eval_owned(4));
+        res.push(z1.eval_owned(5));
+        z1.clock_end(0);
+        assert_eq!(res.as_slice(), &[1, 2]);
+
+        let mut res = Vec::new();
+        z1.clock_start(0);
+        res.push(z1.eval_owned(6));
+        res.push(z1.eval_owned(7));
+        res.push(z1.eval(&8));
+        res.push(z1.eval(&9));
+        z1.clock_end(0);
+        assert_eq!(res.as_slice(), &[4, 5, 0, 0]);
+
+        z1.clock_end(1);
+
         // Test `StrictUnaryOperator` API.
+        z1.clock_start(1);
+
         let mut res = Vec::new();
         z1.clock_start(0);
         res.push(z1.get_output());
@@ -317,5 +533,7 @@ mod test {
         z1.clock_end(0);
 
         assert_eq!(res.as_slice(), &[4, 5, 0, 0]);
+
+        z1.clock_end(1);
     }
 }


### PR DESCRIPTION
We use a form of caching to reuse previously constructed fragments of
the circuit. For instance, a `stream.integrate()` call creates a
feedback loop with an adder and a `z^-1` operator.  The output of this
circuit is cached, so that the next identical call will return the same
stream without creating a new copy of the same operators.  Stream
integral is one example of a derived stream.  Others include nested
integral, delayed stream, etc.  Caching will allow simplifying
high-level APIs like nested incremental join that combine several
derived streams.  Without caching, such methods would have to either
construct all derived streams internally, potentially creating duplicate
operators and thus wasting CPU and memory or take multiple derived
streams as input, which would require the caller to track these
derivatives manually.