### PR TITLE
Stream caching.

### DIFF
--- a/src/circuit/cache.rs
+++ b/src/circuit/cache.rs
@@ -1,0 +1,91 @@
+//! Circuit cache.
+//!
+//! # Background
+//!
+//! We use a form of caching to reuse previously constructed fragments of the
+//! circuit. For instance, a
+//! [`stream.integrate()`](`crate::circuit::Stream::integrate`) call creates a
+//! feedback loop with an adder and a `z^-1` operator.  The output of this
+//! circuit is cached, so that the next identical call will return the same
+//! stream without creating a new copy of the same operators.  Stream integral
+//! is one example of a derived stream.  Others include
+//! [nested integral](`crate::circuit::Stream::integrate_nested`), [delayed
+//! stream](`crate::circuit::Stream::delay`), etc.  Caching allows simplifying
+//! high-level APIs like nested incremental join that combine several derived
+//! streams.  Without caching, such methods would have to either construct all
+//! derived streams internally, potentially creating duplicate operators and
+//! thus wasting CPU and memory or take multiple derived streams as input, which
+//! would require the caller to track these derivatives manually.
+//!
+//! # API
+//!
+//! This module provides a low-level mechanism that individual operators use to
+//! perform operator-specific caching.  The mechanism consists of a key-value
+//! store associated with each circuit.  We use `TypedMap`, which supports
+//! multiple key and value types, for the store.  An operator registers a new
+//! key type and associated value type using the [`circuit_cache_key`] macro,
+//! e.g.,
+//!
+//! ```ignore
+//! circuit_cache_key!(IntegralId<C, D>(NodeId => Stream<C, D>));
+//! ```
+//!
+//! declares a mapping from `NodeId` to `Stream` used by the
+//! [`Stream::integrate`](`crate::circuit::Stream::integrate`) method to cache
+//! the output of the integrator.  Internally, the method first performs a map
+//! lookup and returns the cached stream, if one exists; otherwise it
+//! instantiates the integration circuit and stores its output stream in the
+//! cache before returning it to the caller.
+
+use typedmap::TypedMap;
+
+pub struct CircuitStoreMarker;
+
+/// Per-circuit cache.
+pub type CircuitCache = TypedMap<CircuitStoreMarker>;
+
+/// Declare an anonymous struct type to be used as a key in the cache and
+/// associated value type.
+///
+/// # Example
+///
+/// ```ignore
+/// circuit_cache_key!(IntegralId<C, D>(NodeId => Stream<C, D>));
+/// ```
+///
+/// declares `struct IntegralId(NodeId)` key type with associated value type
+/// `Stream<C, D>`.
+#[macro_export]
+macro_rules! circuit_cache_key {
+    ($constructor:ident<$($typearg:ident),*>($key_type:ty => $val_type:ty)) => {
+        #[repr(transparent)]
+        pub struct $constructor<$($typearg: 'static),*>(pub $key_type, std::marker::PhantomData<($($typearg),*)>);
+
+        impl<$($typearg),*> $constructor<$($typearg),*> {
+            pub fn new(key: $key_type) -> Self {
+                Self(key, std::marker::PhantomData)
+            }
+        }
+
+        impl<$($typearg),*> std::hash::Hash for $constructor<$($typearg),*> {
+            fn hash<H>(&self, state: &mut H)
+            where
+                H: std::hash::Hasher
+            {
+                self.0.hash(state);
+            }
+        }
+
+        impl<$($typearg),*> PartialEq for $constructor<$($typearg),*> {
+            fn eq(&self, other: &Self) -> bool {
+                self.0.eq(&other.0)
+            }
+        }
+
+        impl<$($typearg),*> Eq for $constructor<$($typearg),*> {}
+
+        impl<$($typearg: 'static),*> typedmap::TypedMapKey<$crate::circuit::cache::CircuitStoreMarker> for $constructor<$($typearg),*> {
+            type Value = $val_type;
+        }
+    }
+}

--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -15,11 +15,13 @@ Copyright (c) $CURRENT_YEAR VMware, Inc
 pub mod circuit_builder;
 mod runtime;
 
+pub mod cache;
 pub mod operator_traits;
 pub mod schedule;
 pub mod trace;
 
 pub use circuit_builder::{
-    Circuit, FeedbackConnector, GlobalNodeId, NodeId, OwnershipPreference, Root, Scope, Stream,
+    Circuit, ExportId, ExportStream, FeedbackConnector, GlobalNodeId, NodeId, OwnershipPreference,
+    Root, Scope, Stream,
 };
 pub use runtime::{LocalStore, LocalStoreMarker, Runtime, RuntimeHandle};

--- a/src/circuit/runtime.rs
+++ b/src/circuit/runtime.rs
@@ -12,8 +12,6 @@ use std::{
 };
 use typedmap::{TypedDashMap, TypedMapKey};
 
-pub struct LocalStoreMarker;
-
 // Thread-local variables used by the termination protocol.
 thread_local! {
     // Parker that must be used by all schedulers within the worker
@@ -25,6 +23,8 @@ thread_local! {
     // and exit immediately returning `SchedulerError::Killed`.
     static KILL_SIGNAL: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
 }
+
+pub struct LocalStoreMarker;
 
 /// Local data store shared by all workers in a runtime.
 pub type LocalStore = TypedDashMap<LocalStoreMarker>;

--- a/src/operator/index.rs
+++ b/src/operator/index.rs
@@ -154,7 +154,6 @@ mod test {
             circuit.add_source(Generator::new(move || inputs.next().unwrap() ))
                    .index()
                    .integrate()
-                   .current
                    .inspect(move |fm: &FiniteHashMap<_, _>| assert_eq!(fm, &outputs.next().unwrap()));
         })
         .unwrap();
@@ -190,7 +189,6 @@ mod test {
             circuit.add_source(Generator::new(move || inputs.next().unwrap() ))
                    .index()
                    .integrate()
-                   .current
                    .inspect(move |fm: &FiniteHashMap<_, _>| assert_eq!(fm, &outputs.next().unwrap()));
         })
         .unwrap();

--- a/src/operator/mod.rs
+++ b/src/operator/mod.rs
@@ -16,13 +16,12 @@ mod plus;
 pub use plus::Plus;
 
 mod z1;
-pub use z1::{Z1Nested, Z1};
+pub use z1::{DelayedFeedback, Z1Nested, Z1};
 
 mod generator;
 pub use generator::Generator;
 
 mod integrate;
-pub use integrate::StreamIntegral;
 
 pub mod communication;
 


### PR DESCRIPTION
We use a form of caching to reuse previously constructed fragments of
the circuit. For instance, a `stream.integrate()` call creates a
feedback loop with an adder and a `z^-1` operator.  The output of this
circuit is cached, so that the next identical call will return the same
stream without creating a new copy of the same operators.  Stream
integral is one example of a derived stream.  Others include nested
integral, delayed stream, etc.  Caching will allow simplifying
high-level APIs like nested incremental join that combine several
derived streams.  Without caching, such methods would have to either
construct all derived streams internally, potentially creating duplicate
operators and thus wasting CPU and memory or take multiple derived
streams as input, which would require the caller to track these
derivatives manually.