### PR TITLE
Nested incremental join.

### DIFF
--- a/src/algebra/finite_map/mod.rs
+++ b/src/algebra/finite_map/mod.rs
@@ -3,8 +3,12 @@ mod map_macro;
 #[cfg(test)]
 mod tests;
 
-use crate::algebra::{
-    Add, AddAssign, AddAssignByRef, AddByRef, GroupValue, HasZero, Neg, NegByRef, WithNumEntries,
+use crate::{
+    algebra::{
+        Add, AddAssign, AddAssignByRef, AddByRef, GroupValue, HasZero, Neg, NegByRef,
+        WithNumEntries,
+    },
+    shared_ref_self_generic,
 };
 use hashbrown::{
     hash_map,
@@ -175,6 +179,8 @@ pub struct FiniteHashMap<Key, Value> {
     // that have non-zero values are in this map.
     pub(super) value: HashMap<Key, Value>,
 }
+
+shared_ref_self_generic!(<Key, Value>, FiniteHashMap<Key, Value>);
 
 impl<Key, Value> FiniteHashMap<Key, Value> {
     /// Create a new map

--- a/src/operator/adapter.rs
+++ b/src/operator/adapter.rs
@@ -28,15 +28,14 @@ use crate::{
 /// Unary operator adapter unwraps input values of type
 /// `I` wrapped in a shared reference.  See
 /// [module-level documentation](`crate::operator::adapter`) for details.
-pub struct UnaryOperatorAdapter<I, O, Op> {
+pub struct UnaryOperatorAdapter<O, Op> {
     op: Op,
-    _types: PhantomData<(I, O)>,
+    _types: PhantomData<O>,
 }
 
-impl<I, O, Op> Operator for UnaryOperatorAdapter<I, O, Op>
+impl<O, Op> Operator for UnaryOperatorAdapter<O, Op>
 where
     Op: Operator,
-    I: 'static,
     O: 'static,
 {
     fn name(&self) -> Cow<'static, str> {
@@ -62,11 +61,10 @@ where
     }
 }
 
-impl<RI, I, RO, O, Op> UnaryOperator<RI, RO> for UnaryOperatorAdapter<I, O, Op>
+impl<RI, RO, O, Op> UnaryOperator<RI, RO> for UnaryOperatorAdapter<O, Op>
 where
-    Op: UnaryOperator<I, O>,
-    RI: SharedRef<I>,
-    I: 'static,
+    RI: SharedRef,
+    Op: UnaryOperator<<RI as SharedRef>::Target, O>,
     RO: From<O>,
     O: 'static,
 {
@@ -90,12 +88,12 @@ where
 /// Binary operator adapter unwraps input values of types
 /// `I1` and `I2` wrapped in shared references.  See
 /// [module-level documentation](`crate::operator::adapter`) for details.
-pub struct BinaryOperatorAdapter<I1, I2, O, Op> {
+pub struct BinaryOperatorAdapter<O, Op> {
     op: Op,
-    _types: PhantomData<(I1, I2, O)>,
+    _types: PhantomData<O>,
 }
 
-impl<I1, I2, O, Op> BinaryOperatorAdapter<I1, I2, O, Op> {
+impl<O, Op> BinaryOperatorAdapter<O, Op> {
     pub fn new(op: Op) -> Self {
         Self {
             op,
@@ -104,11 +102,9 @@ impl<I1, I2, O, Op> BinaryOperatorAdapter<I1, I2, O, Op> {
     }
 }
 
-impl<I1, I2, O, Op> Operator for BinaryOperatorAdapter<I1, I2, O, Op>
+impl<O, Op> Operator for BinaryOperatorAdapter<O, Op>
 where
     Op: Operator,
-    I1: 'static,
-    I2: 'static,
     O: 'static,
 {
     fn name(&self) -> Cow<'static, str> {
@@ -134,14 +130,11 @@ where
     }
 }
 
-impl<RI1, I1, RI2, I2, RO, O, Op> BinaryOperator<RI1, RI2, RO>
-    for BinaryOperatorAdapter<I1, I2, O, Op>
+impl<RI1, RI2, RO, O, Op> BinaryOperator<RI1, RI2, RO> for BinaryOperatorAdapter<O, Op>
 where
-    Op: BinaryOperator<I1, I2, O>,
-    RI1: SharedRef<I1>,
-    RI2: SharedRef<I2>,
-    I1: 'static,
-    I2: 'static,
+    RI1: SharedRef,
+    RI2: SharedRef,
+    Op: BinaryOperator<<RI1 as SharedRef>::Target, <RI2 as SharedRef>::Target, O>,
     RO: From<O>,
     O: 'static,
 {

--- a/src/operator/integrate.rs
+++ b/src/operator/integrate.rs
@@ -138,7 +138,7 @@ where
             return integral.clone();
         }
 
-        let feedback = DelayedNestedFeedback::new(self.circuit(), Rc::new(D::zero()));
+        let feedback = DelayedNestedFeedback::new(self.circuit());
         let integral = self.circuit().add_binary_operator_with_preference(
             <BinaryOperatorAdapter<D, _>>::new(Plus::new()),
             feedback.stream(),

--- a/src/operator/integrate.rs
+++ b/src/operator/integrate.rs
@@ -6,6 +6,7 @@ use crate::{
         z1::{DelayedFeedback, DelayedNestedFeedback},
         BinaryOperatorAdapter, Plus,
     },
+    SharedRef,
 };
 use std::{ops::Add, rc::Rc};
 
@@ -125,7 +126,10 @@ where
     /// 2 3 4 5 1
     /// 4 5 6 5 1
     /// ```
-    pub fn integrate_nested(&self) -> Stream<Circuit<P>, Rc<D>> {
+    pub fn integrate_nested(&self) -> Stream<Circuit<P>, Rc<D>>
+    where
+        D: SharedRef<Target = D>,
+    {
         if let Some(integral) = self
             .circuit()
             .cache()
@@ -136,7 +140,7 @@ where
 
         let feedback = DelayedNestedFeedback::new(self.circuit(), Rc::new(D::zero()));
         let integral = self.circuit().add_binary_operator_with_preference(
-            <BinaryOperatorAdapter<D, D, D, _>>::new(Plus::new()),
+            <BinaryOperatorAdapter<D, _>>::new(Plus::new()),
             feedback.stream(),
             self,
             OwnershipPreference::STRONGLY_PREFER_OWNED,

--- a/src/operator/mod.rs
+++ b/src/operator/mod.rs
@@ -13,10 +13,10 @@ mod apply2;
 pub use apply2::Apply2;
 
 mod plus;
-pub use plus::Plus;
+pub use plus::{Minus, Plus};
 
 mod z1;
-pub use z1::{DelayedFeedback, Z1Nested, Z1};
+pub use z1::{DelayedFeedback, DelayedNestedFeedback, Z1Nested, Z1};
 
 mod generator;
 pub use generator::Generator;
@@ -26,7 +26,6 @@ mod integrate;
 pub mod communication;
 
 mod differentiate;
-pub use differentiate::Differentiate;
 
 mod filter;
 pub use filter::FilterKeys;

--- a/src/shared_ref.rs
+++ b/src/shared_ref.rs
@@ -17,37 +17,31 @@ pub trait SharedRef: Borrow<Self::Target> + Clone + Sized {
     fn try_into_owned(self) -> Result<Self::Target, Self>;
 }
 
+/// Implement `SharedRef<Target=Self>` for a type.
+#[macro_export]
 macro_rules! shared_ref_self {
     ($type:ty) => {
-        impl SharedRef for $type
-        {
+        impl $crate::SharedRef for $type {
             type Target = Self;
 
-            fn try_into_owned(self) -> Result<Self::Target, Self> {
-                Ok(self)
-            }
-        }
-    };
-
-    ($($typearg:ident),*>, $type:ty) => {
-        impl<$($typearg),*> SharedRef for $type<$($typearg),*>
-        {
-            fn try_into_owned(self) -> Result<Self::Target, Self> {
+            fn try_into_owned(self) -> std::result::Result<Self::Target, Self> {
                 Ok(self)
             }
         }
     };
 }
 
+/// Implement `SharedRef<Target=Self>` for a type.
+#[macro_export]
 macro_rules! shared_ref_self_generic {
     (<$($typearg:ident),*>, $type:ty) => {
-        impl<$($typearg),*> SharedRef for $type
+        impl<$($typearg),*> $crate::SharedRef for $type
         where
             $($typearg: Clone),*
         {
             type Target = Self;
 
-            fn try_into_owned(self) -> Result<Self::Target, Self> {
+            fn try_into_owned(self) -> std::result::Result<Self::Target, Self> {
                 Ok(self)
             }
         }

--- a/src/shared_ref.rs
+++ b/src/shared_ref.rs
@@ -7,25 +7,87 @@ use std::{borrow::Borrow, rc::Rc};
 /// The holder of a shared reference can extract an owned copy
 /// of the reference object from it if there are no other references
 /// to the same object (the refcount is 0).
-pub trait SharedRef<T>: Borrow<T> + Clone + Sized {
+pub trait SharedRef: Borrow<Self::Target> + Clone + Sized {
+    type Target;
+
     /// Try to extract the owned value from `self`.
     ///
     /// If `self` is the last reference to the object, returns
     /// the object; otherwise, returns `Err(self)`.
-    fn try_into_owned(self) -> Result<T, Self>;
+    fn try_into_owned(self) -> Result<Self::Target, Self>;
 }
 
-impl<T> SharedRef<T> for T
-where
-    T: Clone,
-{
-    fn try_into_owned(self) -> Result<T, Self> {
-        Ok(self)
-    }
+macro_rules! shared_ref_self {
+    ($type:ty) => {
+        impl SharedRef for $type
+        {
+            type Target = Self;
+
+            fn try_into_owned(self) -> Result<Self::Target, Self> {
+                Ok(self)
+            }
+        }
+    };
+
+    ($($typearg:ident),*>, $type:ty) => {
+        impl<$($typearg),*> SharedRef for $type<$($typearg),*>
+        {
+            fn try_into_owned(self) -> Result<Self::Target, Self> {
+                Ok(self)
+            }
+        }
+    };
 }
 
-impl<T> SharedRef<T> for Rc<T> {
-    fn try_into_owned(self) -> Result<T, Self> {
+macro_rules! shared_ref_self_generic {
+    (<$($typearg:ident),*>, $type:ty) => {
+        impl<$($typearg),*> SharedRef for $type
+        where
+            $($typearg: Clone),*
+        {
+            type Target = Self;
+
+            fn try_into_owned(self) -> Result<Self::Target, Self> {
+                Ok(self)
+            }
+        }
+    };
+}
+
+shared_ref_self!(u8);
+shared_ref_self!(u16);
+shared_ref_self!(u32);
+shared_ref_self!(u64);
+shared_ref_self!(u128);
+shared_ref_self!(usize);
+
+shared_ref_self!(i8);
+shared_ref_self!(i16);
+shared_ref_self!(i32);
+shared_ref_self!(i64);
+shared_ref_self!(i128);
+shared_ref_self!(isize);
+
+shared_ref_self!(String);
+shared_ref_self!(&'static str);
+
+shared_ref_self!(());
+shared_ref_self_generic!(<T1, T2>, (T1, T2));
+shared_ref_self_generic!(<T1, T2, T3>, (T1, T2, T3));
+shared_ref_self_generic!(<T1, T2, T3, T4>, (T1, T2, T3, T4));
+shared_ref_self_generic!(<T1, T2, T3, T4, T5>, (T1, T2, T3, T4, T5));
+shared_ref_self_generic!(<T1, T2, T3, T4, T5, T6>, (T1, T2, T3, T4, T5, T6));
+shared_ref_self_generic!(<T1, T2, T3, T4, T5, T6, T7>, (T1, T2, T3, T4, T5, T6, T7));
+shared_ref_self_generic!(<T1, T2, T3, T4, T5, T6, T7, T8>, (T1, T2, T3, T4, T5, T6, T7, T8));
+shared_ref_self_generic!(<T1, T2, T3, T4, T5, T6, T7, T8, T9>, (T1, T2, T3, T4, T5, T6, T7, T8, T9));
+shared_ref_self_generic!(<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>, (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10));
+shared_ref_self_generic!(<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>, (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11));
+shared_ref_self_generic!(<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>, (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12));
+
+impl<T> SharedRef for Rc<T> {
+    type Target = T;
+
+    fn try_into_owned(self) -> Result<Self::Target, Self> {
         Rc::try_unwrap(self)
     }
 }


### PR DESCRIPTION
We implement incremental join over nested streams according to the
following formula (see the full DBSP paper):

```
(↑((↑(a <> b))∆))∆ =
    I(↑I(a)) <> b            +
    ↑I(a) <> I(z^-1(b))      +
    a <> I(↑I(↑z^-1(b)))     +
    I(z^-1(a)) <> ↑I(↑z^-1(b)).
```

This required a series of other refactorings, which unfortunately ended
up bundled with this CV:

- `HasZero`, `HasOne` - remove default implementation of these traits
  for types that implement `num::Zero` and `num::One`, as these
  impls make it impossible to write impl
  `impl<T: HasZero> HasZero for Rc<T>`.  Instead we add macros to
  write such impls as one-liners for relevant types.
- Added `Minus` operator, currently implemented on top of `Add` and
  `Neg`, but the plan is that `GroupValue` will in the future support
  `Sub`, which can be slightly more efficient.
- Added `differentiate_nested`; also re-implemented `differentiate`
  as a coposition of `Minus` and `z-1`.
- Add caching support for `index`, `differentiate`,
  `differentiate_nested`.
- Generalize `join` to work with `SharedRef`.
- Change `Z1Nested` implementation to output the last value in the
  stored prefix instead of zero when asked to produce output for
  timestamps (the assumption here is that the circuit was evaluated to
  a fixed point at the previous parent timestamp, and hence the rest of
  the stream will contain the same fixed point value).