### PR TITLE
More ergonomic caching API.

### DIFF
--- a/src/operator/differentiate.rs
+++ b/src/operator/differentiate.rs
@@ -1,4 +1,4 @@
-//! Differentiator operator.
+//! Differentiation operators.
 
 use crate::{
     algebra::GroupValue,
@@ -20,45 +20,21 @@ where
     /// Computes the difference between current and previous value
     /// of `self`: `differentiate(a) = a - z^-1(a)`.
     pub fn differentiate(&self) -> Stream<Circuit<P>, D> {
-        if let Some(differential) = self
-            .circuit()
-            .cache()
-            .get(&DifferentiateId::new(self.local_node_id()))
-        {
-            return differential.clone();
-        }
-
-        let differential = self
-            .circuit()
-            .add_binary_operator(Minus::new(), self, &self.delay());
-
-        self.circuit().cache().insert(
-            DifferentiateId::new(self.local_node_id()),
-            differential.clone(),
-        );
-
-        differential
+        self.circuit()
+            .cache_get_or_insert_with(DifferentiateId::new(self.local_node_id()), || {
+                self.circuit()
+                    .add_binary_operator(Minus::new(), self, &self.delay())
+            })
+            .clone()
     }
 
     /// Nested stream differentiation.
     pub fn differentiate_nested(&self) -> Stream<Circuit<P>, D> {
-        if let Some(differential) = self
-            .circuit()
-            .cache()
-            .get(&NestedDifferentiateId::new(self.local_node_id()))
-        {
-            return differential.clone();
-        }
-
-        let differential =
-            self.circuit()
-                .add_binary_operator(Minus::new(), self, &self.delay_nested());
-
-        self.circuit().cache().insert(
-            NestedDifferentiateId::new(self.local_node_id()),
-            differential.clone(),
-        );
-
-        differential
+        self.circuit()
+            .cache_get_or_insert_with(NestedDifferentiateId::new(self.local_node_id()), || {
+                self.circuit()
+                    .add_binary_operator(Minus::new(), self, &self.delay_nested())
+            })
+            .clone()
     }
 }

--- a/src/operator/index.rs
+++ b/src/operator/index.rs
@@ -1,3 +1,5 @@
+//! Index operator.
+
 use crate::{
     algebra::{finite_map::KeyProperties, IndexedZSet, MapBuilder, ZRingValue},
     circuit::{
@@ -48,21 +50,11 @@ where
         for<'a> <&'a CI as IntoIterator>::Item: RefPair<'a, (K, V), W>,
         CO: IndexedZSet<K, V, W>,
     {
-        if let Some(index) = self
-            .circuit()
-            .cache()
-            .get(&IndexId::new(self.local_node_id()))
-        {
-            return index.clone();
-        }
-
-        let index = self.circuit().add_unary_operator(Index::new(), self);
-
         self.circuit()
-            .cache()
-            .insert(IndexId::new(self.local_node_id()), index.clone());
-
-        index
+            .cache_get_or_insert_with(IndexId::new(self.local_node_id()), || {
+                self.circuit().add_unary_operator(Index::new(), self)
+            })
+            .clone()
     }
 }
 

--- a/src/operator/join.rs
+++ b/src/operator/join.rs
@@ -1,3 +1,5 @@
+//! Relational join operator.
+
 use crate::{
     algebra::{finite_map::KeyProperties, IndexedZSet, MapBuilder, ZRingValue, ZSet},
     circuit::{

--- a/src/operator/plus.rs
+++ b/src/operator/plus.rs
@@ -1,4 +1,4 @@
-//! Binary plus operator.
+//! Binary plus and minus operators.
 
 use crate::{
     algebra::{AddAssignByRef, AddByRef, NegByRef},


### PR DESCRIPTION
Add `Circuit::cache_lookup_or_insert_with` that combines cache lookup
with insertion on cache miss.