### PR TITLE
Distinct operator.

### DIFF
--- a/src/algebra/mod.rs
+++ b/src/algebra/mod.rs
@@ -242,8 +242,11 @@ impl<T> RingValue for T where
 
 /// A ring where elements can be compared with zero
 pub trait ZRingValue: RingValue {
-    /// True if value is greater or equal to zero
+    /// True if value is greater or equal to zero.
     fn ge0(&self) -> bool;
+
+    /// True if value is less than or equal to zero.
+    fn le0(&self) -> bool;
 }
 
 /// Default implementation of ZRingValue for all types that have the required
@@ -266,6 +269,10 @@ where
 {
     fn ge0(&self) -> bool {
         *self >= Self::zero()
+    }
+
+    fn le0(&self) -> bool {
+        *self <= Self::zero()
     }
 }
 

--- a/src/algebra/zset/mod.rs
+++ b/src/algebra/zset/mod.rs
@@ -30,6 +30,9 @@ where
     /// `self` with weights set to 1.
     fn distinct(&self) -> Self;
 
+    /// Like `distinct` but optimized to operate on an owned value.
+    fn distinct_owned(self) -> Self;
+
     /// Given a Z-set 'set' partition it using a 'partitioner'
     /// function which is applied independently to each tuple.
     /// This consumes the Z-set.
@@ -97,9 +100,22 @@ where
 
     fn distinct(&self) -> Self {
         let mut result = Self::new();
+
         for (key, value) in &self.value {
             if value.ge0() {
                 result.increment(key, Weight::one());
+            }
+        }
+
+        result
+    }
+
+    fn distinct_owned(self) -> Self {
+        let mut result = Self::new();
+
+        for (key, value) in self.value.into_iter() {
+            if value.ge0() {
+                result.increment_owned(key, Weight::one());
             }
         }
 

--- a/src/operator/adapter.rs
+++ b/src/operator/adapter.rs
@@ -25,9 +25,8 @@ use crate::{
     SharedRef,
 };
 
-/// Unary operator adapter unwraps input values of type
-/// `I` wrapped in a shared reference.  See
-/// [module-level documentation](`crate::operator::adapter`) for details.
+/// Unary operator adapter unwraps input values wrapped in a shared reference.
+/// See [module-level documentation](`crate::operator::adapter`) for details.
 pub struct UnaryOperatorAdapter<O, Op> {
     op: Op,
     _types: PhantomData<O>,

--- a/src/operator/adapter.rs
+++ b/src/operator/adapter.rs
@@ -33,6 +33,15 @@ pub struct UnaryOperatorAdapter<O, Op> {
     _types: PhantomData<O>,
 }
 
+impl<O, Op> UnaryOperatorAdapter<O, Op> {
+    pub fn new(op: Op) -> Self {
+        Self {
+            op,
+            _types: PhantomData,
+        }
+    }
+}
+
 impl<O, Op> Operator for UnaryOperatorAdapter<O, Op>
 where
     Op: Operator,

--- a/src/operator/condition.rs
+++ b/src/operator/condition.rs
@@ -214,7 +214,7 @@ mod test {
                             &edges,
                         );
 
-                    let reachable = init.plus(&suc).apply(ZSet::distinct);
+                    let reachable = init.plus(&suc).distinct();
                     feedback.connect(&reachable);
                     let condition = reachable.differentiate().condition(|z| z.support_size() == 0);
                     (condition, reachable.export())

--- a/src/operator/distinct.rs
+++ b/src/operator/distinct.rs
@@ -1,0 +1,292 @@
+//! Distinct operator.
+
+use std::{borrow::Cow, marker::PhantomData};
+
+use crate::{
+    algebra::{finite_map::KeyProperties, ZRingValue, ZSet},
+    circuit::{
+        operator_traits::{BinaryOperator, Operator, UnaryOperator},
+        Circuit, NodeId, Scope, Stream,
+    },
+    circuit_cache_key,
+    operator::{BinaryOperatorAdapter, UnaryOperatorAdapter},
+    SharedRef,
+};
+
+circuit_cache_key!(DistinctId<C, D>(NodeId => Stream<C, D>));
+circuit_cache_key!(DistinctIncrementalId<C, D>(NodeId => Stream<C, D>));
+
+impl<P, Z> Stream<Circuit<P>, Z>
+where
+    P: Clone + 'static,
+{
+    /// Apply [`Distinct`] operator to `self`.
+    pub fn distinct<V, W>(&self) -> Stream<Circuit<P>, <Z as SharedRef>::Target>
+    where
+        V: KeyProperties,
+        W: ZRingValue,
+        Z: SharedRef + 'static,
+        <Z as SharedRef>::Target: ZSet<V, W>,
+    {
+        self.circuit()
+            .cache_get_or_insert_with(DistinctId::new(self.local_node_id()), || {
+                self.circuit()
+                    .add_unary_operator(UnaryOperatorAdapter::new(Distinct::new()), self)
+            })
+            .clone()
+    }
+
+    /// Incremental version of the [`Distinct`] operator.
+    ///
+    /// This is equivalent to `self.integrate().distinct().differentiate()`, but
+    /// is more efficient.
+    pub fn distinct_incremental<V, W>(&self) -> Stream<Circuit<P>, <Z as SharedRef>::Target>
+    where
+        V: KeyProperties,
+        W: ZRingValue,
+        Z: SharedRef + 'static,
+        <Z as SharedRef>::Target: ZSet<V, W> + SharedRef<Target = Z::Target>,
+        for<'a> &'a <Z as SharedRef>::Target: IntoIterator<Item = (&'a V, &'a W)>,
+    {
+        self.circuit()
+            .cache_get_or_insert_with(DistinctIncrementalId::new(self.local_node_id()), || {
+                self.circuit().add_binary_operator(
+                    BinaryOperatorAdapter::new(DistinctIncremental::new()),
+                    self,
+                    &self.integrate().delay(),
+                )
+            })
+            .clone()
+    }
+
+    /// Incremental nested version of the [`Distinct`] operator.
+    pub fn distinct_incremental_nested<V, W>(&self) -> Stream<Circuit<P>, <Z as SharedRef>::Target>
+    where
+        V: KeyProperties,
+        W: ZRingValue,
+        Z: SharedRef + 'static,
+        <Z as SharedRef>::Target: ZSet<V, W> + SharedRef<Target = Z::Target>,
+        for<'a> &'a <Z as SharedRef>::Target: IntoIterator<Item = (&'a V, &'a W)>,
+    {
+        self.integrate_nested()
+            .distinct_incremental()
+            .differentiate_nested()
+    }
+}
+
+/// Distinct operator changes all weights in the support of a Z-set to 1.
+pub struct Distinct<V, W, Z> {
+    _type: PhantomData<(V, W, Z)>,
+}
+
+impl<V, W, Z> Distinct<V, W, Z> {
+    pub fn new() -> Self {
+        Self { _type: PhantomData }
+    }
+}
+
+impl<V, W, Z> Default for Distinct<V, W, Z> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<V, W, Z> Operator for Distinct<V, W, Z>
+where
+    V: 'static,
+    W: 'static,
+    Z: 'static,
+{
+    fn name(&self) -> Cow<'static, str> {
+        Cow::from("Distinct")
+    }
+    fn clock_start(&mut self, _scope: Scope) {}
+    fn clock_end(&mut self, _scope: Scope) {}
+}
+
+impl<V, W, Z> UnaryOperator<Z, Z> for Distinct<V, W, Z>
+where
+    V: KeyProperties,
+    W: ZRingValue,
+    Z: ZSet<V, W> + 'static,
+{
+    fn eval(&mut self, i: &Z) -> Z {
+        i.distinct()
+    }
+
+    fn eval_owned(&mut self, i: Z) -> Z {
+        i.distinct_owned()
+    }
+}
+
+/// Incremental version of the distinct operator.
+///
+/// Takes a stream `a` of changes to relation `A` and a stream with delayed
+/// value of `A`: `z^-1(A) = a.integrate().delay()` and computes
+/// `distinct(A) - distinct(z^-1(A))` incrementally, by only considering
+/// values in the support of `a`.
+struct DistinctIncremental<V, W, Z> {
+    _type: PhantomData<(V, W, Z)>,
+}
+
+impl<V, W, Z> DistinctIncremental<V, W, Z> {
+    pub fn new() -> Self {
+        Self { _type: PhantomData }
+    }
+}
+
+impl<V, W, Z> Default for DistinctIncremental<V, W, Z> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<V, W, Z> Operator for DistinctIncremental<V, W, Z>
+where
+    V: 'static,
+    W: 'static,
+    Z: 'static,
+{
+    fn name(&self) -> Cow<'static, str> {
+        Cow::from("DistinctIncremental")
+    }
+    fn clock_start(&mut self, _scope: Scope) {}
+    fn clock_end(&mut self, _scope: Scope) {}
+}
+
+impl<V, W, Z> BinaryOperator<Z, Z, Z> for DistinctIncremental<V, W, Z>
+where
+    V: KeyProperties,
+    W: ZRingValue,
+    for<'a> &'a Z: IntoIterator<Item = (&'a V, &'a W)>,
+    Z: ZSet<V, W> + 'static,
+{
+    fn eval(&mut self, delta: &Z, delayed_integral: &Z) -> Z {
+        let mut result = Z::empty();
+
+        for (v, w) in delta.into_iter() {
+            let old_weight = delayed_integral.lookup(v);
+            let new_weight = old_weight.clone() + w.clone();
+
+            if old_weight.le0() {
+                // Weight changes from non-positive to positive.
+                if new_weight.ge0() && !new_weight.is_zero() {
+                    result.increment(v, W::one());
+                }
+            } else if new_weight.le0() {
+                // Weight changes from positive to non-positive.
+                result.increment(v, W::one().neg());
+            }
+        }
+
+        result
+    }
+
+    fn eval_owned_and_ref(&mut self, delta: Z, delayed_integral: &Z) -> Z {
+        let mut result = Z::empty();
+
+        for (v, w) in delta.into_iter() {
+            let old_weight = delayed_integral.lookup(&v);
+            let new_weight = old_weight.clone() + w;
+
+            if old_weight.le0() {
+                // Weight changes from non-positive to positive.
+                if new_weight.ge0() && !new_weight.is_zero() {
+                    result.increment_owned(v, W::one());
+                }
+            } else if new_weight.le0() {
+                // Weight changes from positive to non-positive.
+                result.increment_owned(v, W::one().neg());
+            }
+        }
+
+        result
+    }
+
+    fn eval_owned(&mut self, delta: Z, delayed_integral: Z) -> Z {
+        self.eval_owned_and_ref(delta, &delayed_integral)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{cell::RefCell, rc::Rc};
+
+    use crate::{
+        algebra::FiniteHashMap,
+        circuit::Root,
+        finite_map,
+        operator::{Apply2, GeneratorNested},
+    };
+
+    #[test]
+    fn distinct_incremental_nested_test() {
+        let root = Root::build(move |circuit| {
+            // Changes to the edges relation.
+            let mut inputs = vec![
+                vec![
+                    finite_map! { 1 => 1, 2 => 1 },
+                    finite_map! { 2 => -1, 3 => 2, 4 => 2 },
+                ],
+                vec![
+                    finite_map! { 2 => 1, 3 => 1 },
+                    finite_map! { 3 => -2, 4 => -1 },
+                ],
+                vec![
+                    finite_map! { 5 => 1, 6 => 1 },
+                    finite_map! { 2 => -1, 7 => 1 },
+                    finite_map! { 2 => 1, 7 => -1, 8 => 2, 9 => 1 },
+                ],
+            ]
+            .into_iter();
+
+            circuit
+                .iterate(|child| {
+                    let counter = Rc::new(RefCell::new(0));
+                    let counter_clone = counter.clone();
+
+                    let input = child.add_source(GeneratorNested::new(Box::new(move || {
+                        *counter_clone.borrow_mut() = 0;
+                        let mut deltas = inputs.next().unwrap_or_else(|| Vec::new()).into_iter();
+                        Box::new(move || deltas.next().unwrap_or_else(|| finite_map! {}))
+                    })));
+
+                    let distinct_inc = input.distinct_incremental_nested();
+                    let distinct_noninc = input
+                        // Non-incremental implementation of distinct_nested_incremental.
+                        .integrate()
+                        .integrate_nested()
+                        .distinct()
+                        .differentiate()
+                        .differentiate_nested();
+
+                    child
+                        .add_binary_operator(
+                            Apply2::new(
+                                |d1: &FiniteHashMap<usize, isize>,
+                                 d2: &FiniteHashMap<usize, isize>| {
+                                    (d1.clone(), d2.clone())
+                                },
+                            ),
+                            &distinct_inc,
+                            &distinct_noninc,
+                        )
+                        .inspect(|(d1, d2)| assert_eq!(d1, d2));
+
+                    Ok((
+                        move || {
+                            *counter.borrow_mut() += 1;
+                            *counter.borrow() == 4
+                        },
+                        (),
+                    ))
+                })
+                .unwrap();
+        })
+        .unwrap();
+
+        for _ in 0..3 {
+            root.step().unwrap();
+        }
+    }
+}

--- a/src/operator/index.rs
+++ b/src/operator/index.rs
@@ -161,7 +161,7 @@ mod test {
                 finite_map!{ 1 => finite_map!{"a" => 3, "d" => 1, "e" => 1}, 2 => finite_map!{"c" => 1}, 3 => finite_map!{"a" => 2}},
             ].into_iter();
             circuit.add_source(Generator::new(move || inputs.next().unwrap() ))
-                   .index()
+                   .index::<_,_,_,FiniteHashMap<_,_>>()
                    .integrate()
                    .inspect(move |fm: &FiniteHashMap<_, _>| assert_eq!(fm, &outputs.next().unwrap()));
         })
@@ -196,7 +196,7 @@ mod test {
                 finite_map!{ 1 => finite_map!{"a" => 3, "d" => 1, "e" => 1}, 2 => finite_map!{"c" => 1}, 3 => finite_map!{"a" => 2}},
             ].into_iter();
             circuit.add_source(Generator::new(move || inputs.next().unwrap() ))
-                   .index()
+                   .index::<_, _, _, FiniteHashMap<_, _>>()
                    .integrate()
                    .inspect(move |fm: &FiniteHashMap<_, _>| assert_eq!(fm, &outputs.next().unwrap()));
         })

--- a/src/operator/index.rs
+++ b/src/operator/index.rs
@@ -161,7 +161,7 @@ mod test {
                 finite_map!{ 1 => finite_map!{"a" => 3, "d" => 1, "e" => 1}, 2 => finite_map!{"c" => 1}, 3 => finite_map!{"a" => 2}},
             ].into_iter();
             circuit.add_source(Generator::new(move || inputs.next().unwrap() ))
-                   .index::<_,_,_,FiniteHashMap<_,_>>()
+                   .index::<_, _, _, FiniteHashMap<_, _>>()
                    .integrate()
                    .inspect(move |fm: &FiniteHashMap<_, _>| assert_eq!(fm, &outputs.next().unwrap()));
         })

--- a/src/operator/join.rs
+++ b/src/operator/join.rs
@@ -264,7 +264,7 @@ where
 #[cfg(test)]
 mod test {
     use crate::{
-        algebra::{FiniteHashMap, FiniteMap, ZSet},
+        algebra::{FiniteHashMap, FiniteMap},
         circuit::{Root, Stream},
         finite_map,
         operator::{DelayedFeedback, Generator},
@@ -446,12 +446,7 @@ mod test {
                 let edges_indexed: Stream<_, FiniteHashMap<usize, FiniteHashMap<usize, isize>>> = edges.index();
 
                 let paths = edges.plus(&paths_inverted_indexed.join_incremental_nested(&edges_indexed, |_via, from, to| (*from, *to)))
-                    // Non-incremental implementation of distinct_nested_incremental.
-                    .integrate()
-                    .integrate_nested()
-                    .apply(|i| i.distinct())
-                    .differentiate()
-                    .differentiate_nested();
+                    .distinct_incremental_nested();
                 paths_delayed.connect(&paths);
                 let output = paths.integrate();
                 Ok((
@@ -464,7 +459,7 @@ mod test {
             })
             .unwrap();
 
-            paths.integrate().apply(ZSet::distinct).inspect(move |ps| {
+            paths.integrate().distinct().inspect(move |ps| {
                 assert_eq!(*ps, outputs.next().unwrap());
             })
         })

--- a/src/operator/join.rs
+++ b/src/operator/join.rs
@@ -264,7 +264,7 @@ where
 #[cfg(test)]
 mod test {
     use crate::{
-        algebra::{FiniteHashMap, FiniteMap},
+        algebra::{FiniteHashMap, HasZero},
         circuit::{Root, Stream},
         finite_map,
         operator::{DelayedFeedback, Generator},
@@ -451,8 +451,8 @@ mod test {
                 let output = paths.integrate();
                 Ok((
                     vec![
-                        paths.condition(|delta| delta.support_size() == 0),
-                        paths.integrate_nested().condition(|delta| delta.support_size() == 0)
+                        paths.condition(HasZero::is_zero),
+                        paths.integrate_nested().condition(HasZero::is_zero)
                     ],
                     output.export(),
                 ))

--- a/src/operator/mod.rs
+++ b/src/operator/mod.rs
@@ -19,7 +19,7 @@ mod z1;
 pub use z1::{DelayedFeedback, DelayedNestedFeedback, Z1Nested, Z1};
 
 mod generator;
-pub use generator::Generator;
+pub use generator::{Generator, GeneratorNested};
 
 mod integrate;
 
@@ -44,3 +44,6 @@ pub use join::Join;
 
 mod sum;
 pub use sum::Sum;
+
+mod distinct;
+pub use distinct::Distinct;

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -189,7 +189,7 @@ fn transitive_closure() {
 
                 let join_output = child.add_binary_operator(join_op, &add_output, &i_output);
 
-                let distinct_output = join_output.plus(&i_output).apply(ZSet::distinct);
+                let distinct_output = join_output.plus(&i_output).distinct();
                 z1_feedback.connect(&distinct_output);
                 let differentiator_output = distinct_output.differentiate();
                 let condition = differentiator_output.condition(HasZero::is_zero);


### PR DESCRIPTION
Implemented three flavors of the `distinct` operator:

- Non-incremental: `Stream::distinct`.

- Incremental: `Stream::distinct_incremental`.  Functionally this
  operator is equivalent to `D(distinct(I(stream))`, but the implementation is
  incremental, only looking at values in the support of the latest delta.

- Incremental nested: `Stream::distinct_incremental_nested`.  Complete
  implementation:
  ```
  self.integrate_nested()
      .distinct_incremental()
      .differentiate_nested()
  ```

We also add a version of the `Generator` operator (`GeneratorNested`)
that generates nested streams.  This is useful for testing nested
operators.