### PR TITLE
`map_keys`, `filter_map_keys` operators.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,10 @@ extern crate num;
 
 mod shared_ref;
 pub use shared_ref::SharedRef;
+
+mod ref_pair;
+pub use ref_pair::RefPair;
+
 pub mod algebra;
 pub mod circuit;
 pub mod operator;

--- a/src/operator/filter_map.rs
+++ b/src/operator/filter_map.rs
@@ -1,0 +1,136 @@
+//! Filter-map operators.
+
+use crate::{
+    circuit::{
+        operator_traits::{Operator, UnaryOperator},
+        Circuit, Scope, Stream,
+    },
+    RefPair,
+};
+use std::{borrow::Cow, marker::PhantomData};
+
+impl<P, CI> Stream<Circuit<P>, CI>
+where
+    CI: Clone,
+    P: Clone + 'static,
+{
+    /// Apply [`FilterMapKeys`] operator to `self`.
+    ///
+    /// The `func` closure takes input keys by reference.
+    pub fn filter_map_keys<K1, K2, V, CO, F>(&self, func: F) -> Stream<Circuit<P>, CO>
+    where
+        K1: Clone + 'static,
+        K2: Clone + 'static,
+        V: Clone + 'static,
+        CI: IntoIterator<Item = (K1, V)> + 'static,
+        for<'a> &'a CI: IntoIterator,
+        for<'a> <&'a CI as IntoIterator>::Item: RefPair<'a, K1, V>,
+        CO: FromIterator<(K2, V)> + Clone + 'static,
+        F: Fn(&K1) -> Option<K2> + Clone + 'static,
+    {
+        self.circuit()
+            .add_unary_operator(FilterMapKeys::new(func.clone(), move |x| (func)(&x)), self)
+    }
+
+    /// Apply [`FilterMapKeys`] operator to `self`.
+    ///
+    /// The `func` closure operates on owned keys.
+    pub fn filter_map_keys_owned<K1, K2, V, CO, F>(&self, func: F) -> Stream<Circuit<P>, CO>
+    where
+        K1: Clone + 'static,
+        K2: Clone + 'static,
+        V: Clone + 'static,
+        CI: IntoIterator<Item = (K1, V)> + 'static,
+        for<'a> &'a CI: IntoIterator,
+        for<'a> <&'a CI as IntoIterator>::Item: RefPair<'a, K1, V>,
+        CO: FromIterator<(K2, V)> + Clone + 'static,
+        F: Fn(K1) -> Option<K2> + Clone + 'static,
+    {
+        let func_clone = func.clone();
+        self.circuit().add_unary_operator(
+            FilterMapKeys::new(move |x: &K1| (func)(x.clone()), func_clone),
+            self,
+        )
+    }
+}
+
+/// Operator that both filters and maps keys in a collection of key/value
+/// pairs.
+///
+/// # Type arguments
+///
+/// * `K1` - input key type.
+/// * `K2` - output key type.
+/// * `V` - value type.
+/// * `CI` - input collection type.
+/// * `CO` - output collection type.
+/// * `FB` - key mapping function type that takes a borrowed key.
+/// * `FO` - key mapping function type that takes an owned key.
+pub struct FilterMapKeys<K1, K2, V, CI, CO, FB, FO>
+where
+    FB: 'static,
+    FO: 'static,
+{
+    map_borrowed: FB,
+    map_owned: FO,
+    _type: PhantomData<(K1, K2, V, CI, CO)>,
+}
+
+impl<K1, K2, V, CI, CO, FB, FO> FilterMapKeys<K1, K2, V, CI, CO, FB, FO>
+where
+    FB: 'static,
+    FO: 'static,
+{
+    pub fn new(map_borrowed: FB, map_owned: FO) -> Self {
+        Self {
+            map_borrowed,
+            map_owned,
+            _type: PhantomData,
+        }
+    }
+}
+
+impl<K1, K2, V, CI, CO, FB, FO> Operator for FilterMapKeys<K1, K2, V, CI, CO, FB, FO>
+where
+    K1: 'static,
+    K2: 'static,
+    V: 'static,
+    CI: 'static,
+    CO: 'static,
+    FB: 'static,
+    FO: 'static,
+{
+    fn name(&self) -> Cow<'static, str> {
+        Cow::from("FilterMapKeys")
+    }
+    fn clock_start(&mut self, _scope: Scope) {}
+    fn clock_end(&mut self, _scope: Scope) {}
+}
+
+impl<K1, K2, V, CI, CO, FB, FO> UnaryOperator<CI, CO> for FilterMapKeys<K1, K2, V, CI, CO, FB, FO>
+where
+    K1: Clone + 'static,
+    K2: Clone + 'static,
+    V: Clone + 'static,
+    CI: IntoIterator<Item = (K1, V)> + 'static,
+    for<'a> &'a CI: IntoIterator,
+    for<'a> <&'a CI as IntoIterator>::Item: RefPair<'a, K1, V>,
+    CO: FromIterator<(K2, V)> + 'static,
+    FB: Fn(&K1) -> Option<K2> + 'static,
+    FO: Fn(K1) -> Option<K2> + 'static,
+{
+    fn eval(&mut self, i: &CI) -> CO {
+        i.into_iter()
+            .filter_map(|pair| {
+                let (k, v) = pair.into_refs();
+                (self.map_borrowed)(k).map(|k| (k, v.clone()))
+            })
+            .collect()
+    }
+
+    fn eval_owned(&mut self, i: CI) -> CO {
+        i.into_iter()
+            .filter_map(|(k, v)| (self.map_owned)(k).map(|k| (k, v)))
+            .collect()
+    }
+}

--- a/src/operator/index.rs
+++ b/src/operator/index.rs
@@ -6,33 +6,11 @@ use crate::{
         operator_traits::{Operator, UnaryOperator},
         Circuit, NodeId, Scope, Stream,
     },
-    circuit_cache_key,
+    circuit_cache_key, RefPair,
 };
 use std::{borrow::Cow, marker::PhantomData};
 
 circuit_cache_key!(IndexId<C, D>(NodeId => Stream<C, D>));
-
-/// Trait for types that can be converted into a pair of references
-///
-/// This trait unifies `(&K, &V)` and `&(K, V)` types, so that the
-/// [`Index`] operator can work over types that can iterate over either,
-/// such as vectors (which iterate over `&(K,V)`) and maps (which iterate
-/// over `(&K, &V)`)
-pub trait RefPair<'a, K, V> {
-    fn into_refs(self) -> (&'a K, &'a V);
-}
-
-impl<'a, K, V> RefPair<'a, K, V> for &'a (K, V) {
-    fn into_refs(self) -> (&'a K, &'a V) {
-        (&self.0, &self.1)
-    }
-}
-
-impl<'a, K, V> RefPair<'a, K, V> for (&'a K, &'a V) {
-    fn into_refs(self) -> (&'a K, &'a V) {
-        (self.0, self.1)
-    }
-}
 
 impl<P, CI> Stream<Circuit<P>, CI>
 where

--- a/src/operator/join.rs
+++ b/src/operator/join.rs
@@ -436,11 +436,11 @@ mod test {
                 //      join_incremental_nested
                 // ```
                 let edges = edges.delta0(child);
-                let paths_delayed = DelayedFeedback::new(child);
+                let paths_delayed = <DelayedFeedback<_, FiniteHashMap<_, _>>>::new(child);
 
                 let paths_inverted: Stream<_, FiniteHashMap<(usize, usize), isize>> = paths_delayed
                     .stream()
-                    .apply(|paths: &FiniteHashMap<(usize, usize), isize>| paths.into_iter().map(|((x,y), w)| ((*y, *x), *w)).collect());
+                    .map_keys(|&(x, y)| (y, x));
 
                 let paths_inverted_indexed: Stream<_, FiniteHashMap<usize, FiniteHashMap<usize, isize>>> = paths_inverted.index();
                 let edges_indexed: Stream<_, FiniteHashMap<usize, FiniteHashMap<usize, isize>>> = edges.index();

--- a/src/operator/map.rs
+++ b/src/operator/map.rs
@@ -1,0 +1,220 @@
+//! Map operators.
+
+use crate::{
+    circuit::{
+        operator_traits::{Operator, UnaryOperator},
+        Circuit, Scope, Stream,
+    },
+    RefPair,
+};
+use std::{borrow::Cow, marker::PhantomData};
+
+impl<P, CI> Stream<Circuit<P>, CI>
+where
+    CI: Clone,
+    P: Clone + 'static,
+{
+    /// Apply [`MapKeys`] operator to `self`.
+    ///
+    /// The `map` closure takes input keys by reference.
+    pub fn map_keys<K1, K2, V, CO, F>(&self, map: F) -> Stream<Circuit<P>, CO>
+    where
+        K1: Clone + 'static,
+        K2: Clone + 'static,
+        V: Clone + 'static,
+        CI: IntoIterator<Item = (K1, V)> + 'static,
+        for<'a> &'a CI: IntoIterator,
+        for<'a> <&'a CI as IntoIterator>::Item: RefPair<'a, K1, V>,
+        CO: FromIterator<(K2, V)> + Clone + 'static,
+        F: Fn(&K1) -> K2 + Clone + 'static,
+    {
+        self.circuit()
+            .add_unary_operator(MapKeys::new(map.clone(), move |x| (map)(&x)), self)
+    }
+
+    /// Apply [`MapKeys`] operator to `self`.
+    ///
+    /// The `map` closure operates on owned keys.
+    pub fn map_keys_owned<K1, K2, V, CO, F>(&self, map: F) -> Stream<Circuit<P>, CO>
+    where
+        K1: Clone + 'static,
+        K2: Clone + 'static,
+        V: Clone + 'static,
+        CI: IntoIterator<Item = (K1, V)> + 'static,
+        for<'a> &'a CI: IntoIterator,
+        for<'a> <&'a CI as IntoIterator>::Item: RefPair<'a, K1, V>,
+        CO: FromIterator<(K2, V)> + Clone + 'static,
+        F: Fn(K1) -> K2 + Clone + 'static,
+    {
+        let func_clone = map.clone();
+        self.circuit().add_unary_operator(
+            MapKeys::new(move |x: &K1| (map)(x.clone()), func_clone),
+            self,
+        )
+    }
+}
+
+/// Operator that applies a user-defined function to each value in a collection
+/// of key/value pairs.
+///
+/// # Type arguments
+///
+/// * `K1` - input key type.
+/// * `K2` - output key type.
+/// * `V` - value type.
+/// * `CI` - input collection type.
+/// * `CO` - output collection type.
+/// * `FB` - key mapping function type that takes a borrowed key.
+/// * `FO` - key mapping function type that takes an owned key.
+pub struct MapKeys<K1, K2, V, CI, CO, FB, FO>
+where
+    FB: 'static,
+    FO: 'static,
+{
+    map_borrowed: FB,
+    map_owned: FO,
+    _type: PhantomData<(K1, K2, V, CI, CO)>,
+}
+
+impl<K1, K2, V, CI, CO, FB, FO> MapKeys<K1, K2, V, CI, CO, FB, FO>
+where
+    FB: 'static,
+    FO: 'static,
+{
+    pub fn new(map_borrowed: FB, map_owned: FO) -> Self {
+        Self {
+            map_borrowed,
+            map_owned,
+            _type: PhantomData,
+        }
+    }
+}
+
+impl<K1, K2, V, CI, CO, FB, FO> Operator for MapKeys<K1, K2, V, CI, CO, FB, FO>
+where
+    K1: 'static,
+    K2: 'static,
+    V: 'static,
+    CI: 'static,
+    CO: 'static,
+    FB: 'static,
+    FO: 'static,
+{
+    fn name(&self) -> Cow<'static, str> {
+        Cow::from("MapKeys")
+    }
+    fn clock_start(&mut self, _scope: Scope) {}
+    fn clock_end(&mut self, _scope: Scope) {}
+}
+
+impl<K1, K2, V, CI, CO, FB, FO> UnaryOperator<CI, CO> for MapKeys<K1, K2, V, CI, CO, FB, FO>
+where
+    K1: Clone + 'static,
+    K2: Clone + 'static,
+    V: Clone + 'static,
+    CI: IntoIterator<Item = (K1, V)> + 'static,
+    for<'a> &'a CI: IntoIterator,
+    for<'a> <&'a CI as IntoIterator>::Item: RefPair<'a, K1, V>,
+    CO: FromIterator<(K2, V)> + 'static,
+    FB: Fn(&K1) -> K2 + 'static,
+    FO: Fn(K1) -> K2 + 'static,
+{
+    fn eval(&mut self, i: &CI) -> CO {
+        i.into_iter()
+            .map(|pair| {
+                let (k, v) = pair.into_refs();
+                ((self.map_borrowed)(k), v.clone())
+            })
+            .collect()
+    }
+
+    fn eval_owned(&mut self, i: CI) -> CO {
+        i.into_iter()
+            .map(|(k, v)| ((self.map_owned)(k), v))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        algebra::FiniteHashMap,
+        circuit::{Root, Stream},
+        finite_map,
+        operator::Generator,
+    };
+    use std::vec;
+
+    #[test]
+    fn map_keys_test() {
+        let root = Root::build(move |circuit| {
+            let mut input_map: vec::IntoIter<FiniteHashMap<isize, isize>> =
+                vec![finite_map! { 1 => 1, -1 => 1, 5 => 1 }].into_iter();
+            let mut times2_output: vec::IntoIter<FiniteHashMap<isize, isize>> =
+                vec![finite_map! { 2 => 1, -2 => 1, 10 => 1 }].into_iter();
+            let mut times2_pos_output: vec::IntoIter<FiniteHashMap<isize, isize>> =
+                vec![finite_map! { 2 => 1, 10 => 1 }].into_iter();
+            let mut neg_output: vec::IntoIter<FiniteHashMap<isize, isize>> =
+                vec![finite_map! { -1 => 1, 1 => 1, -5 => 1}].into_iter();
+            let mut neg_pos_output: vec::IntoIter<FiniteHashMap<isize, isize>> =
+                vec![finite_map! { -1 => 1, -5 => 1}].into_iter();
+
+            let mut input_vec: vec::IntoIter<Vec<(isize, isize)>> =
+                vec![vec![(1, 1), (-1, 1)]].into_iter();
+            let mut abs_output: vec::IntoIter<FiniteHashMap<isize, isize>> =
+                vec![finite_map! { 1 => 2 }].into_iter();
+            let mut abs_pos_output: vec::IntoIter<FiniteHashMap<isize, isize>> =
+                vec![finite_map! { 1 => 1 }].into_iter();
+            let mut sqr_output: vec::IntoIter<FiniteHashMap<isize, isize>> =
+                vec![finite_map! { 1 => 2, }].into_iter();
+            let mut sqr_pos_output: vec::IntoIter<FiniteHashMap<isize, isize>> =
+                vec![finite_map! { 1 => 1, }].into_iter();
+
+            let input_map_stream =
+                circuit.add_source(Generator::new(move || input_map.next().unwrap()));
+            let input_vec_stream =
+                circuit.add_source(Generator::new(move || input_vec.next().unwrap()));
+            let times2: Stream<_, FiniteHashMap<_, _>> = input_map_stream.map_keys(|n| n * 2);
+            let times2_pos: Stream<_, FiniteHashMap<_, _>> =
+                input_map_stream.filter_map_keys(|n| if *n > 0 { Some(n * 2) } else { None });
+            let neg: Stream<_, FiniteHashMap<_, _>> = input_map_stream.map_keys_owned(|n| -n);
+            let neg_pos: Stream<_, FiniteHashMap<_, _>> =
+                input_map_stream.filter_map_keys_owned(|n| if n > 0 { Some(-n) } else { None });
+            let abs: Stream<_, FiniteHashMap<_, _>> = input_vec_stream.map_keys(|n| n.abs());
+            let abs_pos: Stream<_, FiniteHashMap<_, _>> =
+                input_vec_stream.filter_map_keys(|n| if *n > 0 { Some(n.abs()) } else { None });
+            let sqr: Stream<_, FiniteHashMap<_, _>> = input_vec_stream.map_keys_owned(|n| n * n);
+            let sqr_pos: Stream<_, FiniteHashMap<_, _>> =
+                input_vec_stream.filter_map_keys_owned(|n| if n > 0 { Some(n * n) } else { None });
+            times2.inspect(move |n| {
+                assert_eq!(*n, times2_output.next().unwrap());
+            });
+            times2_pos.inspect(move |n| {
+                assert_eq!(*n, times2_pos_output.next().unwrap());
+            });
+            neg.inspect(move |n| {
+                assert_eq!(*n, neg_output.next().unwrap());
+            });
+            neg_pos.inspect(move |n| {
+                assert_eq!(*n, neg_pos_output.next().unwrap());
+            });
+            abs.inspect(move |n| {
+                assert_eq!(*n, abs_output.next().unwrap());
+            });
+            abs_pos.inspect(move |n| {
+                assert_eq!(*n, abs_pos_output.next().unwrap());
+            });
+            sqr.inspect(move |n| {
+                assert_eq!(*n, sqr_output.next().unwrap());
+            });
+            sqr_pos.inspect(move |n| {
+                assert_eq!(*n, sqr_pos_output.next().unwrap());
+            });
+        })
+        .unwrap();
+
+        for _ in 0..1 {
+            root.step().unwrap();
+        }
+    }
+}

--- a/src/operator/mod.rs
+++ b/src/operator/mod.rs
@@ -47,3 +47,9 @@ pub use sum::Sum;
 
 mod distinct;
 pub use distinct::Distinct;
+
+mod map;
+pub use map::MapKeys;
+
+mod filter_map;
+pub use filter_map::FilterMapKeys;

--- a/src/ref_pair.rs
+++ b/src/ref_pair.rs
@@ -1,0 +1,23 @@
+//! Trait for types that can be converted into a pair of references.
+
+/// Trait for types that can be converted into a pair of references
+///
+/// This trait unifies `(&K, &V)` and `&(K, V)` types, so that
+/// operator can work on collection types that can iterate over either,
+/// such as vectors (which iterate over `&(K,V)`) and maps (which iterate
+/// over `(&K, &V)`)
+pub trait RefPair<'a, K, V> {
+    fn into_refs(self) -> (&'a K, &'a V);
+}
+
+impl<'a, K, V> RefPair<'a, K, V> for &'a (K, V) {
+    fn into_refs(self) -> (&'a K, &'a V) {
+        (&self.0, &self.1)
+    }
+}
+
+impl<'a, K, V> RefPair<'a, K, V> for (&'a K, &'a V) {
+    fn into_refs(self) -> (&'a K, &'a V) {
+        (self.0, self.1)
+    }
+}


### PR DESCRIPTION
Please look at the **last** commit only.

We implement two flavors of both operators that work on borrowed and owned keys respectively.
 
As always, we make operators generic over input and output collections, which means that the user needs to write type annotations when instantiating the operators.