### PR TITLE
Start building infra for arbitrarily nested circuits.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,6 @@ required-features = ["with-csv"]
 [[bench]]
 name = "path"
 harness = false
+
+[profile.bench]
+debug = true

--- a/benches/path.rs
+++ b/benches/path.rs
@@ -3,6 +3,7 @@ use dbsp::{
     monitor::TraceMonitor,
     operator::{DelayedFeedback, Generator},
     profile::CPUProfiler,
+    time::NestedTimestamp32,
     trace::{
         ord::{OrdIndexedZSet, OrdZSet},
         Batch,
@@ -103,8 +104,10 @@ fn main() {
 
                 let paths = edges
                     .plus(
-                        &paths_inverted_indexed
-                            .join_trace(&edges_indexed, |_via, from, to| (*from, *to)),
+                        &paths_inverted_indexed.join_trace::<NestedTimestamp32, _, _, _>(
+                            &edges_indexed,
+                            |_via, from, to| (*from, *to),
+                        ),
                     )
                     .distinct_trace();
                 paths_delayed.connect(&paths);

--- a/src/lattice.rs
+++ b/src/lattice.rs
@@ -15,7 +15,7 @@ pub trait Lattice: PartialOrder {
     ///
     /// ```
     /// # use timely::PartialOrder;
-    /// # use timely::order::Product;
+    /// # use dbsp::time::Product;
     /// # use dbsp::lattice::Lattice;
     /// # fn main() {
     ///
@@ -35,7 +35,7 @@ pub trait Lattice: PartialOrder {
     ///
     /// ```
     /// # use timely::PartialOrder;
-    /// # use timely::order::Product;
+    /// # use dbsp::time::Product;
     /// # use dbsp::lattice::Lattice;
     /// # fn main() {
     ///
@@ -59,7 +59,7 @@ pub trait Lattice: PartialOrder {
     ///
     /// ```
     /// # use timely::PartialOrder;
-    /// # use timely::order::Product;
+    /// # use dbsp::time::Product;
     /// # use dbsp::lattice::Lattice;
     /// # fn main() {
     ///
@@ -79,7 +79,7 @@ pub trait Lattice: PartialOrder {
     ///
     /// ```
     /// # use timely::PartialOrder;
-    /// # use timely::order::Product;
+    /// # use dbsp::time::Product;
     /// # use dbsp::lattice::Lattice;
     /// # fn main() {
     ///
@@ -113,7 +113,7 @@ pub trait Lattice: PartialOrder {
     ///
     /// ```
     /// # use timely::PartialOrder;
-    /// # use timely::order::Product;
+    /// # use dbsp::time::Product;
     /// # use dbsp::lattice::Lattice;
     /// # fn main() {
     ///
@@ -150,26 +150,6 @@ pub trait Lattice: PartialOrder {
                 result.meet_assign(&self.join(f));
             }
             *self = result;
-        }
-    }
-}
-
-use timely::order::Product;
-
-impl<T1: Lattice, T2: Lattice> Lattice for Product<T1, T2> {
-    #[inline]
-    fn join(&self, other: &Product<T1, T2>) -> Product<T1, T2> {
-        Product {
-            outer: self.outer.join(&other.outer),
-            inner: self.inner.join(&other.inner),
-        }
-    }
-
-    #[inline]
-    fn meet(&self, other: &Product<T1, T2>) -> Product<T1, T2> {
-        Product {
-            outer: self.outer.meet(&other.outer),
-            inner: self.inner.meet(&other.inner),
         }
     }
 }

--- a/src/operator/adapter.rs
+++ b/src/operator/adapter.rs
@@ -68,8 +68,8 @@ where
         self.op.register_ready_callback(cb);
     }
 
-    fn fixedpoint(&self) -> bool {
-        self.op.fixedpoint()
+    fn fixedpoint(&self, scope: Scope) -> bool {
+        self.op.fixedpoint(scope)
     }
 }
 
@@ -141,8 +141,8 @@ where
         self.op.register_ready_callback(cb);
     }
 
-    fn fixedpoint(&self) -> bool {
-        self.op.fixedpoint()
+    fn fixedpoint(&self, scope: Scope) -> bool {
+        self.op.fixedpoint(scope)
     }
 }
 

--- a/src/operator/aggregate.rs
+++ b/src/operator/aggregate.rs
@@ -6,7 +6,7 @@ use crate::{
     algebra::{HasOne, HasZero, IndexedZSet, ZRingValue, ZSet},
     circuit::{
         operator_traits::{BinaryOperator, Operator, UnaryOperator},
-        Circuit, Stream,
+        Circuit, Scope, Stream,
     },
     trace::{cursor::Cursor, BatchReader},
     NumEntries,
@@ -178,7 +178,7 @@ where
     fn name(&self) -> Cow<'static, str> {
         Cow::from("Aggregate")
     }
-    fn fixedpoint(&self) -> bool {
+    fn fixedpoint(&self, _scope: Scope) -> bool {
         true
     }
 }
@@ -247,7 +247,7 @@ where
     fn name(&self) -> Cow<'static, str> {
         Cow::from("AggregateIncremental")
     }
-    fn fixedpoint(&self) -> bool {
+    fn fixedpoint(&self, _scope: Scope) -> bool {
         true
     }
 }

--- a/src/operator/apply.rs
+++ b/src/operator/apply.rs
@@ -2,7 +2,7 @@
 
 use crate::circuit::{
     operator_traits::{Operator, UnaryOperator},
-    Circuit, Stream,
+    Circuit, Scope, Stream,
 };
 
 use std::borrow::Cow;
@@ -45,7 +45,7 @@ where
         Cow::from("Apply")
     }
 
-    fn fixedpoint(&self) -> bool {
+    fn fixedpoint(&self, _scope: Scope) -> bool {
         // TODO: either change `F` type to `Fn` from `FnMut` or
         // parameterize the operator with custom fixed point check.
         unimplemented!();

--- a/src/operator/apply2.rs
+++ b/src/operator/apply2.rs
@@ -1,6 +1,9 @@
 //! Binary operator that applies an arbitrary binary function to its inputs.
 
-use crate::circuit::operator_traits::{BinaryOperator, Operator};
+use crate::circuit::{
+    operator_traits::{BinaryOperator, Operator},
+    Scope,
+};
 use std::borrow::Cow;
 
 /// Applies a user-provided binary function to its inputs at each timestamp.
@@ -25,7 +28,7 @@ where
         Cow::from("Apply2")
     }
 
-    fn fixedpoint(&self) -> bool {
+    fn fixedpoint(&self, _scope: Scope) -> bool {
         // TODO: either change `F` type to `Fn` from `FnMut` or
         // parameterize the operator with custom fixed point check.
         unimplemented!();

--- a/src/operator/communication/exchange.rs
+++ b/src/operator/communication/exchange.rs
@@ -447,7 +447,7 @@ where
         self.exchange.ready_to_send(self.worker_index)
     }
 
-    fn fixedpoint(&self) -> bool {
+    fn fixedpoint(&self, _scope: Scope) -> bool {
         // TODO: Add a mechanism to communicate fixed point status among peers.
         unimplemented!()
     }
@@ -536,7 +536,7 @@ where
         self.exchange.ready_to_receive(self.worker_index)
     }
 
-    fn fixedpoint(&self) -> bool {
+    fn fixedpoint(&self, _scope: Scope) -> bool {
         // TODO: Add a mechanism to communicate fixed point status among peers.
         unimplemented!()
     }

--- a/src/operator/consolidate.rs
+++ b/src/operator/consolidate.rs
@@ -5,7 +5,7 @@ use std::{borrow::Cow, convert::TryFrom, marker::PhantomData};
 use crate::{
     circuit::{
         operator_traits::{Operator, UnaryOperator},
-        Circuit, NodeId, OwnershipPreference, Stream,
+        Circuit, NodeId, OwnershipPreference, Scope, Stream,
     },
     circuit_cache_key,
     trace::{Batch, Trace},
@@ -70,7 +70,7 @@ where
     fn name(&self) -> Cow<'static, str> {
         Cow::from("Consolidate")
     }
-    fn fixedpoint(&self) -> bool {
+    fn fixedpoint(&self, _scope: Scope) -> bool {
         true
     }
 }

--- a/src/operator/csv.rs
+++ b/src/operator/csv.rs
@@ -63,7 +63,7 @@ where
     fn clock_start(&mut self, _scope: Scope) {
         self.time = 0;
     }
-    fn fixedpoint(&self) -> bool {
+    fn fixedpoint(&self, _scope: Scope) -> bool {
         self.time >= 2
     }
 }

--- a/src/operator/delta0.rs
+++ b/src/operator/delta0.rs
@@ -4,7 +4,7 @@ use crate::{
     algebra::HasZero,
     circuit::{
         operator_traits::{Data, ImportOperator, Operator},
-        Circuit, OwnershipPreference, Stream,
+        Circuit, OwnershipPreference, Scope, Stream,
     },
 };
 use std::borrow::Cow;
@@ -88,8 +88,14 @@ where
     fn name(&self) -> Cow<'static, str> {
         Cow::from("delta0")
     }
-    fn fixedpoint(&self) -> bool {
-        self.fixedpoint
+    fn fixedpoint(&self, scope: Scope) -> bool {
+        if scope == 0 {
+            // Output becomes stable (all zeros) after the first clock cycle.
+            self.fixedpoint
+        } else {
+            // Delta0 does not maintain any state across epochs.
+            true
+        }
     }
 }
 

--- a/src/operator/distinct.rs
+++ b/src/operator/distinct.rs
@@ -134,7 +134,7 @@ where
     fn name(&self) -> Cow<'static, str> {
         Cow::from("Distinct")
     }
-    fn fixedpoint(&self) -> bool {
+    fn fixedpoint(&self, _scope: Scope) -> bool {
         true
     }
 }
@@ -182,7 +182,7 @@ where
     fn name(&self) -> Cow<'static, str> {
         Cow::from("DistinctIncremental")
     }
-    fn fixedpoint(&self) -> bool {
+    fn fixedpoint(&self, _scope: Scope) -> bool {
         true
     }
 }
@@ -417,7 +417,9 @@ where
             self.empty_output = false;
         }
     }
-    fn fixedpoint(&self) -> bool {
+    fn fixedpoint(&self, scope: Scope) -> bool {
+        // TODO: generalize `DistinctTrace` to support arbitrarily nested scopes.
+        assert_eq!(scope, 0);
         self.empty_input
             && self.empty_output
             && self

--- a/src/operator/filter.rs
+++ b/src/operator/filter.rs
@@ -3,7 +3,7 @@
 use crate::{
     circuit::{
         operator_traits::{Operator, UnaryOperator},
-        Circuit, Stream,
+        Circuit, Scope, Stream,
     },
     trace::{Batch, BatchReader, Builder, Cursor},
 };
@@ -67,7 +67,7 @@ where
     fn name(&self) -> Cow<'static, str> {
         Cow::from("FilterKeys")
     }
-    fn fixedpoint(&self) -> bool {
+    fn fixedpoint(&self, _scope: Scope) -> bool {
         true
     }
 }

--- a/src/operator/filter_map.rs
+++ b/src/operator/filter_map.rs
@@ -3,7 +3,7 @@
 use crate::{
     circuit::{
         operator_traits::{Operator, UnaryOperator},
-        Circuit, Stream,
+        Circuit, Scope, Stream,
     },
     trace::{Batch, BatchReader, Cursor},
 };
@@ -91,7 +91,7 @@ where
     fn name(&self) -> Cow<'static, str> {
         Cow::from("FilterMapKeys")
     }
-    fn fixedpoint(&self) -> bool {
+    fn fixedpoint(&self, _scope: Scope) -> bool {
         true
     }
 }

--- a/src/operator/generator.rs
+++ b/src/operator/generator.rs
@@ -35,7 +35,7 @@ where
     fn name(&self) -> Cow<'static, str> {
         Cow::from("Generator")
     }
-    fn fixedpoint(&self) -> bool {
+    fn fixedpoint(&self, _scope: Scope) -> bool {
         false
     }
 }
@@ -85,7 +85,7 @@ where
         }
     }
 
-    fn fixedpoint(&self) -> bool {
+    fn fixedpoint(&self, _scope: Scope) -> bool {
         // TODO: do we want a version of `GeneratorNested` that
         // can inform the circuit that it's reached a fixedpoint?
         false

--- a/src/operator/index.rs
+++ b/src/operator/index.rs
@@ -4,7 +4,7 @@ use crate::{
     algebra::{IndexedZSet, ZRingValue, ZSet},
     circuit::{
         operator_traits::{Operator, UnaryOperator},
-        Circuit, NodeId, Stream,
+        Circuit, NodeId, Scope, Stream,
     },
     circuit_cache_key,
     trace::{cursor::Cursor, ord::OrdZSet, Batch, Builder},
@@ -82,7 +82,7 @@ where
     fn name(&self) -> Cow<'static, str> {
         Cow::from("Index")
     }
-    fn fixedpoint(&self) -> bool {
+    fn fixedpoint(&self, _scope: Scope) -> bool {
         true
     }
 }

--- a/src/operator/inspect.rs
+++ b/src/operator/inspect.rs
@@ -3,7 +3,7 @@
 
 use crate::circuit::{
     operator_traits::{Operator, SinkOperator},
-    Circuit, Stream,
+    Circuit, Scope, Stream,
 };
 use std::{borrow::Cow, marker::PhantomData};
 
@@ -71,7 +71,7 @@ where
         Cow::from("Inspect")
     }
 
-    fn fixedpoint(&self) -> bool {
+    fn fixedpoint(&self, _scope: Scope) -> bool {
         true
     }
 }

--- a/src/operator/map.rs
+++ b/src/operator/map.rs
@@ -3,7 +3,7 @@
 use crate::{
     circuit::{
         operator_traits::{Operator, UnaryOperator},
-        Circuit, Stream,
+        Circuit, Scope, Stream,
     },
     trace::{cursor::Cursor, Batch, BatchReader},
 };
@@ -104,7 +104,7 @@ where
     fn name(&self) -> Cow<'static, str> {
         Cow::from("MapKeys")
     }
-    fn fixedpoint(&self) -> bool {
+    fn fixedpoint(&self, _scope: Scope) -> bool {
         true
     }
 }
@@ -181,7 +181,7 @@ where
     fn name(&self) -> Cow<'static, str> {
         Cow::from("MapValues")
     }
-    fn fixedpoint(&self) -> bool {
+    fn fixedpoint(&self, _scope: Scope) -> bool {
         true
     }
 }

--- a/src/operator/plus.rs
+++ b/src/operator/plus.rs
@@ -4,7 +4,7 @@ use crate::{
     algebra::{AddAssignByRef, AddByRef, NegByRef},
     circuit::{
         operator_traits::{BinaryOperator, Operator},
-        Circuit, OwnershipPreference, Stream,
+        Circuit, OwnershipPreference, Scope, Stream,
     },
 };
 use std::{
@@ -90,7 +90,7 @@ where
         Cow::from("Plus")
     }
 
-    fn fixedpoint(&self) -> bool {
+    fn fixedpoint(&self, _scope: Scope) -> bool {
         true
     }
 }
@@ -147,7 +147,7 @@ where
         Cow::from("Minus")
     }
 
-    fn fixedpoint(&self) -> bool {
+    fn fixedpoint(&self, _scope: Scope) -> bool {
         true
     }
 }

--- a/src/operator/sum.rs
+++ b/src/operator/sum.rs
@@ -4,7 +4,7 @@ use crate::{
     algebra::{AddAssignByRef, AddByRef, HasZero},
     circuit::{
         operator_traits::{NaryOperator, Operator},
-        Circuit, OwnershipPreference, Stream,
+        Circuit, OwnershipPreference, Scope, Stream,
     },
     NumEntries,
 };
@@ -68,7 +68,7 @@ where
         Cow::from("Sum")
     }
 
-    fn fixedpoint(&self) -> bool {
+    fn fixedpoint(&self, _scope: Scope) -> bool {
         true
     }
 }

--- a/src/operator/trace.rs
+++ b/src/operator/trace.rs
@@ -199,7 +199,7 @@ where
     fn eval(&mut self, _trace: &T, _batch: &B) -> T {
         // Refuse to accept trace by reference.  This should not happen in a correctly
         // constructed circuit.
-        unimplemented!()
+        panic!("UntimedTraceAppend::eval(): cannot accept trace by reference")
     }
 
     fn eval_owned_and_ref(&mut self, mut trace: T, batch: &B) -> T {
@@ -210,7 +210,7 @@ where
     fn eval_ref_and_owned(&mut self, _trace: &T, _batch: B) -> T {
         // Refuse to accept trace by reference.  This should not happen in a correctly
         // constructed circuit.
-        unimplemented!()
+        panic!("UntimedTraceAppend::eval_ref_and_owned(): cannot accept trace by reference")
     }
 
     fn eval_owned(&mut self, mut trace: T, batch: B) -> T {

--- a/src/operator/z1.rs
+++ b/src/operator/z1.rs
@@ -196,11 +196,15 @@ where
         //println!("zbytes:{}", bytes);
     }
 
-    fn fixedpoint(&self) -> bool {
-        (self.val.num_entries_shallow() == 0) && self.empty_output
-        /*if res == false {
-            eprintln!("num_entries_shallow: {}", self.val.num_entries_shallow());
-        }*/
+    fn fixedpoint(&self, scope: Scope) -> bool {
+        if scope == 0 {
+            (self.val.num_entries_shallow() == 0) && self.empty_output
+            /*if res == false {
+                eprintln!("num_entries_shallow: {}", self.val.num_entries_shallow());
+            }*/
+        } else {
+            true
+        }
     }
 }
 
@@ -359,11 +363,15 @@ where
         //println!("bytes: {}", total_bytes);
     }
 
-    fn fixedpoint(&self) -> bool {
-        self.val
-            .iter()
-            .skip(self.timestamp - 1)
-            .all(|v| *v == self.zero)
+    fn fixedpoint(&self, scope: Scope) -> bool {
+        if scope == 0 {
+            self.val
+                .iter()
+                .skip(self.timestamp - 1)
+                .all(|v| *v == self.zero)
+        } else {
+            false
+        }
     }
 }
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,6 +1,7 @@
 use crate::{circuit::Scope, lattice::Lattice};
 use deepsize_derive::DeepSizeOf;
 use timely::{progress::PathSummary, PartialOrder};
+use std::hash::Hash;
 
 /// Logical timestamp.
 ///
@@ -58,7 +59,7 @@ use timely::{progress::PathSummary, PartialOrder};
 // TODO: Eliminate timely dependency.
 // TODO: Conversion to/from the most general time representation (`[usize]`).
 // TODO: Model overflow by having `advance` return Option<Self>.
-pub trait Timestamp: PartialOrder + Clone + Ord + PartialEq + Eq + 'static {
+pub trait Timestamp: PartialOrder + Clone + Ord + PartialEq + Eq + Hash + 'static {
     fn minimum() -> Self;
 
     /// Advance the timestamp by one clock tick.

--- a/src/time/nested_ts32.rs
+++ b/src/time/nested_ts32.rs
@@ -1,0 +1,126 @@
+use crate::{circuit::Scope, lattice::Lattice, time::Timestamp};
+use deepsize_derive::DeepSizeOf;
+use std::fmt::{Debug, Display, Formatter};
+use timely::PartialOrder;
+
+const INNER_MASK: u32 = 0x7fffffff;
+const EPOCH_MASK: u32 = 0x80000000;
+
+/// Nested timestamp that allocates one bit for the parent clock and the
+/// remaining 31 bits for the child clock.
+///
+/// This representation precisely captures the nested clock value, but only
+/// distinguishes the latest parent clock cycle, or "epoch", (higher-order bit
+/// set to `1`) from all previous epochs (higher order bit is `0`).
+#[derive(Clone, DeepSizeOf, Default, Eq, PartialEq, Debug, Hash, PartialOrd, Ord)]
+pub struct NestedTimestamp32(u32);
+
+impl Display for NestedTimestamp32 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(
+            f,
+            "({}, {})",
+            if self.epoch() { "new" } else { "old" },
+            self.inner(),
+        )
+    }
+}
+
+impl NestedTimestamp32 {
+    #[inline]
+    pub fn new(epoch: bool, inner: u32) -> Self {
+        debug_assert_eq!(inner >> 31, 0);
+
+        let epoch = if epoch { EPOCH_MASK } else { 0 };
+        Self(epoch | inner)
+    }
+
+    #[inline]
+    pub fn epoch(&self) -> bool {
+        self.0 >> 31 == 1
+    }
+
+    #[inline]
+    pub fn inner(&self) -> u32 {
+        self.0 & INNER_MASK
+    }
+}
+
+impl PartialOrder for NestedTimestamp32 {
+    #[inline]
+    fn less_equal(&self, other: &Self) -> bool {
+        self.epoch().le(&other.epoch()) && self.inner().less_equal(&other.inner())
+    }
+}
+
+impl Timestamp for NestedTimestamp32 {
+    fn minimum() -> Self {
+        Self::new(false, 0)
+    }
+
+    /// Start with epoch set to 1 (current epoch).
+    fn clock_start() -> Self {
+        Self::new(true, 0)
+    }
+
+    fn advance(&self, scope: Scope) -> Self {
+        if scope == 0 {
+            if self.0 & INNER_MASK == INNER_MASK {
+                panic!("NestedTimestamp32::advance timestamp overflow");
+            }
+            Self(self.0 + 1)
+        } else {
+            Self::new(true, 0)
+        }
+    }
+
+    fn recede(&self, scope: Scope) -> Self {
+        if scope == 0 {
+            if self.0 & INNER_MASK == 0 {
+                panic!("NestedTimestamp32::recede timestamp underflow");
+            }
+            Self(self.0 - 1)
+        } else if scope == 1 {
+            Self(self.0 & INNER_MASK)
+        } else {
+            self.clone()
+        }
+    }
+
+    fn epoch_start(&self, scope: Scope) -> Self {
+        if scope == 0 {
+            Self::new(self.epoch(), 0x0)
+        } else if scope == 1 {
+            Self::new(false, 0x0)
+        } else {
+            unreachable!()
+        }
+    }
+
+    fn epoch_end(&self, scope: Scope) -> Self {
+        if scope == 0 {
+            Self::new(self.epoch(), INNER_MASK)
+        } else if scope == 1 {
+            Self::new(true, INNER_MASK)
+        } else {
+            unreachable!()
+        }
+    }
+}
+
+impl Lattice for NestedTimestamp32 {
+    #[inline]
+    fn join(&self, other: &NestedTimestamp32) -> NestedTimestamp32 {
+        Self::new(
+            self.epoch() || other.epoch(),
+            self.inner().join(&other.inner()),
+        )
+    }
+    #[inline]
+    fn meet(&self, other: &NestedTimestamp32) -> NestedTimestamp32 {
+        Self::new(
+            self.epoch() && other.epoch(),
+            self.inner().meet(&other.inner()),
+        )
+    }
+}

--- a/src/time/product.rs
+++ b/src/time/product.rs
@@ -1,0 +1,104 @@
+use crate::{circuit::Scope, lattice::Lattice, time::Timestamp};
+use deepsize_derive::DeepSizeOf;
+use std::fmt::{Debug, Display, Formatter};
+use timely::PartialOrder;
+
+/// A nested pair of timestamps, one outer and one inner.
+#[derive(Copy, Clone, Hash, Eq, PartialEq, Default, Ord, PartialOrd, DeepSizeOf)]
+pub struct Product<TOuter, TInner> {
+    /// Outer timestamp.
+    pub outer: TOuter,
+    /// Inner timestamp.
+    pub inner: TInner,
+}
+
+impl<TOuter, TInner> Product<TOuter, TInner> {
+    /// Creates a new product from outer and inner coordinates.
+    pub fn new(outer: TOuter, inner: TInner) -> Product<TOuter, TInner> {
+        Product { outer, inner }
+    }
+}
+
+impl<T1: Lattice, T2: Lattice> Lattice for Product<T1, T2> {
+    #[inline]
+    fn join(&self, other: &Product<T1, T2>) -> Product<T1, T2> {
+        Product {
+            outer: self.outer.join(&other.outer),
+            inner: self.inner.join(&other.inner),
+        }
+    }
+
+    #[inline]
+    fn meet(&self, other: &Product<T1, T2>) -> Product<T1, T2> {
+        Product {
+            outer: self.outer.meet(&other.outer),
+            inner: self.inner.meet(&other.inner),
+        }
+    }
+}
+
+/// Debug implementation to avoid seeing fully qualified path names.
+impl<TOuter: Debug, TInner: Debug> Debug for Product<TOuter, TInner> {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), std::fmt::Error> {
+        f.write_str(&format!("({:?}, {:?})", self.outer, self.inner))
+    }
+}
+
+impl<TOuter: Display, TInner: Display> Display for Product<TOuter, TInner> {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), std::fmt::Error> {
+        f.write_str(&format!("({}, {})", self.outer, self.inner))
+    }
+}
+
+impl<TOuter: PartialOrder, TInner: PartialOrder> PartialOrder for Product<TOuter, TInner> {
+    #[inline(always)]
+    fn less_equal(&self, other: &Self) -> bool {
+        self.outer.less_equal(&other.outer) && self.inner.less_equal(&other.inner)
+    }
+}
+
+impl<TOuter, TInner> Timestamp for Product<TOuter, TInner>
+where
+    TOuter: Timestamp,
+    TInner: Timestamp,
+{
+    fn minimum() -> Self {
+        Self::new(TOuter::minimum(), TInner::minimum())
+    }
+
+    fn clock_start() -> Self {
+        Self::new(TOuter::clock_start(), TInner::clock_start())
+    }
+
+    fn advance(&self, scope: Scope) -> Self {
+        if scope == 0 {
+            Self::new(self.outer.clone(), self.inner.advance(0))
+        } else {
+            Self::new(self.outer.advance(scope - 1), TInner::minimum())
+        }
+    }
+
+    fn recede(&self, scope: Scope) -> Self {
+        if scope == 0 {
+            Self::new(self.outer.clone(), self.inner.recede(0))
+        } else {
+            Self::new(self.outer.recede(scope - 1), self.inner.clone())
+        }
+    }
+
+    fn epoch_start(&self, scope: Scope) -> Self {
+        if scope == 0 {
+            Self::new(self.outer.clone(), TInner::minimum())
+        } else {
+            Self::new(self.outer.epoch_start(scope - 1), TInner::minimum())
+        }
+    }
+
+    fn epoch_end(&self, scope: Scope) -> Self {
+        if scope == 0 {
+            Self::new(self.outer.clone(), self.inner.epoch_end(0))
+        } else {
+            Self::new(self.outer.epoch_end(scope - 1), self.inner.epoch_end(0))
+        }
+    }
+}

--- a/src/trace/cursor/mod.rs
+++ b/src/trace/cursor/mod.rs
@@ -1,9 +1,15 @@
-//! Traits and types for navigating order sequences of update tuples.
+//! Traits and types for navigating order sequences of
+//! `(key, val, time, diff)` tuples.
 //!
 //! The `Cursor` trait contains several methods for efficiently navigating
-//! ordered collections of tuples of the form `(key, val, time, diff)`. The
-//! cursor is different from an iterator both because it allows navigation on
-//! multiple levels (key and val), but also because it supports efficient
+//! ordered collections of tuples of the form `(key, val, time, diff)`.  The
+//! tuples are ordered by key, then by value within each key.  Ordering by time
+//! is not guaranteed, in particular [`CursorList`](`cursor_list::CursorList`)
+//! and [`CursorPair`](`cursor_pair::CursorPair`) cursors can contain
+//! out-of-order and duplicate timestamps.
+//!
+//! The cursor is different from an iterator both because it allows navigation
+//! on multiple levels (key and val), but also because it supports efficient
 //! seeking (via the `seek_key` and `seek_val` methods).
 
 pub mod cursor_list;
@@ -11,7 +17,7 @@ pub mod cursor_pair;
 
 pub use self::cursor_list::CursorList;
 
-/// A cursor for navigating ordered `(key, val, time, diff)` updates.
+/// A cursor for navigating ordered `(key, val, time, diff)` tuples.
 pub trait Cursor<K, V, T, R> {
     /// Type the cursor addresses data in.
     type Storage;
@@ -26,9 +32,9 @@ pub trait Cursor<K, V, T, R> {
     /// for this key.
     fn val_valid(&self, storage: &Self::Storage) -> bool;
 
-    /// A reference to the current key. Asserts if invalid.
+    /// A reference to the current key. Panics if invalid.
     fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K;
-    /// A reference to the current value. Asserts if invalid.
+    /// A reference to the current value. Panics if invalid.
     fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V;
 
     /// Returns a reference to the current key, if valid.

--- a/src/trace/ord/indexed_zset_batch.rs
+++ b/src/trace/ord/indexed_zset_batch.rs
@@ -1,7 +1,7 @@
 use std::{
     cmp::max,
     convert::{TryFrom, TryInto},
-    fmt::Debug,
+    fmt::{Debug, Display, Formatter},
     marker::PhantomData,
     ops::{Add, AddAssign, Neg},
     rc::Rc,
@@ -41,6 +41,26 @@ where
     pub layer: OrderedLayer<K, OrderedLeaf<V, R>, O>,
     pub lower: Antichain<()>,
     pub upper: Antichain<()>,
+}
+
+impl<K, V, R, O> Display for OrdIndexedZSet<K, V, R, O>
+where
+    K: Ord + Clone + Display,
+    V: Ord + Clone + Display,
+    R: Eq + HasZero + AddAssignByRef + Clone + Display,
+    O: OrdOffset,
+    <O as TryFrom<usize>>::Error: Debug,
+    <O as TryInto<usize>>::Error: Debug,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        writeln!(
+            f,
+            "lower: {:?}, upper: {:?}\nlayer:\n{}",
+            self.lower,
+            self.upper,
+            textwrap::indent(&self.layer.to_string(), "    ")
+        )
+    }
 }
 
 impl<K, V, R, O> HasZero for OrdIndexedZSet<K, V, R, O>


### PR DESCRIPTION
This PR makes progress towards building circuits with more than one level of nesting.  These don't occur very often, but for example efficient implementation of some graph [algorithms](https://github.com/TimelyDataflow/differential-dataflow/tree/master/src/algorithms/graphs) like strongly connected components requires an extra level of nested circuits.

Specifically, we add a `Product` type that allows creating arbitrarily nested clocks.  We also generalize the `join_trace` operator to work for any nesting depth.

Future PRs will generalize `distinct` and `aggregate`.