### PR TITLE
Use blanket implementation for HasZero and HasOne.

### DIFF
--- a/src/algebra/mod.rs
+++ b/src/algebra/mod.rs
@@ -84,7 +84,8 @@ pub trait AddAssignByRef {
     fn add_assign_by_ref(&mut self, other: &Self);
 }
 
-/// Implementation of AddAssignByRef for types that already have `AddAssign<&T>`.
+/// Implementation of AddAssignByRef for types that already have
+/// `AddAssign<&T>`.
 impl<T> AddAssignByRef for T
 where
     for<'a> T: AddAssign<&'a T>,

--- a/src/algebra/mod.rs
+++ b/src/algebra/mod.rs
@@ -1,9 +1,7 @@
 //! This module contains declarations of abstract algebraic concepts:
 //! monoids, groups, rings, etc.
 
-use std::{
-    ops::{Add, AddAssign, Mul, Neg},
-};
+use std::ops::{Add, AddAssign, Mul, Neg};
 
 #[macro_use]
 mod checked_int;
@@ -207,6 +205,7 @@ where
 #[cfg(test)]
 mod integer_ring_tests {
     use super::*;
+    use num::bigint::BigInt;
 
     #[test]
     fn fixed_integer_tests() {
@@ -216,6 +215,17 @@ mod integer_ring_tests {
         assert_eq!(2, two);
         assert_eq!(-2, two.neg_by_ref());
         assert_eq!(-4, two.mul_by_ref(&two.neg_by_ref()));
+    }
+
+    #[test]
+    fn fixed_big_integer_tests() {
+        let two = BigInt::one().add_by_ref(&BigInt::one());
+        assert_eq!(BigInt::one() + BigInt::one(), two);
+        assert_eq!((BigInt::one() + BigInt::one()).neg(), two.neg_by_ref());
+        assert_eq!(
+            (BigInt::one() + BigInt::one()).neg() * 2,
+            two.mul_by_ref(&two.neg_by_ref())
+        );
     }
 
     #[test]

--- a/src/algebra/mod.rs
+++ b/src/algebra/mod.rs
@@ -2,9 +2,7 @@
 //! monoids, groups, rings, etc.
 
 use std::{
-    num::Wrapping,
     ops::{Add, AddAssign, Mul, Neg},
-    rc::Rc,
 };
 
 #[macro_use]
@@ -16,7 +14,7 @@ pub use zset::{IndexedZSet, ZSet};
 
 /// A trait for types that have a zero value.
 ///
-/// This is simlar to the standard Zero trait, but that
+/// This is similar to the standard Zero trait, but that
 /// trait depends on Add and HasZero doesn't.
 pub trait HasZero {
     fn is_zero(&self) -> bool;
@@ -24,54 +22,15 @@ pub trait HasZero {
 }
 
 /// Implement `HasZero` for types that already implement `Zero`.
-macro_rules! impl_has_zero {
-    ($type:ty) => {
-        impl $crate::algebra::HasZero for $type {
-            fn is_zero(&self) -> bool {
-                <Self as num::traits::Zero>::is_zero(self)
-            }
-            fn zero() -> Self {
-                <Self as num::traits::Zero>::zero()
-            }
-        }
-    };
-}
-
-impl_has_zero!(u8);
-impl_has_zero!(u16);
-impl_has_zero!(u32);
-impl_has_zero!(u64);
-impl_has_zero!(u128);
-impl_has_zero!(usize);
-
-impl_has_zero!(i8);
-impl_has_zero!(i16);
-impl_has_zero!(i32);
-impl_has_zero!(i64);
-impl_has_zero!(isize);
-
-// TODO: Implement for `std::num::Saturating` once stable
-impl<T> HasZero for Wrapping<T>
+impl<T> HasZero for T
 where
-    T: HasZero,
+    T: num::traits::Zero,
 {
     fn is_zero(&self) -> bool {
-        self.0.is_zero()
+        <Self as num::traits::Zero>::is_zero(self)
     }
     fn zero() -> Self {
-        Self(T::zero())
-    }
-}
-
-impl<T> HasZero for Rc<T>
-where
-    T: HasZero,
-{
-    fn is_zero(&self) -> bool {
-        T::is_zero(self.as_ref())
-    }
-    fn zero() -> Self {
-        Rc::new(T::zero())
+        <Self as num::traits::Zero>::zero()
     }
 }
 
@@ -83,35 +42,12 @@ pub trait HasOne {
 }
 
 /// Implement `HasOne` for types that already implement `One`.
-macro_rules! impl_has_one {
-    ($type:ty) => {
-        impl $crate::algebra::HasOne for $type {
-            fn one() -> Self {
-                <Self as num::traits::One>::one()
-            }
-        }
-    };
-}
-
-impl_has_one!(u8);
-impl_has_one!(u16);
-impl_has_one!(u32);
-impl_has_one!(u64);
-impl_has_one!(u128);
-impl_has_one!(usize);
-
-impl_has_one!(i8);
-impl_has_one!(i16);
-impl_has_one!(i32);
-impl_has_one!(i64);
-impl_has_one!(isize);
-
-impl<T> HasOne for Rc<T>
+impl<T> HasOne for T
 where
-    T: HasOne,
+    T: num::traits::One,
 {
     fn one() -> Self {
-        Rc::new(<T as HasOne>::one())
+        <Self as num::traits::One>::one()
     }
 }
 
@@ -145,12 +81,12 @@ where
     }
 }
 
-/// Like the AddAsssign trait, but with arguments by reference
+/// Like the AddAssign trait, but with arguments by reference
 pub trait AddAssignByRef {
     fn add_assign_by_ref(&mut self, other: &Self);
 }
 
-/// Implemenation of AddAssignByRef for types that already have `AddAssign<&T>`.
+/// Implementation of AddAssignByRef for types that already have `AddAssign<&T>`.
 impl<T> AddAssignByRef for T
 where
     for<'a> T: AddAssign<&'a T>,

--- a/src/trace/layers/mod.rs
+++ b/src/trace/layers/mod.rs
@@ -4,8 +4,6 @@
 //! elements in the next layer. Similarly, ranges of elements in the layer
 //! itself may correspond to single elements in the layer above.
 
-use crate::algebra::HasZero;
-
 pub mod ordered;
 pub mod ordered_leaf;
 // pub mod hashed;
@@ -62,15 +60,6 @@ pub trait Trie: Sized {
 }
 
 pub struct TrieSlice<'a, T: Trie>(&'a T, T::Cursor);
-
-impl<T: Trie> HasZero for T {
-    fn is_zero(&self) -> bool {
-        self.keys() == 0
-    }
-    fn zero() -> Self {
-        <Self as Trie>::TupleBuilder::new().done()
-    }
-}
 
 /// A type used to assemble collections.
 pub trait Builder {


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

Note: I don't expect this to be landed (or reviewed for that matter), just exploring the code.

I was browsing the code and started in this module. Noticed that later trait implementations in the module (`AddByRef`, `NegByRef`) were already using blanket implementations, so out of interest, updated `HasZero` and `HasOne` to do so, rather than explicitly doing so for a limited set of integer types (ie. wasn't implemented for `BigInt` or `BigUInt` I don't think? Whereas with the blanket implementation it is).

The one issue was that there was already an explicit implementation of `HasZero` for the `Trie` trait which the compiler detects as a conflict (since `Trie` may be updated in the future to implement `num::traits::zero`). I was going to move that to be a default implementation of the `Trie` trait itself, with something like:

```diff
diff --git a/src/trace/layers/mod.rs b/src/trace/layers/mod.rs
index 92e97c5..04420aa 100644
--- a/src/trace/layers/mod.rs
+++ b/src/trace/layers/mod.rs
@@ -57,6 +57,13 @@ pub trait Trie: Sized {
         merger.push_merge((self, self.cursor()), (other, other.cursor()));
         merger.done()
     }
+
+    fn is_zero(&self) -> bool {
+        self.is_empty()
+    }
+    fn zero() -> Self {
+        <Self as Trie>::TupleBuilder::new().done()
+    }
 }
 
 pub struct TrieSlice<'a, T: Trie>(&'a T, T::Cursor);
```

but as no tests failed when I simply deleted the implementation, I'm not sure if it's actually used, so just left it :)

Other than that, just a couple of typos.