### PR TITLE
Use generic associated types to simplify interaction with cursors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,27 +20,28 @@ jobs:
 
       matrix:
         # We test the following targets:
-        # - 64bit Linux stable
+        # - 64bit Linux nightly
         # - 64bit Linux beta
         # - 64bit Linux nightly
-        # - 64bit MacOS stable
-        # - 64bit Windows stable
-        # - 32bit Windows stable
+        # - 64bit MacOS nightly
+        # - 64bit Windows nightly
+        # - 32bit Windows nightly
         include:
-          - {
-              rust: stable,
-              target: x86_64-unknown-linux-gnu,
-              os: ubuntu-latest,
-            }
-          - { rust: stable, target: x86_64-apple-darwin, os: macos-latest }
-          - { rust: stable, target: x86_64-pc-windows-msvc, os: windows-latest }
-          - { rust: stable, target: i686-pc-windows-msvc, os: windows-latest }
-          - { rust: beta, target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
           - {
               rust: nightly,
               target: x86_64-unknown-linux-gnu,
               os: ubuntu-latest,
             }
+          - { rust: nightly, target: x86_64-apple-darwin, os: macos-latest }
+          - { rust: nightly, target: x86_64-pc-windows-msvc, os: windows-latest }
+          - { rust: nightly, target: i686-pc-windows-msvc, os: windows-latest }
+            # TODO: uncomment when we're back to stable Rust.
+            #- { rust: beta, target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
+            #- {
+            #  rust: nightly,
+            #  target: x86_64-unknown-linux-gnu,
+            #  os: ubuntu-latest,
+            #}
 
     steps:
       - name: Checkout
@@ -239,7 +240,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly
           default: true
 
       - name: Restore cache

--- a/src/algebra/zset/mod.rs
+++ b/src/algebra/zset/mod.rs
@@ -42,13 +42,12 @@ where
         let mut builder = Self::Builder::with_capacity((), self.len());
         let mut cursor = self.cursor();
 
-        while cursor.key_valid(self) {
-            let key = cursor.key(self);
-            let w = cursor.weight(self);
+        while cursor.key_valid() {
+            let w = cursor.weight();
             if w.ge0() {
-                builder.push((key.clone(), (), HasOne::one()));
+                builder.push((cursor.key().clone(), (), HasOne::one()));
             }
-            cursor.step_key(self);
+            cursor.step_key();
         }
 
         builder.done()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(generic_associated_types)]
+
 mod num_entries;
 mod ref_pair;
 mod shared_ref;

--- a/src/monitor/mod.rs
+++ b/src/monitor/mod.rs
@@ -20,6 +20,12 @@ use circuit_graph::{CircuitGraph, Node, NodeKind, Region, RegionId};
 pub mod visual_graph;
 use visual_graph::Graph as VisGraph;
 
+/// Callback function type signature for reporting an invalid `CircuitEvent`.
+type CircuitErrorHandler = dyn Fn(&CircuitEvent, &TraceError);
+
+/// Callback function type signature for reporting an invalid `SchedulerEvent`.
+type SchedulerErrorHandler = dyn Fn(&SchedulerEvent, &TraceError);
+
 /// State of a circuit automaton (see
 /// [`SchedulerEvent`](`super::SchedulerEvent`) documentation).
 enum CircuitState {
@@ -174,11 +180,9 @@ pub struct TraceMonitorInternal {
     /// no further `SchedulerEvent`'s are allowed.
     state: Vec<CircuitState>,
     /// Callback to invoke on each invalid `CircuitEvent`.
-    #[allow(clippy::type_complexity)]
-    circuit_error_handler: Box<dyn Fn(&CircuitEvent, &TraceError)>,
+    circuit_error_handler: Box<CircuitErrorHandler>,
     /// Callback to invoke on each invalid `SchedulerEvent`.
-    #[allow(clippy::type_complexity)]
-    scheduler_error_handler: Box<dyn Fn(&SchedulerEvent, &TraceError)>,
+    scheduler_error_handler: Box<SchedulerErrorHandler>,
 }
 
 impl TraceMonitorInternal {

--- a/src/operator/filter.rs
+++ b/src/operator/filter.rs
@@ -93,17 +93,16 @@ where
         // get merged with other batches soon, at which point the waste is gone.
         let mut builder = CO::Builder::with_capacity((), i.len());
 
-        while cursor.key_valid(i) {
-            let k = cursor.key(i);
-            if (self.filter)(k) {
-                while cursor.val_valid(i) {
-                    let val = cursor.val(i);
-                    let w = cursor.weight(i);
-                    builder.push((k.clone(), val.clone(), w.clone()));
-                    cursor.step_val(i);
+        while cursor.key_valid() {
+            if (self.filter)(cursor.key()) {
+                while cursor.val_valid() {
+                    let val = cursor.val().clone();
+                    let w = cursor.weight();
+                    builder.push((cursor.key().clone(), val, w.clone()));
+                    cursor.step_val();
                 }
             }
-            cursor.step_key(i);
+            cursor.step_key();
         }
         builder.done()
     }

--- a/src/operator/filter_map.rs
+++ b/src/operator/filter_map.rs
@@ -108,17 +108,17 @@ where
     fn eval(&mut self, i: &CI) -> CO {
         let mut cursor = i.cursor();
         let mut batch = Vec::with_capacity(i.len());
-        while cursor.key_valid(i) {
-            let k = cursor.key(i);
+        while cursor.key_valid() {
+            let k = cursor.key();
             if let Some(k2) = (self.map_borrowed)(k) {
-                while cursor.val_valid(i) {
-                    let v = cursor.val(i);
-                    let w = cursor.weight(i);
+                while cursor.val_valid() {
+                    let w = cursor.weight();
+                    let v = cursor.val();
                     batch.push(((k2.clone(), v.clone()), w.clone()));
-                    cursor.step_val(i);
+                    cursor.step_val();
                 }
             }
-            cursor.step_key(i);
+            cursor.step_key();
         }
 
         CO::from_tuples((), batch)

--- a/src/operator/index.rs
+++ b/src/operator/index.rs
@@ -98,12 +98,12 @@ where
         let mut builder = <CO as Batch>::Builder::with_capacity((), i.len());
 
         let mut cursor = i.cursor();
-        while cursor.key_valid(i) {
-            let (k, v) = cursor.key(i);
+        while cursor.key_valid() {
+            let (k, v) = cursor.key().clone();
             // TODO: pass key (and value?) by reference
-            let w = cursor.weight(i);
-            builder.push((k.clone(), v.clone(), w.clone()));
-            cursor.step_key(i);
+            let w = cursor.weight();
+            builder.push((k, v, w));
+            cursor.step_key();
         }
         builder.done()
     }

--- a/src/operator/map.rs
+++ b/src/operator/map.rs
@@ -121,15 +121,15 @@ where
         let mut batch = Vec::with_capacity(i.len());
 
         let mut cursor = i.cursor();
-        while cursor.key_valid(i) {
-            let k = cursor.key(i);
-            while cursor.val_valid(i) {
-                let v = cursor.val(i);
-                let w = cursor.weight(i);
+        while cursor.key_valid() {
+            while cursor.val_valid() {
+                let w = cursor.weight();
+                let v = cursor.val();
+                let k = cursor.key();
                 batch.push((((self.map_borrowed)(k), v.clone()), w.clone()));
-                cursor.step_val(i);
+                cursor.step_val();
             }
-            cursor.step_key(i);
+            cursor.step_key();
         }
         CO::from_tuples((), batch)
     }
@@ -197,15 +197,15 @@ where
         let mut batch = Vec::with_capacity(i.len());
 
         let mut cursor = i.cursor();
-        while cursor.key_valid(i) {
-            let k = cursor.key(i);
-            while cursor.val_valid(i) {
-                let v = cursor.val(i);
-                let w = cursor.weight(i);
-                batch.push(((k.clone(), (self.map)(k, v)), w.clone()));
-                cursor.step_val(i);
+        while cursor.key_valid() {
+            let k = cursor.key().clone();
+            while cursor.val_valid() {
+                let w = cursor.weight().clone();
+                let v = cursor.val();
+                batch.push(((k.clone(), (self.map)(&k, v)), w));
+                cursor.step_val();
             }
-            cursor.step_key(i);
+            cursor.step_key();
         }
         CO::from_tuples((), batch)
     }

--- a/src/operator/trace.rs
+++ b/src/operator/trace.rs
@@ -40,15 +40,14 @@ where
 {
     let mut builder = BO::Builder::with_capacity(timestamp.clone(), batch.len());
     let mut cursor = batch.cursor();
-    while cursor.key_valid(batch) {
-        let key = cursor.key(batch);
-        while cursor.val_valid(batch) {
-            let val = cursor.val(batch);
-            let w = cursor.weight(batch);
-            builder.push((key.clone(), val.clone(), w.clone()));
-            cursor.step_val(batch);
+    while cursor.key_valid() {
+        while cursor.val_valid() {
+            let val = cursor.val().clone();
+            let w = cursor.weight();
+            builder.push((cursor.key().clone(), val, w.clone()));
+            cursor.step_val();
         }
-        cursor.step_key(batch);
+        cursor.step_key();
     }
     builder.done()
 }

--- a/src/trace/cursor/cursor_list.rs
+++ b/src/trace/cursor/cursor_list.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     algebra::{HasZero, MonoidValue},
-    trace::cursor::Cursor,
+    trace::{consolidation::consolidate_from, cursor::Cursor},
 };
 use std::marker::PhantomData;
 
@@ -12,20 +12,20 @@ use std::marker::PhantomData;
 /// the indices of cursors with the minimum key and minimum value. It performs
 /// no clever management of these sets otherwise.
 #[derive(Debug)]
-pub struct CursorList<K, V, T, R, C: Cursor<K, V, T, R>> {
-    _phantom: PhantomData<(K, V, T, R)>,
+pub struct CursorList<'s, K, V, T, R, C: Cursor<'s, K, V, T, R>> {
+    _phantom: PhantomData<(K, V, T, R, &'s ())>,
     cursors: Vec<C>,
     min_key: Vec<usize>,
     min_val: Vec<usize>,
 }
 
-impl<K, V, T, R, C: Cursor<K, V, T, R>> CursorList<K, V, T, R, C>
+impl<'s, K, V, T, R, C: Cursor<'s, K, V, T, R>> CursorList<'s, K, V, T, R, C>
 where
     K: Ord,
     V: Ord,
 {
     /// Creates a new cursor list from pre-existing cursors.
-    pub fn new(cursors: Vec<C>, storage: &[C::Storage]) -> Self {
+    pub fn new(cursors: Vec<C>) -> Self {
         let mut result = CursorList {
             _phantom: PhantomData,
             cursors,
@@ -33,7 +33,7 @@ where
             min_val: Vec::new(),
         };
 
-        result.minimize_keys(storage);
+        result.minimize_keys();
         result
     }
 
@@ -46,13 +46,13 @@ where
     //
     // Once finished, it invokes `minimize_vals()` to ensure the value cursor is
     // in a consistent state as well.
-    fn minimize_keys(&mut self, storage: &[C::Storage]) {
+    fn minimize_keys(&mut self) {
         self.min_key.clear();
 
         // Determine the index of the cursor with minimum key.
         let mut min_key_opt: Option<&K> = None;
         for (index, cursor) in self.cursors.iter().enumerate() {
-            let key = cursor.get_key(&storage[index]);
+            let key = cursor.get_key();
             if key.is_some() {
                 if min_key_opt.is_none() || key.lt(&min_key_opt) {
                     min_key_opt = key;
@@ -64,7 +64,7 @@ where
             }
         }
 
-        self.minimize_vals(storage);
+        self.minimize_vals();
     }
 
     // Initialize min_val with the indices of minimum key cursors with the minimum
@@ -74,13 +74,13 @@ where
     // the indices of cursors whose value equals the minimum valid value seen so
     // far. As it goes, if it observes an improved value it clears the current
     // list, updates the minimum value, and continues.
-    fn minimize_vals(&mut self, storage: &[C::Storage]) {
+    fn minimize_vals(&mut self) {
         self.min_val.clear();
 
         // Determine the index of the cursor with minimum value.
         let mut min_val: Option<&V> = None;
         for &index in self.min_key.iter() {
-            let val = self.cursors[index].get_val(&storage[index]);
+            let val = self.cursors[index].get_val();
             if val.is_some() {
                 if min_val.is_none() || val.lt(&min_val) {
                     min_val = val;
@@ -94,7 +94,8 @@ where
     }
 }
 
-impl<K, V, T, R, C: Cursor<K, V, T, R>> Cursor<K, V, T, R> for CursorList<K, V, T, R, C>
+impl<'s, K, V, T, R, C: Cursor<'s, K, V, T, R>> Cursor<'s, K, V, T, R>
+    for CursorList<'s, K, V, T, R, C>
 where
     K: Ord,
     V: Ord,
@@ -104,93 +105,108 @@ where
 
     // validation methods
     #[inline]
-    fn key_valid(&self, _storage: &Self::Storage) -> bool {
+    fn key_valid(&self) -> bool {
         !self.min_key.is_empty()
     }
     #[inline]
-    fn val_valid(&self, _storage: &Self::Storage) -> bool {
+    fn val_valid(&self) -> bool {
         !self.min_val.is_empty()
     }
 
     // accessors
     #[inline]
-    fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K {
-        debug_assert!(self.key_valid(storage));
-        debug_assert!(self.cursors[self.min_key[0]].key_valid(&storage[self.min_key[0]]));
-        self.cursors[self.min_key[0]].key(&storage[self.min_key[0]])
+    fn key(&self) -> &K {
+        debug_assert!(self.key_valid());
+        debug_assert!(self.cursors[self.min_key[0]].key_valid());
+        self.cursors[self.min_key[0]].key()
     }
     #[inline]
-    fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V {
-        debug_assert!(self.key_valid(storage));
-        debug_assert!(self.val_valid(storage));
-        debug_assert!(self.cursors[self.min_val[0]].val_valid(&storage[self.min_val[0]]));
-        self.cursors[self.min_val[0]].val(&storage[self.min_val[0]])
+    fn val(&self) -> &V {
+        debug_assert!(self.key_valid());
+        debug_assert!(self.val_valid());
+        debug_assert!(self.cursors[self.min_val[0]].val_valid());
+        self.cursors[self.min_val[0]].val()
     }
     #[inline]
-    fn map_times<L: FnMut(&T, &R)>(&mut self, storage: &Self::Storage, mut logic: L) {
+    fn map_times<L: FnMut(&T, &R)>(&mut self, mut logic: L) {
         for &index in self.min_val.iter() {
-            self.cursors[index].map_times(&storage[index], |t, d| logic(t, d));
+            self.cursors[index].map_times(|t, d| logic(t, d));
         }
     }
 
     #[inline]
-    fn weight(&mut self, storage: &Self::Storage) -> R
+    fn weight(&mut self) -> R
     where
         T: PartialEq<()>,
     {
-        debug_assert!(self.key_valid(storage));
-        debug_assert!(self.val_valid(storage));
-        debug_assert!(self.cursors[self.min_val[0]].val_valid(&storage[self.min_val[0]]));
+        debug_assert!(self.key_valid());
+        debug_assert!(self.val_valid());
+        debug_assert!(self.cursors[self.min_val[0]].val_valid());
         let mut res: R = HasZero::zero();
-        self.map_times(storage, |_, w| res.add_assign_by_ref(w));
+        self.map_times(|_, w| res.add_assign_by_ref(w));
         res
     }
 
     // key methods
     #[inline]
-    fn step_key(&mut self, storage: &Self::Storage) {
+    fn step_key(&mut self) {
         for &index in self.min_key.iter() {
-            self.cursors[index].step_key(&storage[index]);
+            self.cursors[index].step_key();
         }
-        self.minimize_keys(storage);
+        self.minimize_keys();
     }
     #[inline]
-    fn seek_key(&mut self, storage: &Self::Storage, key: &K) {
-        for (index, cursor) in self.cursors.iter_mut().enumerate() {
-            cursor.seek_key(&storage[index], key);
+    fn seek_key(&mut self, key: &K) {
+        for cursor in self.cursors.iter_mut() {
+            cursor.seek_key(key);
         }
-        self.minimize_keys(storage);
+        self.minimize_keys();
     }
 
     // value methods
     #[inline]
-    fn step_val(&mut self, storage: &Self::Storage) {
+    fn step_val(&mut self) {
         for &index in self.min_val.iter() {
-            self.cursors[index].step_val(&storage[index]);
+            self.cursors[index].step_val();
         }
-        self.minimize_vals(storage);
+        self.minimize_vals();
     }
     #[inline]
-    fn seek_val(&mut self, storage: &Self::Storage, val: &V) {
+    fn seek_val(&mut self, val: &V) {
         for &index in self.min_key.iter() {
-            self.cursors[index].seek_val(&storage[index], val);
+            self.cursors[index].seek_val(val);
         }
-        self.minimize_vals(storage);
+        self.minimize_vals();
+    }
+
+    fn values<'a>(&mut self, vals: &mut Vec<(&'a V, R)>)
+    where
+        's: 'a,
+    {
+        let offset = vals.len();
+
+        for &index in self.min_val.iter() {
+            self.cursors[index].values(vals);
+        }
+
+        if self.min_val.len() > 1 {
+            consolidate_from(vals, offset);
+        }
     }
 
     // rewinding methods
     #[inline]
-    fn rewind_keys(&mut self, storage: &Self::Storage) {
-        for (index, cursor) in self.cursors.iter_mut().enumerate() {
-            cursor.rewind_keys(&storage[index]);
+    fn rewind_keys(&mut self) {
+        for cursor in self.cursors.iter_mut() {
+            cursor.rewind_keys();
         }
-        self.minimize_keys(storage);
+        self.minimize_keys();
     }
     #[inline]
-    fn rewind_vals(&mut self, storage: &Self::Storage) {
+    fn rewind_vals(&mut self) {
         for &index in self.min_key.iter() {
-            self.cursors[index].rewind_vals(&storage[index]);
+            self.cursors[index].rewind_vals();
         }
-        self.minimize_vals(storage);
+        self.minimize_vals();
     }
 }

--- a/src/trace/cursor/mod.rs
+++ b/src/trace/cursor/mod.rs
@@ -18,37 +18,37 @@ pub mod cursor_pair;
 pub use self::cursor_list::CursorList;
 
 /// A cursor for navigating ordered `(key, val, time, diff)` tuples.
-pub trait Cursor<K, V, T, R> {
+pub trait Cursor<'s, K, V, T, R> {
     /// Type the cursor addresses data in.
     type Storage;
 
     /// Indicates if the current key is valid.
     ///
     /// A value of `false` indicates that the cursor has exhausted all keys.
-    fn key_valid(&self, storage: &Self::Storage) -> bool;
+    fn key_valid(&self) -> bool;
     /// Indicates if the current value is valid.
     ///
     /// A value of `false` indicates that the cursor has exhausted all values
     /// for this key.
-    fn val_valid(&self, storage: &Self::Storage) -> bool;
+    fn val_valid(&self) -> bool;
 
     /// A reference to the current key. Panics if invalid.
-    fn key<'a>(&self, storage: &'a Self::Storage) -> &'a K;
+    fn key(&self) -> &K;
     /// A reference to the current value. Panics if invalid.
-    fn val<'a>(&self, storage: &'a Self::Storage) -> &'a V;
+    fn val(&self) -> &V;
 
     /// Returns a reference to the current key, if valid.
-    fn get_key<'a>(&self, storage: &'a Self::Storage) -> Option<&'a K> {
-        if self.key_valid(storage) {
-            Some(self.key(storage))
+    fn get_key(&self) -> Option<&K> {
+        if self.key_valid() {
+            Some(self.key())
         } else {
             None
         }
     }
     /// Returns a reference to the current value, if valid.
-    fn get_val<'a>(&self, storage: &'a Self::Storage) -> Option<&'a V> {
-        if self.val_valid(storage) {
-            Some(self.val(storage))
+    fn get_val(&self) -> Option<&V> {
+        if self.val_valid() {
+            Some(self.val())
         } else {
             None
         }
@@ -56,7 +56,7 @@ pub trait Cursor<K, V, T, R> {
 
     /// Applies `logic` to each pair of time and difference. Intended for
     /// mutation of the closure's scope.
-    fn map_times<L: FnMut(&T, &R)>(&mut self, storage: &Self::Storage, logic: L);
+    fn map_times<L: FnMut(&T, &R)>(&mut self, logic: L);
 
     /// Returns the weight associated with the current key/value pair.
     ///
@@ -68,66 +68,69 @@ pub trait Cursor<K, V, T, R> {
     /// # Panics
     ///
     /// Panics if not `self.key_valid() && self.val_valid()`.
-    fn weight(&mut self, storage: &Self::Storage) -> R
+    fn weight(&mut self) -> R
     where
         T: PartialEq<()>;
 
     /// Apply a function to all values associated with the current key.
-    fn map_values<L: FnMut(&V, &R)>(&mut self, storage: &Self::Storage, mut logic: L)
+    fn map_values<L: FnMut(&V, &R)>(&mut self, mut logic: L)
     where
         T: PartialEq<()>,
     {
-        while self.val_valid(storage) {
-            let weight = self.weight(storage);
-            let val = self.val(storage);
+        while self.val_valid() {
+            let weight = self.weight();
+            let val = self.val();
             logic(val, &weight);
-            self.step_val(storage);
+            self.step_val();
         }
     }
 
     /// Advances the cursor to the next key.
-    fn step_key(&mut self, storage: &Self::Storage);
+    fn step_key(&mut self);
     /// Advances the cursor to the specified key.
-    fn seek_key(&mut self, storage: &Self::Storage, key: &K);
+    fn seek_key(&mut self, key: &K);
 
     /// Advances the cursor to the next value.
-    fn step_val(&mut self, storage: &Self::Storage);
+    fn step_val(&mut self);
     /// Advances the cursor to the specified value.
-    fn seek_val(&mut self, storage: &Self::Storage, val: &V);
+    fn seek_val(&mut self, val: &V);
+
+    /// Push sorted list of values for the current key
+    /// to `vals`.
+    fn values<'a>(&mut self, vals: &mut Vec<(&'a V, R)>)
+    where
+        's: 'a;
 
     /// Rewinds the cursor to the first key.
-    fn rewind_keys(&mut self, storage: &Self::Storage);
+    fn rewind_keys(&mut self);
     /// Rewinds the cursor to the first value for current key.
-    fn rewind_vals(&mut self, storage: &Self::Storage);
+    fn rewind_vals(&mut self);
 }
 
 /// Debugging and testing utilities for Cursor.
-pub trait CursorDebug<K: Clone, V: Clone, T: Clone, R: Clone>: Cursor<K, V, T, R> {
+pub trait CursorDebug<'s, K: Clone, V: Clone, T: Clone, R: Clone>: Cursor<'s, K, V, T, R> {
     /// Rewinds the cursor and outputs its contents to a Vec
     #[allow(clippy::type_complexity)]
-    fn to_vec(&mut self, storage: &Self::Storage) -> Vec<((K, V), Vec<(T, R)>)> {
+    fn to_vec(&mut self) -> Vec<((K, V), Vec<(T, R)>)> {
         let mut out = Vec::new();
-        self.rewind_keys(storage);
-        self.rewind_vals(storage);
-        while self.key_valid(storage) {
-            while self.val_valid(storage) {
+        self.rewind_keys();
+        self.rewind_vals();
+        while self.key_valid() {
+            while self.val_valid() {
                 let mut kv_out = Vec::new();
-                self.map_times(storage, |ts, r| {
+                self.map_times(|ts, r| {
                     kv_out.push((ts.clone(), r.clone()));
                 });
-                out.push((
-                    (self.key(storage).clone(), self.val(storage).clone()),
-                    kv_out,
-                ));
-                self.step_val(storage);
+                out.push(((self.key().clone(), self.val().clone()), kv_out));
+                self.step_val();
             }
-            self.step_key(storage);
+            self.step_key();
         }
         out
     }
 }
 
-impl<C, K: Clone, V: Clone, T: Clone, R: Clone> CursorDebug<K, V, T, R> for C where
-    C: Cursor<K, V, T, R>
+impl<'s, C, K: Clone, V: Clone, T: Clone, R: Clone> CursorDebug<'s, K, V, T, R> for C where
+    C: Cursor<'s, K, V, T, R>
 {
 }

--- a/src/trace/layers/mod.rs
+++ b/src/trace/layers/mod.rs
@@ -22,7 +22,9 @@ pub trait Trie: Sized {
     /// The type of item from which the type is constructed.
     type Item;
     /// The type of cursor used to navigate the type.
-    type Cursor: Cursor<Self>;
+    type Cursor<'s>: Cursor<'s>
+    where
+        Self: 's;
     /// The type used to merge instances of the type together.
     type MergeBuilder: MergeBuilder<Trie = Self>;
     /// The type used to assemble instances of the type from its `Item`s.
@@ -40,12 +42,12 @@ pub trait Trie: Sized {
     /// The total number of tuples in the collection.
     fn tuples(&self) -> usize;
     /// Returns a cursor capable of navigating the collection.
-    fn cursor(&self) -> Self::Cursor {
+    fn cursor(&self) -> Self::Cursor<'_> {
         self.cursor_from(0, self.keys())
     }
     /// Returns a cursor over a range of data, commonly used by others to
     /// restrict navigation to sub-collections.
-    fn cursor_from(&self, lower: usize, upper: usize) -> Self::Cursor;
+    fn cursor_from(&self, lower: usize, upper: usize) -> Self::Cursor<'_>;
 
     /// Merges two collections into a third.
     ///
@@ -56,12 +58,10 @@ pub trait Trie: Sized {
     fn merge(&self, other: &Self) -> Self {
         let mut merger = Self::MergeBuilder::with_capacity(self, other);
         // println!("{:?} and {:?}", self.keys(), other.keys());
-        merger.push_merge((self, self.cursor()), (other, other.cursor()));
+        merger.push_merge(self.cursor(), other.cursor());
         merger.done()
     }
 }
-
-pub struct TrieSlice<'a, T: Trie>(&'a T, T::Cursor);
 
 impl<T: Trie> HasZero for T {
     fn is_zero(&self) -> bool {
@@ -96,10 +96,10 @@ pub trait MergeBuilder: Builder {
     /// Copies sub-collections of `other` into this collection.
     fn copy_range(&mut self, other: &Self::Trie, lower: usize, upper: usize);
     /// Merges two sub-collections into one sub-collection.
-    fn push_merge(
-        &mut self,
-        other1: (&Self::Trie, <Self::Trie as Trie>::Cursor),
-        other2: (&Self::Trie, <Self::Trie as Trie>::Cursor),
+    fn push_merge<'a>(
+        &'a mut self,
+        other1: <Self::Trie as Trie>::Cursor<'a>,
+        other2: <Self::Trie as Trie>::Cursor<'a>,
     ) -> usize;
 }
 
@@ -121,29 +121,28 @@ pub trait TupleBuilder: Builder {
 /// The precise meaning of this navigation is not defined by the trait. It is
 /// likely that having navigated around, the cursor will be different in some
 /// other way, but the `Cursor` trait does not explain how this is so.
-pub trait Cursor<Storage> {
+pub trait Cursor<'s> {
     /// The type revealed by the cursor.
     type Key;
     type ValueStorage: Trie;
 
     fn keys(&self) -> usize;
     /// Reveals the current key.
-    fn key<'a>(&self, storage: &'a Storage) -> &'a Self::Key;
-    fn values<'a>(
-        &self,
-        storage: &'a Storage,
-    ) -> (&'a Self::ValueStorage, <Self::ValueStorage as Trie>::Cursor);
+    fn key(&self) -> &'s Self::Key;
+
+    fn values(&self) -> <Self::ValueStorage as Trie>::Cursor<'s>;
+
     /// Advances the cursor by one element.
-    fn step(&mut self, storage: &Storage);
+    fn step(&mut self);
     /// Advances the cursor until the location where `key` would be expected.
-    fn seek(&mut self, storage: &Storage, key: &Self::Key);
+    fn seek(&mut self, key: &Self::Key);
     /// Returns `true` if the cursor points at valid data. Returns `false` if
     /// the cursor is exhausted.
-    fn valid(&self, storage: &Storage) -> bool;
+    fn valid(&self) -> bool;
     /// Rewinds the cursor to its initial state.
-    fn rewind(&mut self, storage: &Storage);
+    fn rewind(&mut self);
     /// Repositions the cursor to a different range of values.
-    fn reposition(&mut self, storage: &Storage, lower: usize, upper: usize);
+    fn reposition(&mut self, lower: usize, upper: usize);
 }
 
 /// Reports the number of elements satisfing the predicate.
@@ -188,7 +187,7 @@ pub fn advance<T, F: Fn(&T) -> bool>(slice: &[T], function: F) -> usize {
 
 impl Trie for () {
     type Item = ();
-    type Cursor = ();
+    type Cursor<'s> = ();
     type MergeBuilder = ();
     type TupleBuilder = ();
 
@@ -198,7 +197,7 @@ impl Trie for () {
     fn tuples(&self) -> usize {
         0
     }
-    fn cursor_from(&self, _lower: usize, _upper: usize) -> Self::Cursor {}
+    fn cursor_from(&self, _lower: usize, _upper: usize) -> Self::Cursor<'_> {}
 }
 
 impl Builder for () {
@@ -216,8 +215,8 @@ impl MergeBuilder for () {
     fn copy_range(&mut self, _other: &Self::Trie, _lower: usize, _upper: usize) {}
     fn push_merge(
         &mut self,
-        _other1: (&Self::Trie, <Self::Trie as Trie>::Cursor),
-        _other2: (&Self::Trie, <Self::Trie as Trie>::Cursor),
+        _other1: <Self::Trie as Trie>::Cursor<'static>,
+        _other2: <Self::Trie as Trie>::Cursor<'static>,
     ) -> usize {
         0
     }
@@ -234,24 +233,22 @@ impl TupleBuilder for () {
     }
 }
 
-impl Cursor<()> for () {
+impl<'s> Cursor<'s> for () {
     type Key = ();
     type ValueStorage = ();
 
     fn keys(&self) -> usize {
         0
     }
-    fn key<'a>(&self, _storage: &'a ()) -> &'a Self::Key {
+    fn key(&self) -> &'s Self::Key {
         &()
     }
-    fn values<'a>(&self, _storage: &'a ()) -> (&'a (), ()) {
-        (&(), ())
-    }
-    fn step(&mut self, _storage: &()) {}
-    fn seek(&mut self, _storage: &(), _key: &Self::Key) {}
-    fn valid(&self, _storage: &()) -> bool {
+    fn values(&self) {}
+    fn step(&mut self) {}
+    fn seek(&mut self, _key: &Self::Key) {}
+    fn valid(&self) -> bool {
         false
     }
-    fn rewind(&mut self, _storage: &()) {}
-    fn reposition(&mut self, _storage: &(), _lower: usize, _upper: usize) {}
+    fn rewind(&mut self) {}
+    fn reposition(&mut self, _lower: usize, _upper: usize) {}
 }


### PR DESCRIPTION
Use generic associated types for better ergonomics when working with the cursor API

The good parts:
 - Greatly simplifies&hardens the cursor API (no more storage arguments are needed)
 - Gets rid of some unsafe code (in ListCursor)
 - Helps with eventual persistence (can store rocksdb iterators in the Cursor now because they have a lifetime, and Cursor now has one too...)

The bad part:
 - Needs nightly rust
 - But, GATs will *hopefully* be stabilized soon: https://github.com/rust-lang/rust/pull/96709
 - Discussion in favor/against stabilization is still ongoing (so feel free to show your support in favor of the feature)