### PR TITLE
Give Stream::index() a concrete return type.

### DIFF
--- a/benches/path.rs
+++ b/benches/path.rs
@@ -4,10 +4,7 @@ use dbsp::{
     operator::{DelayedFeedback, Generator},
     profile::CPUProfiler,
     time::NestedTimestamp32,
-    trace::{
-        ord::{OrdIndexedZSet, OrdZSet},
-        Batch,
-    },
+    trace::{ord::OrdZSet, Batch},
 };
 use std::{collections::HashMap, fmt::Write, fs};
 
@@ -95,9 +92,8 @@ fn main() {
                 let paths_inverted: Stream<_, OrdZSet<(u32, u32), i32>> =
                     paths_delayed.stream().map_keys(|&(x, y)| (y, x));
 
-                let paths_inverted_indexed: Stream<_, OrdIndexedZSet<u32, u32, i32>> =
-                    paths_inverted.index();
-                let edges_indexed: Stream<_, OrdIndexedZSet<u32, u32, i32>> = edges.index();
+                let paths_inverted_indexed = paths_inverted.index();
+                let edges_indexed = edges.index();
 
                 let paths = edges
                     .plus(

--- a/src/operator/aggregate.rs
+++ b/src/operator/aggregate.rs
@@ -293,9 +293,9 @@ mod test {
     use std::{cell::RefCell, rc::Rc};
 
     use crate::{
-        circuit::{Root, Stream},
+        circuit::Root,
         operator::{Apply2, GeneratorNested},
-        trace::ord::{OrdIndexedZSet, OrdZSet},
+        trace::ord::OrdZSet,
         zset,
     };
 
@@ -320,7 +320,7 @@ mod test {
                     let counter = Rc::new(RefCell::new(0));
                     let counter_clone = counter.clone();
 
-                    let input: Stream<_, OrdIndexedZSet<usize, usize, isize>> = child
+                    let input = child
                         .add_source(GeneratorNested::new(Box::new(move || {
                             *counter_clone.borrow_mut() = 0;
                             let mut deltas = inputs.next().unwrap_or_default().into_iter();

--- a/src/operator/index.rs
+++ b/src/operator/index.rs
@@ -1,13 +1,12 @@
-//! Index operator.
+//! Operators to convert Z-sets into indexed Z-sets.
 
 use crate::{
-    algebra::{IndexedZSet, ZRingValue, ZSet},
     circuit::{
         operator_traits::{Operator, UnaryOperator},
         Circuit, NodeId, Scope, Stream,
     },
     circuit_cache_key,
-    trace::{cursor::Cursor, ord::OrdZSet, Batch, Builder},
+    trace::{cursor::Cursor, ord::OrdIndexedZSet, Batch, BatchReader, Builder},
 };
 use std::{borrow::Cow, marker::PhantomData};
 
@@ -15,14 +14,30 @@ circuit_cache_key!(IndexId<C, D>(NodeId => Stream<C, D>));
 
 impl<P, CI> Stream<Circuit<P>, CI>
 where
-    CI: Clone,
+    CI: Clone + 'static,
     P: Clone + 'static,
 {
-    /// Apply [`Index`] operator to `self`.
-    pub fn index<CO>(&self) -> Stream<Circuit<P>, CO>
+    /// Convert input batches to an indexed representation.
+    ///
+    /// Converts input batches whose key type is a `(key,value)` tuple into an
+    /// indexed Z-set using the first element of each tuple as a key and the
+    /// second element as the value. The indexed Z-set representation is
+    /// used as input to various join and aggregation operators.
+    pub fn index<K, V>(&self) -> Stream<Circuit<P>, OrdIndexedZSet<K, V, CI::R>>
     where
-        CI: ZSet<Key = (CO::Key, CO::Val), Time = (), R = CO::R> + 'static,
-        CO: IndexedZSet<Time = ()>,
+        K: Ord + Clone + 'static,
+        V: Ord + Clone + 'static,
+        CI: BatchReader<Key = (K, V), Val = (), Time = ()>,
+    {
+        self.index_generic()
+    }
+
+    /// Like [`index`](`Self::index`), but can return any indexed Z-set type,
+    /// not just `OrdIndexedZSet`.
+    pub fn index_generic<CO>(&self) -> Stream<Circuit<P>, CO>
+    where
+        CI: BatchReader<Key = (CO::Key, CO::Val), Val = (), Time = (), R = CO::R> + 'static,
+        CO: Batch<Time = ()> + Clone + 'static,
         CO::Key: Clone,
         CO::Val: Clone,
     {
@@ -33,17 +48,40 @@ where
             .clone()
     }
 
-    pub fn index_with<CO, F>(&self, f: F) -> Stream<Circuit<P>, CO>
+    /// Convert input batches to an indexed representation with the help of a
+    /// user-provided function that maps a key in the input Z-set into an
+    /// output `(key, value)` pair.
+    ///
+    /// Converts input batches into an indexed Z-set by applying `index_func` to
+    /// each key in the input batch and using the first element of the
+    /// resulting tuple as a key and the second element as the value.  The
+    /// indexed Z-set representation is used as input to join and
+    /// aggregation operators.
+    pub fn index_with<K, V, F>(
+        &self,
+        index_func: F,
+    ) -> Stream<Circuit<P>, OrdIndexedZSet<K, V, CI::R>>
     where
-        CI: ZSet<Time = (), R = CO::R> + 'static,
-        CO: IndexedZSet<Time = ()>,
+        CI: BatchReader<Time = (), Val = ()> + 'static,
+        F: Fn(&CI::Key) -> (K, V) + Clone + 'static,
+        K: Ord + Clone + 'static,
+        V: Ord + Clone + 'static,
+    {
+        self.index_with_generic(index_func)
+    }
+
+    /// Like [`index_with`](`Self::index_with`), but can return any indexed
+    /// Z-set type, not just `OrdIndexedZSet`.
+    pub fn index_with_generic<CO, F>(&self, index_func: F) -> Stream<Circuit<P>, CO>
+    where
+        CI: BatchReader<Time = (), Val = ()> + 'static,
+        CO: Batch<Time = (), R = CI::R> + Clone + 'static,
         CO::Key: Clone + Ord,
         CO::Val: Clone + Ord,
-        CO::R: ZRingValue,
         F: Fn(&CI::Key) -> (CO::Key, CO::Val) + Clone + 'static,
     {
-        // TODO: implement UnorderedLeaf trie backed by an unsorted vector.
-        self.map_keys::<OrdZSet<_, _>, _>(f).index()
+        self.circuit()
+            .add_unary_operator(IndexWith::new(index_func), self)
     }
 }
 
@@ -55,9 +93,8 @@ where
 ///
 /// # Type arguments
 ///
-/// * `CI` - input collection type.
-/// * `CO` - output collection type, a finite map from keys to a Z-set of
-///   values.
+/// * `CI` - input batch type.
+/// * `CO` - output batch type.
 pub struct Index<CI, CO> {
     _type: PhantomData<(CI, CO)>,
 }
@@ -89,8 +126,8 @@ where
 
 impl<CI, CO> UnaryOperator<CI, CO> for Index<CI, CO>
 where
-    CO: IndexedZSet<Time = ()>,
-    CI: ZSet<Key = (CO::Key, CO::Val), Time = (), R = CO::R> + 'static,
+    CO: Batch<Time = ()> + Clone + 'static,
+    CI: BatchReader<Key = (CO::Key, CO::Val), Val = (), Time = (), R = CO::R> + 'static,
     CO::Key: Clone,
     CO::Val: Clone,
 {
@@ -114,6 +151,76 @@ where
     }
 }
 
+/// Operator that generates an indexed representation of a Z-set
+/// using a function that maps each key in the input Z-set into an output
+/// (key, value) pair.
+///
+/// The input of the operator is a Z-set where the value type is
+/// a key/value pair.  The output is an indexed representation of
+/// the Z-set.
+///
+/// # Type arguments
+///
+/// * `CI` - input batch type.
+/// * `CO` - output batch type.
+/// * `F` - function that maps each key in the input batch into an output (key,
+///   value) pair.
+pub struct IndexWith<CI, CO, F> {
+    index_func: F,
+    _type: PhantomData<(CI, CO)>,
+}
+
+impl<CI, CO, F> IndexWith<CI, CO, F> {
+    pub fn new(index_func: F) -> Self {
+        Self {
+            index_func,
+            _type: PhantomData,
+        }
+    }
+}
+
+impl<CI, CO, F> Operator for IndexWith<CI, CO, F>
+where
+    CI: 'static,
+    CO: 'static,
+    F: 'static,
+{
+    fn name(&self) -> Cow<'static, str> {
+        Cow::from("IndexWith")
+    }
+    fn fixedpoint(&self, _scope: Scope) -> bool {
+        true
+    }
+}
+
+impl<CI, CO, F> UnaryOperator<CI, CO> for IndexWith<CI, CO, F>
+where
+    CO: Batch<Time = ()> + Clone + 'static,
+    CI: BatchReader<Val = (), Time = (), R = CO::R> + 'static,
+    F: Fn(&CI::Key) -> (CO::Key, CO::Val) + 'static,
+    CO::Key: Clone,
+    CO::Val: Clone,
+{
+    fn eval(&mut self, i: &CI) -> CO {
+        let mut tuples = Vec::with_capacity(i.len());
+
+        let mut cursor = i.cursor();
+        while cursor.key_valid() {
+            let (k, v) = (self.index_func)(cursor.key());
+            // TODO: pass key (and value?) by reference
+            let w = cursor.weight();
+            tuples.push(((k, v), w));
+            cursor.step_key();
+        }
+
+        CO::from_tuples((), tuples)
+    }
+
+    fn eval_owned(&mut self, i: CI) -> CO {
+        // TODO: owned implementation.
+        self.eval(&i)
+    }
+}
 #[cfg(test)]
 mod test {
     use crate::{
@@ -121,15 +228,15 @@ mod test {
     };
 
     #[test]
-    fn index_sequence() {
+    fn index_test() {
         let root = Root::build(move |circuit| {
             let mut inputs = vec![
                 zset!{ (1, "a") => 1
-                     , (1, "a") => 2
                      , (1, "b") => 1
-                     , (1, "b") => -1
                      , (2, "a") => 1
                      , (2, "c") => 1
+                     , (1, "a") => 2
+                     , (1, "b") => -1
                 },
                 zset!{ (1, "d") => 1
                      , (1, "e") => 1
@@ -154,7 +261,7 @@ mod test {
     }
 
     #[test]
-    fn index_zset() {
+    fn index_with_test() {
         let root = Root::build(move |circuit| {
             let mut inputs = vec![
                 zset!{ (1, "a") => 1
@@ -175,7 +282,7 @@ mod test {
                 indexed_zset!{ 1 => {"a" => 3, "d" => 1, "e" => 1}, 2 => {"c" => 1}, 3 => {"a" => 2}},
             ].into_iter();
             circuit.add_source(Generator::new(move || inputs.next().unwrap() ))
-                   .index()
+                   .index_with(|(k, v)| (k.clone(), v.clone()))
                    .integrate()
                    .inspect(move |fm: &OrdIndexedZSet<_, _, _>| assert_eq!(fm, &outputs.next().unwrap()));
         })

--- a/src/operator/index.rs
+++ b/src/operator/index.rs
@@ -142,7 +142,7 @@ mod test {
                 indexed_zset!{ 1 => {"a" => 3, "d" => 1, "e" => 1}, 2 => {"c" => 1}, 3 => {"a" => 2}},
             ].into_iter();
             circuit.add_source(Generator::new(move || inputs.next().unwrap() ))
-                   .index::<OrdIndexedZSet<_, _, _>>()
+                   .index()
                    .integrate()
                    .inspect(move |fm: &OrdIndexedZSet<_, _, _>| assert_eq!(fm, &outputs.next().unwrap()));
         })
@@ -175,7 +175,7 @@ mod test {
                 indexed_zset!{ 1 => {"a" => 3, "d" => 1, "e" => 1}, 2 => {"c" => 1}, 3 => {"a" => 2}},
             ].into_iter();
             circuit.add_source(Generator::new(move || inputs.next().unwrap() ))
-                   .index::<OrdIndexedZSet<_, _, _>>()
+                   .index()
                    .integrate()
                    .inspect(move |fm: &OrdIndexedZSet<_, _, _>| assert_eq!(fm, &outputs.next().unwrap()));
         })

--- a/src/operator/join.rs
+++ b/src/operator/join.rs
@@ -647,8 +647,8 @@ mod test {
                     .stream()
                     .map_keys(|&(x, y)| (y, x));
 
-                let paths_inverted_indexed: Stream<_, OrdIndexedZSet<usize, usize, isize>> = paths_inverted.index();
-                let edges_indexed: Stream<_, OrdIndexedZSet<usize, usize, isize>> = edges.index();
+                let paths_inverted_indexed = paths_inverted.index();
+                let edges_indexed = edges.index();
 
                 let paths = edges.plus(&paths_inverted_indexed.join_trace::<NestedTimestamp32, _, _, _>(&edges_indexed, |_via, from, to| (*from, *to)))
                     .distinct_trace();
@@ -710,10 +710,9 @@ mod test {
 
                 computed_labels.connect(
                     &result
-                        .index_with::<OrdIndexedZSet<_, _, _>, _>(|label| (label.0, label.1))
+                        .index_with(|label| (label.0, label.1))
                         .join_trace::<TS, _, _, _>(
-                            &edges
-                                .index_with::<OrdIndexedZSet<_, _, _>, _>(|edge| (edge.0, edge.1)),
+                            &edges.index_with(|edge| (edge.0, edge.1)),
                             |_from, label, to| Label(*to, *label),
                         ),
                 );

--- a/src/operator/map.rs
+++ b/src/operator/map.rs
@@ -63,9 +63,6 @@ where
 ///
 /// # Type arguments
 ///
-/// * `K1` - input key type.
-/// * `K2` - output key type.
-/// * `V` - value type.
 /// * `CI` - input collection type.
 /// * `CO` - output collection type.
 /// * `FB` - key mapping function type that takes a borrowed key.
@@ -145,10 +142,6 @@ where
 ///
 /// # Type arguments
 ///
-/// * `K` - key type in the input collection.
-/// * `V1` - value type in the input collection.
-/// * `V2` - value type in the output collection (the key type in the output
-///   collection is the same as in the input collection).
 /// * `CI` - input collection type.
 /// * `CO` - output collection type.
 /// * `F` - function that maps input key-value pairs into output values.


### PR DESCRIPTION
One of the DBSP API usability problems listed in #92 is that most
operators are currently generic over return type, e.g.,
`Stream::index` can return any `IndexedZSet`, forcing the programmer
to annotate every call to such operators with concrete return type,
usually `OrdIndexedZSet`.

In this commit we prototype a solution to this problem for the `index`
operator.  We split it into two: `index_generic`, which can return
any indexed Z-set type, and `index`, which specializes `index_generic`
to return `OrdIndexedZSet`.  We do the same for `index_with`.

The result is that I was able to remove all type annotations on
`index` and `index_with` calls.

We also eliminate an inefficiency in the implementation of `index_with`,
which used to create an intermediate batch instead of converting input
batch directly to output Z-set.