### PR TITLE
Rename join->stream_join, join_trace->join.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,9 +199,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+checksum = "5999502d32b9c48d492abe66392408144895020ec4709e549e840799f3bb74c0"
 dependencies = [
  "generic-array",
  "typenum",
@@ -531,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
 dependencies = [
  "autocfg",
  "num-bigint",
@@ -715,15 +715,15 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "1578c6245786b9d168c5447eeacfb96856573ca56c9d68fdcf394be134882a47"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "023e9b1467aef8a10fb88f25611870ada9800ef7e22afce356bb0d2387b6f27c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -760,9 +760,9 @@ checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "smawk"

--- a/benches/path.rs
+++ b/benches/path.rs
@@ -84,7 +84,7 @@ fn main() {
                 //     └────────►│ X │ ◄─────────────────────┘
                 //               │   │
                 //               └───┘
-                //            join_trace
+                //               join
                 // ```
                 let edges = edges.delta0(child);
                 let paths_delayed = <DelayedFeedback<_, OrdZSet<_, _>>>::new(child);
@@ -95,14 +95,13 @@ fn main() {
                 let paths_inverted_indexed = paths_inverted.index();
                 let edges_indexed = edges.index();
 
-                let paths = edges
-                    .plus(
-                        &paths_inverted_indexed.join_trace::<NestedTimestamp32, _, _, _>(
+                let paths =
+                    edges
+                        .plus(&paths_inverted_indexed.join::<NestedTimestamp32, _, _, _>(
                             &edges_indexed,
                             |_via, from, to| (*from, *to),
-                        ),
-                    )
-                    .distinct_trace();
+                        ))
+                        .distinct_trace();
                 paths_delayed.connect(&paths);
 
                 Ok(paths.integrate_trace().export())

--- a/src/circuit/circuit_builder.rs
+++ b/src/circuit/circuit_builder.rs
@@ -2486,33 +2486,32 @@ where
     }
 
     unsafe fn eval(&mut self) -> Result<(), SchedulerError> {
-        self.output_stream
-            .put((&mut *self.operator.get()).get_output());
+        self.output_stream.put((*self.operator.get()).get_output());
         Ok(())
     }
 
     fn clock_start(&mut self, scope: Scope) {
         unsafe {
-            (&mut *self.operator.get()).clock_start(scope);
+            (*self.operator.get()).clock_start(scope);
         }
     }
 
     unsafe fn clock_end(&mut self, scope: Scope) {
         if scope == 0 {
             self.export_stream
-                .put((&mut *self.operator.get()).get_final_output())
+                .put((*self.operator.get()).get_final_output())
         }
-        (&mut *self.operator.get()).clock_end(scope);
+        (*self.operator.get()).clock_end(scope);
     }
 
     fn summary(&self, output: &mut String) {
         unsafe {
-            (&*self.operator.get()).summary(output);
+            (*self.operator.get()).summary(output);
         }
     }
 
     fn fixedpoint(&self, scope: Scope) -> bool {
-        unsafe { (&*self.operator.get()).fixedpoint(scope) }
+        unsafe { (*self.operator.get()).fixedpoint(scope) }
     }
 }
 
@@ -2570,8 +2569,8 @@ where
 
     unsafe fn eval(&mut self) -> Result<(), SchedulerError> {
         match self.input_stream.take() {
-            Cow::Owned(v) => (&mut *self.operator.get()).eval_strict_owned(v),
-            Cow::Borrowed(v) => (&mut *self.operator.get()).eval_strict(v),
+            Cow::Owned(v) => (*self.operator.get()).eval_strict_owned(v),
+            Cow::Borrowed(v) => (*self.operator.get()).eval_strict(v),
         };
         Ok(())
     }
@@ -2584,12 +2583,12 @@ where
 
     fn summary(&self, output: &mut String) {
         unsafe {
-            (&*self.operator.get()).summary(output);
+            (*self.operator.get()).summary(output);
         }
     }
 
     fn fixedpoint(&self, scope: Scope) -> bool {
-        unsafe { (&*self.operator.get()).fixedpoint(scope) }
+        unsafe { (*self.operator.get()).fixedpoint(scope) }
     }
 }
 

--- a/src/circuit/runtime.rs
+++ b/src/circuit/runtime.rs
@@ -130,7 +130,7 @@ impl Runtime {
     }
 
     fn inner(&self) -> &RuntimeInner {
-        &*self.0
+        &self.0
     }
 
     /// Returns the number of workers in this runtime.

--- a/src/operator/condition.rs
+++ b/src/operator/condition.rs
@@ -214,7 +214,8 @@ mod test {
                             let feedback_indexed: Stream<_, OrdIndexedZSet<usize, (), isize>> =
                                 feedback_pairs.index();
 
-                            let suc = feedback_indexed.join(&edges_indexed, |_node, &(), &to| to);
+                            let suc =
+                                feedback_indexed.stream_join(&edges_indexed, |_node, &(), &to| to);
 
                             let reachable = init.plus(&suc).distinct();
                             feedback.connect(&reachable);

--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -53,7 +53,7 @@ pub use product::Product;
 ///
 /// # Example: `NestedTimestamp32`.
 ///
-/// [`join_trace`](`crate::circuit::Stream::join_trace`) and
+/// [`join`](`crate::circuit::Stream::join`) and
 /// [`distinct_trace`](`crate::circuit::Stream::distinct_trace`) methods compute
 /// incremental versions
 /// of `join` and `distinct` operators within nested scopes.  They need to know

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -283,18 +283,18 @@ pub mod rc_blanket_impls {
         type Cursor<'s> = RcBatchCursor<'s, B> where B: 's;
         /// Acquires a cursor to the batch's contents.
         fn cursor(&self) -> Self::Cursor<'_> {
-            RcBatchCursor::new((&**self).cursor())
+            RcBatchCursor::new((**self).cursor())
         }
 
         /// The number of updates in the batch.
         fn len(&self) -> usize {
-            (&**self).len()
+            (**self).len()
         }
         fn lower(&self) -> &Antichain<Self::Time> {
-            (&**self).lower()
+            (**self).lower()
         }
         fn upper(&self) -> &Antichain<Self::Time> {
-            (&**self).upper()
+            (**self).upper()
         }
     }
 


### PR DESCRIPTION
This commit prototypes a solution to the operator naming challenge
(issue #92, problem 2), namely that non-linear operators come in multiple
flavors (incremental/non-incremental, plus implementations specialized for
different nested scopes), making it tricky to pick a correct
implementation.

I propose the following design:

- reserve operator names without modifiers (`join`, `distinct`,
  `aggregate`, etc.) for incremental implementations.  This is in
  the spirit of DD where the user writes a non-incremental program,
  which happens to work correctly over streams of changes.  There
  are useful cases where we want non-incremental semantics, and
  DBSP supports that nicely, but they appear to be far less common.

- Use `stream_` prefix for non-incremental operators, e.g., `stream_join`.
  I am not crazy about this naming decision.  Better suggestions are
  welcome.

- make sure that the same operator name applies in any context
  (i.e., for any nesting depth). This can be achieved by either
  having a single general-purpose implementation or several
  implementations with the same name that specialize for different
  contexts, e.g., one for `Circuit<()>` (top-level circuit) and
  one for `Circuit<Circuit<P>>` (any nested circuit).

In this commit we implement this design for the join operator.  It is
still incomplete because the user must explicitly specify the timestamp
type when instantiating the `join` operator.  Selecting the wrong type
will lead to something that compiles but does not work correctly.  This
will eventually be solved by associating the timestamp type with a
circuit and having operators like join derive their timestamp types
from the circuit.