### PR TITLE
Convenience API for recursive computations

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,6 @@
 name: Coverage
 
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   check:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Rust
 
-on: [pull_request]
+on: [push, pull_request]
 
 env:
   CARGO_TERM_COLOR: always

--- a/src/circuit/circuit_builder.rs
+++ b/src/circuit/circuit_builder.rs
@@ -167,7 +167,10 @@ impl<P, D> Stream<Circuit<P>, D> {
         D: 'static,
     {
         self.circuit()
-            .cache_get_or_insert_with(ExportId::new(self.local_node_id()), || unimplemented!())
+            .cache_get_or_insert_with(
+                ExportId::new(self.origin_node_id().clone()),
+                || unimplemented!(),
+            )
             .clone()
     }
 }
@@ -537,7 +540,7 @@ impl Edge {
     }
 }
 
-circuit_cache_key!(ExportId<C, D>(NodeId => Stream<C, D>));
+circuit_cache_key!(ExportId<C, D>(GlobalNodeId => Stream<C, D>));
 
 /// A circuit consists of nodes and edges.  An edge from
 /// node1 to node2 indicates that the output stream of node1

--- a/src/operator/consolidate.rs
+++ b/src/operator/consolidate.rs
@@ -5,13 +5,13 @@ use std::{borrow::Cow, convert::TryFrom, marker::PhantomData};
 use crate::{
     circuit::{
         operator_traits::{Operator, UnaryOperator},
-        Circuit, NodeId, OwnershipPreference, Scope, Stream,
+        Circuit, GlobalNodeId, OwnershipPreference, Scope, Stream,
     },
     circuit_cache_key,
     trace::{Batch, Trace},
 };
 
-circuit_cache_key!(ConsolidateId<C, D>(NodeId => Stream<C, D>));
+circuit_cache_key!(ConsolidateId<C, D>(GlobalNodeId => Stream<C, D>));
 
 impl<P, T> Stream<Circuit<P>, T>
 where
@@ -35,7 +35,7 @@ where
         B: TryFrom<T::Batch> + Clone + 'static,
     {
         self.circuit()
-            .cache_get_or_insert_with(ConsolidateId::new(self.local_node_id()), || {
+            .cache_get_or_insert_with(ConsolidateId::new(self.origin_node_id().clone()), || {
                 self.circuit().add_unary_operator_with_preference(
                     Consolidate::new(),
                     self,

--- a/src/operator/differentiate.rs
+++ b/src/operator/differentiate.rs
@@ -2,15 +2,15 @@
 
 use crate::{
     algebra::GroupValue,
-    circuit::{Circuit, NodeId, Stream},
+    circuit::{Circuit, GlobalNodeId, Stream},
     circuit_cache_key,
     operator::Minus,
     NumEntries,
 };
 use deepsize::DeepSizeOf;
 
-circuit_cache_key!(DifferentiateId<C, D>(NodeId => Stream<C, D>));
-circuit_cache_key!(NestedDifferentiateId<C, D>(NodeId => Stream<C, D>));
+circuit_cache_key!(DifferentiateId<C, D>(GlobalNodeId => Stream<C, D>));
+circuit_cache_key!(NestedDifferentiateId<C, D>(GlobalNodeId => Stream<C, D>));
 
 impl<P, D> Stream<Circuit<P>, D>
 where
@@ -23,7 +23,7 @@ where
     /// of `self`: `differentiate(a) = a - z^-1(a)`.
     pub fn differentiate(&self) -> Stream<Circuit<P>, D> {
         self.circuit()
-            .cache_get_or_insert_with(DifferentiateId::new(self.local_node_id()), || {
+            .cache_get_or_insert_with(DifferentiateId::new(self.origin_node_id().clone()), || {
                 self.circuit()
                     .add_binary_operator(Minus::new(), self, &self.delay())
             })
@@ -33,10 +33,13 @@ where
     /// Nested stream differentiation.
     pub fn differentiate_nested(&self) -> Stream<Circuit<P>, D> {
         self.circuit()
-            .cache_get_or_insert_with(NestedDifferentiateId::new(self.local_node_id()), || {
-                self.circuit()
-                    .add_binary_operator(Minus::new(), self, &self.delay_nested())
-            })
+            .cache_get_or_insert_with(
+                NestedDifferentiateId::new(self.origin_node_id().clone()),
+                || {
+                    self.circuit()
+                        .add_binary_operator(Minus::new(), self, &self.delay_nested())
+                },
+            )
             .clone()
     }
 }

--- a/src/operator/index.rs
+++ b/src/operator/index.rs
@@ -3,14 +3,14 @@
 use crate::{
     circuit::{
         operator_traits::{Operator, UnaryOperator},
-        Circuit, NodeId, Scope, Stream,
+        Circuit, GlobalNodeId, Scope, Stream,
     },
     circuit_cache_key,
     trace::{cursor::Cursor, ord::OrdIndexedZSet, Batch, BatchReader, Builder},
 };
 use std::{borrow::Cow, marker::PhantomData};
 
-circuit_cache_key!(IndexId<C, D>(NodeId => Stream<C, D>));
+circuit_cache_key!(IndexId<C, D>(GlobalNodeId => Stream<C, D>));
 
 impl<P, CI> Stream<Circuit<P>, CI>
 where
@@ -42,7 +42,7 @@ where
         CO::Val: Clone,
     {
         self.circuit()
-            .cache_get_or_insert_with(IndexId::new(self.local_node_id()), || {
+            .cache_get_or_insert_with(IndexId::new(self.origin_node_id().clone()), || {
                 self.circuit().add_unary_operator(Index::new(), self)
             })
             .clone()

--- a/src/operator/mod.rs
+++ b/src/operator/mod.rs
@@ -67,5 +67,7 @@ mod csv;
 mod neg;
 pub use neg::UnaryMinus;
 
+pub mod recursive;
+
 #[cfg(feature = "with-csv")]
 pub use self::csv::CsvSource;

--- a/src/operator/recursive.rs
+++ b/src/operator/recursive.rs
@@ -356,8 +356,8 @@ mod test {
         }
     }
 
-    // Somewhat lame multiple recursion example to test RecursiveStreams impl for tuples:
-    // compute forward and backward reachability at the same time.
+    // Somewhat lame multiple recursion example to test RecursiveStreams impl for
+    // tuples: compute forward and backward reachability at the same time.
     #[test]
     fn reachability2() {
         let root = Root::build(move |circuit| {

--- a/src/operator/recursive.rs
+++ b/src/operator/recursive.rs
@@ -1,0 +1,428 @@
+//! Convenience API for defining recursive computations.
+
+use crate::{
+    algebra::{ZRingValue, ZSet},
+    circuit::{schedule::Error as SchedulerError, Circuit, Stream},
+    operator::DelayedFeedback,
+    trace::spine_fueled::Spine,
+};
+use deepsize::DeepSizeOf;
+use impl_trait_for_tuples::impl_for_tuples;
+use std::{rc::Rc, result::Result};
+
+/// Generalizes stream operators to groups of streams.
+///
+/// This is a helper trait for the
+/// [`Circuit::recursive`](`crate::circuit::Circuit::recursive`) method.  The
+/// method internally performs several transformations on each recursive stream:
+/// `distinct`, `connect`, `export`, `consolidate`.  This trait generalizes
+/// these methods to operate on multiple streams (e.g., tuples and vectors) of
+/// Z-sets, so that we can define recursive computations over multiple streams.
+pub trait RecursiveStreams<C> {
+    /// Generalizes: [`DelayedFeedback`] type to a group of streams; contains a
+    /// `DelayedFeedback` instance for each stream in the group.
+    type Feedback;
+
+    /// Represents streams in the group exported to the parent circuit.
+    type Export;
+
+    /// Type of the final result of the recursive computation: computed output
+    /// streams exported to the parent circuit and consolidated.
+    type Output;
+
+    /// Create a group of recursive streams along with their feedback
+    /// connectors.
+    fn new(circuit: &C) -> (Self::Feedback, Self);
+
+    /// Apply `distinct` to all streams in `self`.
+    fn distinct(self) -> Self;
+
+    /// Close feedback loop for all streams in `self`.
+    fn connect(&self, vars: Self::Feedback);
+
+    /// Export all streams in `self` to the parent circuit.
+    fn export(self) -> Self::Export;
+
+    /// Apply [`Stream::consolidate`] to all streams in `exports`.
+    fn consolidate(exports: Self::Export) -> Self::Output;
+}
+
+// TODO: Generalize this impl to support arbitrarily nested circuits by
+// fixing `distinct_trace` to work for any nesting depth.
+// Additionally, if we generalize `distinct_trace` to work on arbitrary
+// batches, we can ditch the `B::Val = ()` constraint.
+impl<B> RecursiveStreams<Circuit<Circuit<()>>> for Stream<Circuit<Circuit<()>>, B>
+where
+    //P: Clone +
+    // 'static,
+    B: ZSet + DeepSizeOf + TryFrom<Rc<B>> + 'static,
+    B::Key: Clone + Ord + DeepSizeOf,
+    B::R: DeepSizeOf + ZRingValue,
+{
+    type Feedback = DelayedFeedback<Circuit<()>, B>;
+    type Export = Stream<Circuit<()>, Spine<Rc<B>>>;
+    type Output = Stream<Circuit<()>, B>;
+
+    fn new(circuit: &Circuit<Circuit<()>>) -> (Self::Feedback, Self) {
+        let feedback = DelayedFeedback::new(circuit);
+        let stream = feedback.stream().clone();
+        (feedback, stream)
+    }
+
+    fn distinct(self) -> Self {
+        self.distinct_trace()
+    }
+
+    fn connect(&self, vars: Self::Feedback) {
+        vars.connect(self)
+    }
+
+    fn export(self) -> Self::Export {
+        self.integrate_trace().export()
+    }
+
+    fn consolidate(exports: Self::Export) -> Self::Output {
+        Stream::consolidate(&exports)
+    }
+}
+
+// TODO: `impl RecursiveStreams for Vec<Stream>`.
+
+#[impl_for_tuples(2, 12)]
+#[tuple_types_custom_trait_bound(Clone + RecursiveStreams<C>)]
+impl<C> RecursiveStreams<C> for Tuple {
+    for_tuples!( type Feedback = ( #( Tuple::Feedback ),* ); );
+    for_tuples!( type Export = ( #( Tuple::Export ),* ); );
+    for_tuples!( type Output = ( #( Tuple::Output ),* ); );
+
+    fn new(circuit: &C) -> (Self::Feedback, Self) {
+        let res = (for_tuples!( #( Tuple::new(circuit) ),* ));
+
+        let streams = (for_tuples!( #( { let stream = &res.Tuple; stream.1.clone() } ),* ));
+        let feedback = (for_tuples!( #( { let stream = res.Tuple; stream.0 } ),* ));
+
+        (feedback, streams)
+    }
+
+    fn distinct(self) -> Self {
+        (for_tuples!( #( self.Tuple.distinct() ),* ))
+    }
+
+    fn connect(&self, vars: Self::Feedback) {
+        for_tuples!( #( self.Tuple.connect(vars.Tuple); )* );
+    }
+
+    fn export(self) -> Self::Export {
+        (for_tuples!( #( self.Tuple.export() ),* ))
+    }
+
+    fn consolidate(exports: Self::Export) -> Self::Output {
+        (for_tuples!( #( Tuple::consolidate(exports.Tuple) ),* ))
+    }
+}
+
+impl<P: Clone + 'static> Circuit<P> {
+    /// Create a nested circuit that computes one or more mutually recursive
+    /// streams of Z-sets.
+    ///
+    /// This method implements a common form of iteration that computes a
+    /// solution to an equation `x = f(i, x)` as a fixed point of function
+    /// `f`.  Here `x` is a single Z-set or multiple mutually recursive
+    /// Z-sets.  The computation is maintained incrementally: at each clock
+    /// cycle, the parent circuit feeds an update `Δi` to the external input
+    /// `i` of the nested circuit, and the nested circuit computes `Δx = y
+    /// - x`, where `y` is a solution to the equation `y = f(i+Δi, y)`.
+    ///
+    /// This method is a wrapper around [`Circuit::fixedpoint`] that
+    /// conceptually constructs the following circuit (the exact circuit is
+    /// somewhat different as it takes care of maintaining the computation
+    /// incrementally):
+    ///
+    /// ```text
+    ///     ┌────────────────────────────────────────┐
+    ///     │                                        │
+    ///  i  │            ┌───┐                       │
+    /// ────┼──►δ0──────►│   │      ┌────────┐       │
+    ///     │            │ f ├─────►│distinct├──┬────┼──►
+    ///     │    ┌──────►│   │      └────────┘  │    │
+    ///     │    │       └───┘                  │    │
+    ///     │    │                              │    │
+    ///     │    │                              │    │
+    ///     │    │       ┌────┐                 │    │
+    ///     │    └───────┤z^-1│◄────────────────┘    │
+    ///     │            └────┘                      │
+    ///     │                                        │
+    ///     └────────────────────────────────────────┘
+    /// ```
+    ///
+    /// where the `z^-1` operator connects the previous output of function `f`
+    /// to its input at the next iteration of the fixed point computation.
+    ///
+    /// Note the `distinct` operator attached to the output of `f`.  Most
+    /// recursive computations over Z-sets require this for convergence;
+    /// otherwise their output weights keep growing even when the set of
+    /// elements in the Z-set no longer changes. Hence, strictly speaking
+    /// this circuit computes the fixed point of equation
+    /// `y = distinct(f(i+Δi, y))`.
+    ///
+    /// Finally, the `δ0` block in the diagram represents the
+    /// [`delta0`](`crate::circuit::Stream::delta0`) operator, which imports
+    /// streams from the parent circuit into the nested circuit.  This
+    /// operator must be instantiated manually by the closure `f` for each
+    /// input stream.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dbsp::{
+    ///     circuit::{Root, Stream},
+    ///     operator::Generator,
+    ///     time::NestedTimestamp32,
+    ///     trace::ord::OrdZSet,
+    ///     zset, zset_set,
+    /// };
+    /// use std::vec;
+    ///
+    /// // Propagate labels along graph edges.
+    /// let root = Root::build(move |circuit| {
+    ///     // Graph topology.
+    ///     let mut edges = vec![
+    ///         // Start with four nodes connected in a cycle.
+    ///         zset_set! { (1, 2), (2, 3), (3, 4), (4, 1) },
+    ///         // Add an edge.
+    ///         zset_set! { (4, 5) },
+    ///         // Remove an edge, breaking the cycle.
+    ///         zset! { (1, 2) => -1 },
+    ///     ]
+    ///     .into_iter();
+    ///
+    ///     let edges = circuit
+    ///             .add_source(Generator::new(move || edges.next().unwrap()));
+    ///
+    ///     // Initial labeling of the graph.
+    ///     let mut init_labels = vec![
+    ///         // Start with a single label on node 1.
+    ///         zset_set! { (1, "l1") },
+    ///         // Add a label to node 2.
+    ///         zset_set! { (2, "l2") },
+    ///         zset! { },
+    ///     ]
+    ///     .into_iter();
+    ///
+    ///     let init_labels = circuit
+    ///             .add_source(Generator::new(move || init_labels.next().unwrap()));
+    ///
+    ///     // Expected _changes_ to the output graph labeling after each clock cycle.
+    ///     let mut expected_outputs = vec![
+    ///         zset! { (1, "l1") => 1, (2, "l1") => 1, (3, "l1") => 1, (4, "l1") => 1 },
+    ///         zset! { (1, "l2") => 1, (2, "l2") => 1, (3, "l2") => 1, (4, "l2") => 1, (5, "l1") => 1, (5, "l2") => 1 },
+    ///         zset! { (2, "l1") => -1, (3, "l1") => -1, (4, "l1") => -1, (5, "l1") => -1 },
+    ///     ]
+    ///     .into_iter();
+    ///
+    ///     let labels = circuit.recursive(|child, labels: Stream<_, OrdZSet<(usize, &'static str), isize>>| {
+    ///         // Import `edges` and `init_labels` relations from the parent circuit.
+    ///         let edges = edges.delta0(child);
+    ///         let init_labels = init_labels.delta0(child);
+    ///
+    ///         // Given an edge `from -> to` where the `from` node is labeled with `l`,
+    ///         // propagate `l` to node `to`.
+    ///         let result = labels.index()
+    ///               .join::<NestedTimestamp32, _, _, _>(
+    ///                   &edges.index(),
+    ///                   |_from, l, to| (*to, *l),
+    ///               )
+    ///               .plus(&init_labels);
+    ///         Ok(result)
+    ///     })
+    ///     .unwrap();
+    ///
+    ///     labels.inspect(move |ls| {
+    ///         assert_eq!(*ls, expected_outputs.next().unwrap());
+    ///     })
+    /// })
+    /// .unwrap();
+    ///
+    /// for _ in 0..3 {
+    ///     root.step().unwrap();
+    /// }
+    /// ```
+    pub fn recursive<F, S>(&self, f: F) -> Result<S::Output, SchedulerError>
+    where
+        S: RecursiveStreams<Circuit<Self>>,
+        F: FnOnce(&Circuit<Self>, S) -> Result<S, SchedulerError>,
+    {
+        // The actual circuit we build:
+        //
+        // ```
+        //     ┌───────────────────────────────────────────────────────────────┐
+        //     │                                                               │
+        //  i  │               ┌───┐                                           │
+        // ────┼──►δ0─────────►│   │      ┌────────┐       ┌───────────────┐   │   ┌───────────┐
+        //     │               │ f ├─────►│distinct├──┬───►│integrate_trace├───┼──►│consolidate├───────►
+        //     │       ┌──────►│   │      └────────┘  │    └───────────────┘   │   └───────────┘
+        //     │       │       └───┘                  │                        │
+        //     │       │                              │                        │
+        //     │       │                              │                        │
+        //     │       │       ┌────┐                 │                        │
+        //     │       └───────┤z^-1│◄────────────────┘                        │
+        //     │               └────┘                                          │
+        //     │                                                               │
+        //     └───────────────────────────────────────────────────────────────┘
+        // ```
+        //
+        // where
+        // * `integrate_trace` integrates outputs computed across multiple fixed point
+        //   iterations.
+        // * `consolidate` consolidates the output of the nested circuit into a single
+        //   batch.
+        let traces = self.fixedpoint(|child| {
+            let (vars, input_streams) = S::new(child);
+            let output_streams = f(child, input_streams)?;
+            let output_streams = S::distinct(output_streams);
+            S::connect(&output_streams, vars);
+            Ok(S::export(output_streams))
+        })?;
+
+        Ok(S::consolidate(traces))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        circuit::{Root, Stream},
+        operator::Generator,
+        time::NestedTimestamp32,
+        trace::ord::OrdZSet,
+        zset,
+    };
+    use std::vec;
+
+    #[test]
+    fn reachability() {
+        let root = Root::build(move |circuit| {
+            // Changes to the edges relation.
+            let mut edges = vec![
+                zset! { (1, 2) => 1 },
+                zset! { (2, 3) => 1},
+                zset! { (1, 3) => 1},
+                zset! { (3, 1) => 1},
+                zset! { (3, 1) => -1},
+                zset! { (1, 2) => -1},
+                zset! { (2, 4) => 1, (4, 1) => 1 },
+                zset! { (2, 3) => -1, (3, 2) => 1 },
+            ]
+            .into_iter();
+
+            // Expected content of the reachability relation.
+            let mut outputs = vec![
+                zset! { (1, 2) => 1 },
+                zset! { (1, 2) => 1, (2, 3) => 1, (1, 3) => 1 },
+                zset! { (1, 2) => 1, (2, 3) => 1, (1, 3) => 1 },
+                zset! { (1, 1) => 1, (2, 2) => 1, (3, 3) => 1, (1, 2) => 1, (1, 3) => 1, (2, 3) => 1, (2, 1) => 1, (3, 1) => 1, (3, 2) => 1},
+                zset! { (1, 2) => 1, (2, 3) => 1, (1, 3) => 1 },
+                zset! { (2, 3) => 1, (1, 3) => 1 },
+                zset! { (1, 3) => 1, (2, 3) => 1, (2, 4) => 1, (2, 1) => 1, (4, 1) => 1, (4, 3) => 1 },
+                zset! { (1, 1) => 1, (2, 2) => 1, (3, 3) => 1, (4, 4) => 1,
+                              (1, 2) => 1, (1, 3) => 1, (1, 4) => 1,
+                              (2, 1) => 1, (2, 3) => 1, (2, 4) => 1,
+                              (3, 1) => 1, (3, 2) => 1, (3, 4) => 1,
+                              (4, 1) => 1, (4, 2) => 1, (4, 3) => 1 },
+            ]
+            .into_iter();
+
+            let edges = circuit
+                    .add_source(Generator::new(move || edges.next().unwrap()));
+
+            let paths = circuit.recursive(|child, paths: Stream<_, OrdZSet<(usize, usize), isize>>| {
+                let edges = edges.delta0(child);
+
+                let paths_indexed = paths.index_with(|&(x, y)| (y, x));
+                let edges_indexed = edges.index();
+
+                Ok(edges.plus(&paths_indexed.join::<NestedTimestamp32, _, _, _>(&edges_indexed, |_via, from, to| (*from, *to))))
+            })
+            .unwrap();
+
+            paths.integrate().distinct().inspect(move |ps| {
+                assert_eq!(*ps, outputs.next().unwrap());
+            })
+        })
+        .unwrap();
+
+        for _ in 0..8 {
+            root.step().unwrap();
+        }
+    }
+
+    // Somewhat lame multiple recursion example to test RecursiveStreams impl for tuples:
+    // compute forward and backward reachability at the same time.
+    #[test]
+    fn reachability2() {
+        let root = Root::build(move |circuit| {
+            // Changes to the edges relation.
+            let mut edges = vec![
+                zset! { (1, 2) => 1 },
+                zset! { (2, 3) => 1},
+                zset! { (1, 3) => 1},
+                zset! { (3, 1) => 1},
+                zset! { (3, 1) => -1},
+                zset! { (1, 2) => -1},
+                zset! { (2, 4) => 1, (4, 1) => 1 },
+                zset! { (2, 3) => -1, (3, 2) => 1 },
+            ]
+            .into_iter();
+
+            // Expected content of the reachability relation.
+            let output_vec = vec![
+                zset! { (1, 2) => 1 },
+                zset! { (1, 2) => 1, (2, 3) => 1, (1, 3) => 1 },
+                zset! { (1, 2) => 1, (2, 3) => 1, (1, 3) => 1 },
+                zset! { (1, 1) => 1, (2, 2) => 1, (3, 3) => 1, (1, 2) => 1, (1, 3) => 1, (2, 3) => 1, (2, 1) => 1, (3, 1) => 1, (3, 2) => 1},
+                zset! { (1, 2) => 1, (2, 3) => 1, (1, 3) => 1 },
+                zset! { (2, 3) => 1, (1, 3) => 1 },
+                zset! { (1, 3) => 1, (2, 3) => 1, (2, 4) => 1, (2, 1) => 1, (4, 1) => 1, (4, 3) => 1 },
+                zset! { (1, 1) => 1, (2, 2) => 1, (3, 3) => 1, (4, 4) => 1,
+                              (1, 2) => 1, (1, 3) => 1, (1, 4) => 1,
+                              (2, 1) => 1, (2, 3) => 1, (2, 4) => 1,
+                              (3, 1) => 1, (3, 2) => 1, (3, 4) => 1,
+                              (4, 1) => 1, (4, 2) => 1, (4, 3) => 1 },
+            ];
+
+            let mut outputs = output_vec.clone().into_iter();
+            let mut outputs2 = output_vec.into_iter();
+
+            let edges = circuit
+                    .add_source(Generator::new(move || edges.next().unwrap()));
+
+            let (paths, reverse_paths) = circuit.recursive(|child, (paths, reverse_paths): (Stream<_, OrdZSet<(usize, usize), isize>>, Stream<_, OrdZSet<(usize, usize), isize>>)| {
+                let edges = edges.delta0(child);
+
+                let paths_indexed = paths.index_with(|&(x, y)| (y, x));
+                let reverse_paths_indexed = reverse_paths.index_with(|&(x, y)| (y, x));
+                let edges_indexed = edges.index();
+                let reverse_edges = edges.map_keys(|&(x, y)| (y, x));
+                let reverse_edges_indexed = reverse_edges.index();
+
+                Ok((edges.plus(&paths_indexed.join::<NestedTimestamp32, _, _, _>(&edges_indexed, |_via, from, to| (*from, *to))),
+                    reverse_edges.plus(&reverse_paths_indexed.join::<NestedTimestamp32, _, _, _>(&reverse_edges_indexed, |_via, from, to| (*from, *to)))
+                ))
+            })
+            .unwrap();
+
+            paths.integrate().distinct().inspect(move |ps| {
+                assert_eq!(*ps, outputs.next().unwrap());
+            });
+
+            reverse_paths.map_keys(|&(x, y)| (y, x)).integrate().distinct().inspect(move |ps: &OrdZSet<_,_>| {
+                assert_eq!(*ps, outputs2.next().unwrap());
+            })
+        })
+        .unwrap();
+
+        for _ in 0..8 {
+            root.step().unwrap();
+        }
+    }
+}


### PR DESCRIPTION
This is the next step in improving the operator API (issue https://github.com/vmware/database-stream-processor/issues/92).  We
address problems 4 and 5 related to writing recursive queries over
streams of Z-sets.

We add an API that simplifies the construction of recursive incremental queries in DBSP.
Previously this required the following manual steps:
1. Create a fixed point computation using `Circuit::fixedpoint`.
2. Create a `DelayedFeedback` object for each recursive collection.
3. Apply `distinct` to the output streams to ensure convergence.
4. Connect the outputs of the circuit back to `DelayedFeedback`
   objects to close the loop.
5. Compute the sum of deltas produced at each iteration of the
   fixedpoint computation using `integrate_trace`
6. Export resulting streams to the parent circuit.
7. Consolidate (`stream.consolidate()`) the streams in the parent
   circuit.

The new API takes care of all these steps.  The programmer only needs to
define one iteration of the recursive computation that maps outputs of the previous
iteration to inputs of the next iteration.

Note that steps 3, 4, and 6 above are specific to recursive queries over
Z-sets (as opposed to general recursive queries over arbitrary groups).