### PR TITLE
[nexmark] Add initial nexmark auction generation function.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,6 +308,7 @@ dependencies = [
  "petgraph",
  "priority-queue",
  "rand",
+ "rstest",
  "serde",
  "textwrap",
  "timely",
@@ -363,10 +364,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
 name = "futures-macro"
@@ -380,10 +423,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-sink"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+
+[[package]]
 name = "futures-task"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
@@ -391,9 +446,13 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -829,6 +888,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
+name = "rstest"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c9dc66cc29792b663ffb5269be669f1613664e69ad56441fdb895c2347b930"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5015e68a0685a95ade3eee617ff7101ab6a3fc689203101ca16ebc16f2b89c66"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -839,6 +932,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ zip = "0.6.2"
 anyhow = "1.0.57"
 rand = "0.8"
 clap = { version = "3.2", features = ["derive", "env"] }
+rstest = "0.15"
 
 [[bench]]
 name = "galen"

--- a/benches/nexmark/config.rs
+++ b/benches/nexmark/config.rs
@@ -4,15 +4,8 @@
 //! and the specific [Nexmark Flink Generator config](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/GeneratorConfig.java).
 use clap::Parser;
 
-// We start the ids at specific values to help ensure the queries find a match
-// even on small synthesized dataset sizes.
-pub const FIRST_PERSON_ID: usize = 1000;
-
 // Number of yet-to-be-created people and auction ids allowed.
 pub const PERSON_ID_LEAD: usize = 10;
-
-/// Maximum number of people to consider as active for placing auctions or bids.
-pub const NUM_ACTIVE_PEOPLE: usize = 1000;
 
 /// A Nexmark streaming data source generator
 ///
@@ -20,14 +13,6 @@ pub const NUM_ACTIVE_PEOPLE: usize = 1000;
 #[derive(Parser, Debug)]
 #[clap(author, version, about)]
 pub struct Config {
-    #[clap(
-        long = "person-proportion",
-        default_value = "1",
-        env = "NEXMARK_PERSON_PROPORTION",
-        help = "Specify the proportion of events that will be new people"
-    )]
-    pub person_proportion: usize,
-
     #[clap(
         long = "auction-proportion",
         default_value = "3",
@@ -37,16 +22,89 @@ pub struct Config {
     pub auction_proportion: usize,
 
     #[clap(
-        long = "bit-proportion",
+        long = "bid-proportion",
         default_value = "46",
         env = "NEXMARK_BID_PROPORTION",
         help = "Specify the proportion of events that will be new bids"
     )]
     pub bid_proportion: usize,
+
+    #[clap(
+        long = "person-proportion",
+        default_value = "1",
+        env = "NEXMARK_PERSON_PROPORTION",
+        help = "Specify the proportion of events that will be new people"
+    )]
+    pub person_proportion: usize,
+
+    #[clap(
+        long = "out-of-order-group-size",
+        default_value = "1",
+        env = "NEXMARK_OUT_OF_ORDER_GROUP_SIZE",
+        help = "Number of events in out-of-order groups. 1 implies no out-of-order events. 1000 implies every 1000 events per generator are emitted in pseudo-random order."
+    )]
+    pub out_of_order_group_size: usize,
+
+    #[clap(
+        long = "num-in-flight-auctions",
+        default_value = "100",
+        env = "NEXMARK_NUM_IN_FLIGHT_AUCTIONS",
+        help = "Average number of auctions which should be inflight at any time, per generator."
+    )]
+    pub num_in_flight_auctions: usize,
+
+    #[clap(
+        long = "num-active-people",
+        default_value = "1000",
+        env = "NEXMARK_NUM_ACTIVE_PEOPLE",
+        help = "Maximum number of people to consider as active for placing auctions or bids."
+    )]
+    pub num_active_people: usize,
+
+    #[clap(
+        long = "first-event-rate",
+        default_value = "10000",
+        env = "NEXMARK_FIRST_EVENT_RATE",
+        help = "Initial overall event rate (per second)."
+    )]
+    pub first_event_rate: usize,
+
+    #[clap(
+        long = "num-event-generators",
+        default_value = "1",
+        env = "NEXMARK_NUM_EVENT_GENERATORS",
+        help = "Number of event generators to use. Each generates events in its own timeline."
+    )]
+    pub num_event_generators: usize,
 }
 
+/// Implementation of config methods based on the Java implementation at
+/// [NexmarkConfig.java](https://github.com/nexmark/nexmark/blob/master/nexmark-flink/src/main/java/com/github/nexmark/flink/NexmarkConfiguration.java).
 impl Config {
     pub fn total_proportion(&self) -> usize {
         self.person_proportion + self.auction_proportion + self.bid_proportion
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+
+    pub fn make_default_nexmark_config() -> Config {
+        Config {
+            auction_proportion: 3,
+            bid_proportion: 46,
+            person_proportion: 1,
+            num_in_flight_auctions: 100,
+            num_active_people: 1000,
+            out_of_order_group_size: 1,
+            first_event_rate: 10_000,
+            num_event_generators: 1,
+        }
+    }
+
+    #[test]
+    fn test_total_proportion_default() {
+        assert_eq!(make_default_nexmark_config().total_proportion(), 50);
     }
 }

--- a/benches/nexmark/config.rs
+++ b/benches/nexmark/config.rs
@@ -13,68 +13,38 @@ pub const PERSON_ID_LEAD: usize = 10;
 #[derive(Parser, Debug)]
 #[clap(author, version, about)]
 pub struct Config {
-    #[clap(
-        long = "auction-proportion",
-        default_value = "3",
-        env = "NEXMARK_AUCTION_PROPORTION",
-        help = "Specify the proportion of events that will be new auctions"
-    )]
+    /// Specify the proportion of events that will be new auctions.
+    #[clap(long, default_value = "3", env = "NEXMARK_AUCTION_PROPORTION")]
     pub auction_proportion: usize,
 
-    #[clap(
-        long = "bid-proportion",
-        default_value = "46",
-        env = "NEXMARK_BID_PROPORTION",
-        help = "Specify the proportion of events that will be new bids"
-    )]
+    /// Specify the proportion of events that will be new bids.
+    #[clap(long, default_value = "46", env = "NEXMARK_BID_PROPORTION")]
     pub bid_proportion: usize,
 
-    #[clap(
-        long = "person-proportion",
-        default_value = "1",
-        env = "NEXMARK_PERSON_PROPORTION",
-        help = "Specify the proportion of events that will be new people"
-    )]
+    /// Specify the proportion of events that will be new people.
+    #[clap(long, default_value = "1", env = "NEXMARK_PERSON_PROPORTION")]
     pub person_proportion: usize,
 
-    #[clap(
-        long = "out-of-order-group-size",
-        default_value = "1",
-        env = "NEXMARK_OUT_OF_ORDER_GROUP_SIZE",
-        help = "Number of events in out-of-order groups. 1 implies no out-of-order events. 1000 implies every 1000 events per generator are emitted in pseudo-random order."
-    )]
+    /// Number of events in out-of-order groups. 1 implies no out-of-order
+    /// events. 1000 implies every 1000 events per generator are emitted in
+    /// pseudo-random order.
+    #[clap(long, default_value = "1", env = "NEXMARK_OUT_OF_ORDER_GROUP_SIZE")]
     pub out_of_order_group_size: usize,
 
-    #[clap(
-        long = "num-in-flight-auctions",
-        default_value = "100",
-        env = "NEXMARK_NUM_IN_FLIGHT_AUCTIONS",
-        help = "Average number of auctions which should be inflight at any time, per generator."
-    )]
+    /// Average number of auctions which should be inflight at any time, per generator.
+    #[clap(long, default_value = "100", env = "NEXMARK_NUM_IN_FLIGHT_AUCTIONS")]
     pub num_in_flight_auctions: usize,
 
-    #[clap(
-        long = "num-active-people",
-        default_value = "1000",
-        env = "NEXMARK_NUM_ACTIVE_PEOPLE",
-        help = "Maximum number of people to consider as active for placing auctions or bids."
-    )]
+    /// Maximum number of people to consider as active for placing auctions or bids.
+    #[clap(long, default_value = "1000", env = "NEXMARK_NUM_ACTIVE_PEOPLE")]
     pub num_active_people: usize,
 
-    #[clap(
-        long = "first-event-rate",
-        default_value = "10000",
-        env = "NEXMARK_FIRST_EVENT_RATE",
-        help = "Initial overall event rate (per second)."
-    )]
+    /// Initial overall event rate (per second).
+    #[clap(long, default_value = "10000", env = "NEXMARK_FIRST_EVENT_RATE")]
     pub first_event_rate: usize,
 
-    #[clap(
-        long = "num-event-generators",
-        default_value = "1",
-        env = "NEXMARK_NUM_EVENT_GENERATORS",
-        help = "Number of event generators to use. Each generates events in its own timeline."
-    )]
+    /// Number of event generators to use. Each generates events in its own timeline.
+    #[clap(long, default_value = "1", env = "NEXMARK_NUM_EVENT_GENERATORS")]
     pub num_event_generators: usize,
 }
 
@@ -86,11 +56,8 @@ impl Config {
     }
 }
 
-#[cfg(test)]
-pub mod tests {
-    use super::*;
-
-    pub fn make_default_nexmark_config() -> Config {
+impl Default for Config {
+    fn default() -> Self {
         Config {
             auction_proportion: 3,
             bid_proportion: 46,
@@ -101,10 +68,5 @@ pub mod tests {
             first_event_rate: 10_000,
             num_event_generators: 1,
         }
-    }
-
-    #[test]
-    fn test_total_proportion_default() {
-        assert_eq!(make_default_nexmark_config().total_proportion(), 50);
     }
 }

--- a/benches/nexmark/config.rs
+++ b/benches/nexmark/config.rs
@@ -31,11 +31,13 @@ pub struct Config {
     #[clap(long, default_value = "1", env = "NEXMARK_OUT_OF_ORDER_GROUP_SIZE")]
     pub out_of_order_group_size: usize,
 
-    /// Average number of auctions which should be inflight at any time, per generator.
+    /// Average number of auctions which should be inflight at any time, per
+    /// generator.
     #[clap(long, default_value = "100", env = "NEXMARK_NUM_IN_FLIGHT_AUCTIONS")]
     pub num_in_flight_auctions: usize,
 
-    /// Maximum number of people to consider as active for placing auctions or bids.
+    /// Maximum number of people to consider as active for placing auctions or
+    /// bids.
     #[clap(long, default_value = "1000", env = "NEXMARK_NUM_ACTIVE_PEOPLE")]
     pub num_active_people: usize,
 
@@ -43,7 +45,8 @@ pub struct Config {
     #[clap(long, default_value = "10000", env = "NEXMARK_FIRST_EVENT_RATE")]
     pub first_event_rate: usize,
 
-    /// Number of event generators to use. Each generates events in its own timeline.
+    /// Number of event generators to use. Each generates events in its own
+    /// timeline.
     #[clap(long, default_value = "1", env = "NEXMARK_NUM_EVENT_GENERATORS")]
     pub num_event_generators: usize,
 }

--- a/benches/nexmark/generator/auctions.rs
+++ b/benches/nexmark/generator/auctions.rs
@@ -19,7 +19,8 @@ impl<R: Rng> NexmarkGenerator<R> {
         // What's our current event number?
         let current_event_number = self.config.next_adjusted_event_number(event_count_so_far);
         // How many events until we've generated num_in_flight_actions?
-        // E.g. with defaults, this is 100 * 50 / 3 = 1666 total events (bids, people, auctions)
+        // E.g. with defaults, this is 100 * 50 / 3 = 1666 total events (bids, people,
+        // auctions)
         let num_events_for_auctions = (self.config.nexmark_config.num_in_flight_auctions
             * self.config.nexmark_config.total_proportion())
             / self.config.nexmark_config.auction_proportion;

--- a/benches/nexmark/generator/auctions.rs
+++ b/benches/nexmark/generator/auctions.rs
@@ -5,8 +5,10 @@
 use super::NexmarkGenerator;
 use anyhow::Result;
 use rand::Rng;
-use std::cmp;
-use std::time::{Duration, SystemTime};
+use std::{
+    cmp,
+    time::{Duration, SystemTime},
+};
 
 impl<R: Rng> NexmarkGenerator<R> {
     fn next_auction_length_ms(
@@ -40,14 +42,14 @@ impl<R: Rng> NexmarkGenerator<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::generator::config::tests::make_default_config;
+    use crate::generator::config::Config;
     use rand::rngs::mock::StepRng;
 
     #[test]
     fn test_next_auction_length_ms() {
         let mut ng = NexmarkGenerator {
             rng: StepRng::new(0, 5),
-            config: make_default_config(),
+            config: Config::default(),
         };
 
         let len_ms = ng

--- a/benches/nexmark/generator/auctions.rs
+++ b/benches/nexmark/generator/auctions.rs
@@ -1,0 +1,60 @@
+//! Generates people for the Nexmark streaming data source.
+//!
+//! API based on the equivalent [Nexmark Flink PersonGenerator API](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/model/AuctionGenerator.java).
+
+use super::NexmarkGenerator;
+use anyhow::Result;
+use rand::Rng;
+use std::cmp;
+use std::time::{Duration, SystemTime};
+
+impl<R: Rng> NexmarkGenerator<R> {
+    fn next_auction_length_ms(
+        &mut self,
+        event_count_so_far: usize,
+        timestamp: SystemTime,
+    ) -> Result<Duration> {
+        // What's our current event number?
+        let current_event_number = self.config.next_adjusted_event_number(event_count_so_far);
+        // How many events until we've generated num_in_flight_actions?
+        // E.g. with defaults, this is 100 * 50 / 3 = 1666 total events (bids, people, auctions)
+        let num_events_for_auctions = (self.config.nexmark_config.num_in_flight_auctions
+            * self.config.nexmark_config.total_proportion())
+            / self.config.nexmark_config.auction_proportion;
+        // When will the auction num_in_flight_auctions beyond now be generated?
+        // E.g. with defaults, timestamp for the event 1666 from now
+        // (corresponding to 100 auctions from now).
+        let future_auction = self
+            .config
+            .timestamp_for_event((current_event_number + num_events_for_auctions) as u64);
+        // Choose a length with average horizon.
+        let horizon = future_auction.duration_since(timestamp)?;
+
+        let next_duration_ms: u128 =
+            1 + self.rng.gen_range(0..cmp::max(horizon.as_millis() * 2, 1));
+
+        Ok(Duration::from_millis(next_duration_ms.try_into()?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::generator::config::tests::make_default_config;
+    use rand::rngs::mock::StepRng;
+
+    #[test]
+    fn test_next_auction_length_ms() {
+        let mut ng = NexmarkGenerator {
+            rng: StepRng::new(0, 5),
+            config: make_default_config(),
+        };
+
+        let len_ms = ng
+            .next_auction_length_ms(0, SystemTime::UNIX_EPOCH)
+            .unwrap();
+
+        // Since StepRng always returns zero, can only test the lower bound here.
+        assert_eq!(len_ms.as_millis(), 1);
+    }
+}

--- a/benches/nexmark/generator/config.rs
+++ b/benches/nexmark/generator/config.rs
@@ -39,7 +39,8 @@ impl Config {
         }
     }
 
-    // Return the next event number for a generator which has so far emitted `num_events`.
+    // Return the next event number for a generator which has so far emitted
+    // `num_events`.
     pub fn next_event_number(&self, num_events: Id) -> Id {
         self.first_event_number + num_events
     }

--- a/benches/nexmark/generator/config.rs
+++ b/benches/nexmark/generator/config.rs
@@ -62,19 +62,20 @@ impl Config {
     }
 }
 
+impl Default for Config {
+    fn default() -> Self {
+        Config::new(NexmarkConfig::default(), 0, 1)
+    }
+}
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use crate::config::tests::make_default_nexmark_config;
+    use crate::config::Config as NexmarkConfig;
     use rstest::rstest;
-
-    pub fn make_default_config() -> Config {
-        Config::new(make_default_nexmark_config(), 0, 1)
-    }
 
     #[test]
     fn test_next_event_number() {
-        assert_eq!(make_default_config().next_event_number(4), 5);
+        assert_eq!(Config::default().next_event_number(4), 5);
     }
 
     #[rstest]
@@ -84,7 +85,7 @@ pub mod tests {
     #[case(199, 200)]
     fn test_next_adjusted_event_number_default(#[case] num_events: Id, #[case] expected: Id) {
         assert_eq!(
-            make_default_config().next_adjusted_event_number(num_events),
+            Config::default().next_adjusted_event_number(num_events),
             expected
         );
     }
@@ -106,9 +107,9 @@ pub mod tests {
         let config = Config {
             nexmark_config: NexmarkConfig {
                 out_of_order_group_size: 3,
-                ..make_default_nexmark_config()
+                ..NexmarkConfig::default()
             },
-            ..make_default_config()
+            ..Config::default()
         };
         assert_eq!(config.next_adjusted_event_number(num_events), expected);
     }
@@ -122,7 +123,7 @@ pub mod tests {
     #[case(5, SystemTime::UNIX_EPOCH + Duration::from_micros(100*5))]
     fn test_timestamp_for_event(#[case] event_number: u64, #[case] expected: SystemTime) {
         assert_eq!(
-            make_default_config().timestamp_for_event(event_number),
+            Config::default().timestamp_for_event(event_number),
             expected,
         );
     }

--- a/benches/nexmark/generator/config.rs
+++ b/benches/nexmark/generator/config.rs
@@ -1,0 +1,129 @@
+use super::super::config::Config as NexmarkConfig;
+use super::super::model::Id;
+use std::time::{Duration, SystemTime};
+
+// We start the ids at specific values to help ensure the queries find a match
+// even on small synthesized dataset sizes.
+pub const FIRST_PERSON_ID: usize = 1000;
+
+/// The generator config is a combination of the CLI configuration and the
+/// options specific to this generator instantiation.
+pub struct Config {
+    pub nexmark_config: NexmarkConfig,
+
+    /// Time for first event (ms since epoch).
+    pub base_time: SystemTime,
+
+    /// Generators running in parallel time may share the same event number, and
+    /// the event number is used to determine the event timestamp"
+    pub first_event_number: Id,
+
+    /// Delay between events, in microseconds. If the array has more than one
+    /// entry then the rate is changed every {@link #stepLengthSec}, and wraps
+    /// around.
+    pub inter_event_delay_us: [usize; 5],
+}
+
+/// Implementation of config methods based on the Java implementation at
+/// [GeneratorConfig.java](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/GeneratorConfig.java)
+impl Config {
+    pub fn new(nexmark_config: NexmarkConfig, base_time: u64, first_event_number: Id) -> Config {
+        let inter_event_delay =
+            1_000_000 / nexmark_config.first_event_rate * nexmark_config.num_event_generators;
+
+        Config {
+            nexmark_config,
+            base_time: SystemTime::UNIX_EPOCH + Duration::from_millis(base_time),
+            first_event_number,
+            inter_event_delay_us: [inter_event_delay, 0, 0, 0, 0],
+        }
+    }
+
+    // Return the next event number for a generator which has so far emitted `num_events`.
+    pub fn next_event_number(&self, num_events: Id) -> Id {
+        self.first_event_number + num_events
+    }
+
+    // Return the next event number for a generator which has so far emitted
+    // `num_events`, but adjusted to account for `out_of_order_group_size`.
+    pub fn next_adjusted_event_number(&self, num_events: Id) -> Id {
+        let n = self.nexmark_config.out_of_order_group_size;
+        let event_number = self.next_event_number(num_events);
+        let base = (event_number / n) * n;
+        let offset = (event_number * 953) % n;
+        base + offset
+    }
+
+    // What timestamp should the event with `eventNumber` have for this
+    // generator?
+    pub fn timestamp_for_event(&self, event_number: u64) -> SystemTime {
+        return self.base_time
+            + Duration::from_micros(self.inter_event_delay_us[0] as u64 * event_number);
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::config::tests::make_default_nexmark_config;
+    use rstest::rstest;
+
+    pub fn make_default_config() -> Config {
+        Config::new(make_default_nexmark_config(), 0, 1)
+    }
+
+    #[test]
+    fn test_next_event_number() {
+        assert_eq!(make_default_config().next_event_number(4), 5);
+    }
+
+    #[rstest]
+    #[case(0, 1)]
+    #[case(1, 2)]
+    #[case(2, 3)]
+    #[case(199, 200)]
+    fn test_next_adjusted_event_number_default(#[case] num_events: Id, #[case] expected: Id) {
+        assert_eq!(
+            make_default_config().next_adjusted_event_number(num_events),
+            expected
+        );
+    }
+
+    // When the out-of-order-group-size is 3, each group of three numbers will
+    // have a pseudo-random order, but only from within the same group of three.
+    #[rstest]
+    #[case(0, 2)]
+    #[case(1, 1)]
+    #[case(2, 3)]
+    #[case(3, 5)]
+    #[case(4, 4)]
+    #[case(5, 6)]
+    fn test_next_adjusted_event_number_custom_group_size_3(
+        #[case] num_events: Id,
+        #[case] expected: Id,
+    ) {
+        // Seems to be issues in the Java implementation?!
+        let config = Config {
+            nexmark_config: NexmarkConfig {
+                out_of_order_group_size: 3,
+                ..make_default_nexmark_config()
+            },
+            ..make_default_config()
+        };
+        assert_eq!(config.next_adjusted_event_number(num_events), expected);
+    }
+
+    // With the default first event rate of 10_000 events per second and one
+    // generator, there is 1_000_000 µs/s / 10_000 events/s = 100µs / event, so
+    // the timestamp increases by 100µs for each event.
+    #[rstest]
+    #[case(1, SystemTime::UNIX_EPOCH + Duration::from_micros(100*1))]
+    #[case(2, SystemTime::UNIX_EPOCH + Duration::from_micros(100*2))]
+    #[case(5, SystemTime::UNIX_EPOCH + Duration::from_micros(100*5))]
+    fn test_timestamp_for_event(#[case] event_number: u64, #[case] expected: SystemTime) {
+        assert_eq!(
+            make_default_config().timestamp_for_event(event_number),
+            expected,
+        );
+    }
+}

--- a/benches/nexmark/generator/mod.rs
+++ b/benches/nexmark/generator/mod.rs
@@ -2,9 +2,11 @@
 //!
 //! Based on the equivalent [Nexmark Flink generator API](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/java/com/github/nexmark/flink/generator).
 
-use crate::config::Config;
+use self::config::Config;
 use rand::Rng;
 
+mod auctions;
+mod config;
 mod people;
 mod strings;
 

--- a/benches/nexmark/generator/people.rs
+++ b/benches/nexmark/generator/people.rs
@@ -39,11 +39,12 @@ impl<R: Rng> NexmarkGenerator<R> {
     // Generate and return a random person with next available id.
     pub fn next_person(&mut self, next_event_id: Id, timestamp: u64) -> Person {
         // TODO(absoludity): Figure out the purpose of the extra field - appears to be
-        // aiming to adjust the number of bytes for the record to be an average, which will
-        // need slightly different handling in Rust.
+        // aiming to adjust the number of bytes for the record to be an average, which
+        // will need slightly different handling in Rust.
         // int currentSize =
-        //     8 + name.length() + email.length() + creditCard.length() + city.length() + state.length();
-        // String extra = nextExtra(random, currentSize, config.getAvgPersonByteSize());
+        //     8 + name.length() + email.length() + creditCard.length() + city.length()
+        // + state.length(); String extra = nextExtra(random, currentSize,
+        // config.getAvgPersonByteSize());
 
         Person {
             id: self.last_base0_person_id(next_event_id) + config::FIRST_PERSON_ID,
@@ -59,15 +60,17 @@ impl<R: Rng> NexmarkGenerator<R> {
 
     /// Return a random person id (base 0).
     ///
-    /// Choose a random person from any of the 'active' people, plus a few 'leads'.
-    /// By limiting to 'active' we ensure the density of bids or auctions per person
-    /// does not decrease over time for long running jobs.  By choosing a person id
-    /// ahead of the last valid person id we will make newPerson and newAuction
-    /// events appear to have been swapped in time.
+    /// Choose a random person from any of the 'active' people, plus a few
+    /// 'leads'. By limiting to 'active' we ensure the density of bids or
+    /// auctions per person does not decrease over time for long running
+    /// jobs.  By choosing a person id ahead of the last valid person id we
+    /// will make newPerson and newAuction events appear to have been
+    /// swapped in time.
     ///
-    /// NOTE: The above is the original comment from the Java implementation. The
-    /// "base 0" is referring to the fact that the returned Id is not including the
-    /// FIRST_PERSON_ID offset, and should really be "offset 0".
+    /// NOTE: The above is the original comment from the Java implementation.
+    /// The "base 0" is referring to the fact that the returned Id is not
+    /// including the FIRST_PERSON_ID offset, and should really be "offset
+    /// 0".
     pub fn next_base0_person_id(&mut self, event_id: Id) -> Id {
         let num_people = self.last_base0_person_id(event_id) + 1;
         let active_people = min(num_people, self.config.nexmark_config.num_active_people);

--- a/benches/nexmark/generator/people.rs
+++ b/benches/nexmark/generator/people.rs
@@ -131,15 +131,15 @@ impl<R: Rng> NexmarkGenerator<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{tests::make_default_nexmark_config, Config as NexmarkConfig};
-    use config::{tests::make_default_config, Config};
+    use crate::config::Config as NexmarkConfig;
+    use config::Config;
     use rand::rngs::mock::StepRng;
 
     #[test]
     fn test_next_person() {
         let mut ng = NexmarkGenerator {
             rng: StepRng::new(0, 5),
-            config: make_default_config(),
+            config: Config::default(),
         };
 
         let p = ng.next_person(105, 1_000_000_000_000);
@@ -163,7 +163,7 @@ mod tests {
     fn test_next_base0_person_id() {
         let mut ng = NexmarkGenerator {
             rng: StepRng::new(0, 5),
-            config: make_default_config(),
+            config: Config::default(),
         };
 
         // When one more than the last person id is less than the configured
@@ -195,7 +195,7 @@ mod tests {
     fn test_last_base0_person_id_default() {
         let ng = NexmarkGenerator {
             rng: StepRng::new(0, 5),
-            config: make_default_config(),
+            config: Config::default(),
         };
 
         // With the default config, the first 50 events will only include one
@@ -220,9 +220,9 @@ mod tests {
             config: Config {
                 nexmark_config: NexmarkConfig {
                     bid_proportion: 21,
-                    ..make_default_nexmark_config()
+                    ..NexmarkConfig::default()
                 },
-                ..make_default_config()
+                ..Config::default()
             },
         };
 
@@ -238,7 +238,7 @@ mod tests {
     fn test_next_us_state() {
         let mut ng = NexmarkGenerator {
             rng: StepRng::new(0, 5),
-            config: make_default_config(),
+            config: Config::default(),
         };
 
         let s = ng.next_us_state();
@@ -250,7 +250,7 @@ mod tests {
     fn test_next_us_city() {
         let mut ng = NexmarkGenerator {
             rng: StepRng::new(0, 5),
-            config: make_default_config(),
+            config: Config::default(),
         };
 
         let c = ng.next_us_city();
@@ -262,7 +262,7 @@ mod tests {
     fn test_next_person_name() {
         let mut ng = NexmarkGenerator {
             rng: StepRng::new(0, 5),
-            config: make_default_config(),
+            config: Config::default(),
         };
 
         let n = ng.next_person_name();
@@ -274,7 +274,7 @@ mod tests {
     fn test_next_email() {
         let mut ng = NexmarkGenerator {
             rng: StepRng::new(0, 5),
-            config: make_default_config(),
+            config: Config::default(),
         };
 
         let e = ng.next_email();
@@ -286,7 +286,7 @@ mod tests {
     fn test_next_credit_card() {
         let mut ng = NexmarkGenerator {
             rng: StepRng::new(0, 5),
-            config: make_default_config(),
+            config: Config::default(),
         };
 
         let e = ng.next_credit_card();

--- a/benches/nexmark/generator/people.rs
+++ b/benches/nexmark/generator/people.rs
@@ -2,12 +2,13 @@
 //!
 //! API based on the equivalent [Nexmark Flink PersonGenerator API](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/model/PersonGenerator.java).
 
+use super::config;
 use super::NexmarkGenerator;
-use crate::config;
-use crate::model::{DateTime, Id, Person};
+use crate::config as nexmark_config;
+use crate::model::{Id, Person};
 use rand::{seq::SliceRandom, Rng};
 use std::cmp::min;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 // Keep the number of states small so that the example queries will find
 // results even with a small batch of events.
@@ -51,7 +52,7 @@ impl<R: Rng> NexmarkGenerator<R> {
             credit_card: self.next_credit_card(),
             city: self.next_us_city(),
             state: self.next_us_state(),
-            date_time: DateTime::UNIX_EPOCH + Duration::from_millis(timestamp),
+            date_time: SystemTime::UNIX_EPOCH + Duration::from_millis(timestamp),
             extra: String::new(),
         }
     }
@@ -69,26 +70,26 @@ impl<R: Rng> NexmarkGenerator<R> {
     /// FIRST_PERSON_ID offset, and should really be "offset 0".
     pub fn next_base0_person_id(&mut self, event_id: Id) -> Id {
         let num_people = self.last_base0_person_id(event_id) + 1;
-        let active_people = min(num_people, config::NUM_ACTIVE_PEOPLE);
+        let active_people = min(num_people, self.config.nexmark_config.num_active_people);
         let n = self
             .rng
-            .gen_range(0..(active_people + config::PERSON_ID_LEAD));
+            .gen_range(0..(active_people + nexmark_config::PERSON_ID_LEAD));
         num_people - active_people + n
     }
 
     /// Return the last valid person id (ignoring FIRST_PERSON_ID). Will be the
     /// current person id if due to generate a person.
     pub fn last_base0_person_id(&self, event_id: Id) -> Id {
-        let epoch = event_id / self.config.total_proportion();
-        let mut offset = event_id % self.config.total_proportion();
+        let epoch = event_id / self.config.nexmark_config.total_proportion();
+        let mut offset = event_id % self.config.nexmark_config.total_proportion();
 
-        if offset >= self.config.person_proportion {
+        if offset >= self.config.nexmark_config.person_proportion {
             // About to generate an auction or bid.
             // Go back to the last person generated in this epoch.
-            offset = self.config.person_proportion - 1;
+            offset = self.config.nexmark_config.person_proportion - 1;
         }
         // About to generate a person.
-        epoch * self.config.person_proportion + offset
+        epoch * self.config.nexmark_config.person_proportion + offset
     }
 
     // Return a random US state.
@@ -130,16 +131,9 @@ impl<R: Rng> NexmarkGenerator<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::Config;
+    use crate::config::{tests::make_default_nexmark_config, Config as NexmarkConfig};
+    use config::{tests::make_default_config, Config};
     use rand::rngs::mock::StepRng;
-
-    fn make_default_config() -> Config {
-        Config {
-            person_proportion: 1,
-            auction_proportion: 3,
-            bid_proportion: 46,
-        }
-    }
 
     #[test]
     fn test_next_person() {
@@ -159,7 +153,7 @@ mod tests {
                 credit_card: "0000 0000 0000 0000".into(),
                 city: "Phoenix".into(),
                 state: "AZ".into(),
-                date_time: DateTime::UNIX_EPOCH + Duration::from_millis(1_000_000_000_000),
+                date_time: SystemTime::UNIX_EPOCH + Duration::from_millis(1_000_000_000_000),
                 extra: String::new(),
             }
         );
@@ -224,7 +218,10 @@ mod tests {
         let ng = NexmarkGenerator {
             rng: StepRng::new(0, 5),
             config: Config {
-                bid_proportion: 21,
+                nexmark_config: NexmarkConfig {
+                    bid_proportion: 21,
+                    ..make_default_nexmark_config()
+                },
                 ..make_default_config()
             },
         };

--- a/benches/nexmark/generator/strings.rs
+++ b/benches/nexmark/generator/strings.rs
@@ -20,16 +20,16 @@ impl<R: Rng> NexmarkGenerator<R> {
 
 #[cfg(test)]
 mod tests {
+    //TODO
+    use super::super::config::tests::make_default_config;
     use super::*;
-    use crate::config::Config;
-    use clap::Parser;
     use rand::rngs::mock::StepRng;
 
     #[test]
     fn next_string_length() {
         let mut ng = NexmarkGenerator {
             rng: StepRng::new(0, 5),
-            config: Config::parse(),
+            config: make_default_config(),
         };
 
         let s = ng.next_string(5);

--- a/benches/nexmark/generator/strings.rs
+++ b/benches/nexmark/generator/strings.rs
@@ -20,9 +20,8 @@ impl<R: Rng> NexmarkGenerator<R> {
 
 #[cfg(test)]
 mod tests {
-    //TODO
-    use super::super::config::tests::make_default_config;
     use super::*;
+    use crate::generator::config::tests::make_default_config;
     use rand::rngs::mock::StepRng;
 
     #[test]

--- a/benches/nexmark/generator/strings.rs
+++ b/benches/nexmark/generator/strings.rs
@@ -21,14 +21,14 @@ impl<R: Rng> NexmarkGenerator<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::generator::config::tests::make_default_config;
+    use crate::generator::config::Config;
     use rand::rngs::mock::StepRng;
 
     #[test]
     fn next_string_length() {
         let mut ng = NexmarkGenerator {
             rng: StepRng::new(0, 5),
-            config: make_default_config(),
+            config: Config::default(),
         };
 
         let s = ng.next_string(5);

--- a/benches/nexmark/model.rs
+++ b/benches/nexmark/model.rs
@@ -4,7 +4,6 @@
 
 use std::time::SystemTime;
 
-// TODO: update to u64.
 pub type Id = usize;
 
 /// The Nexmark Person model based on the [Nexmark Java Person class](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/java/com/github/nexmark/flink/model/Person.java).

--- a/benches/nexmark/model.rs
+++ b/benches/nexmark/model.rs
@@ -2,7 +2,9 @@
 //!
 //! Based on the equivalent [Nexmark Flink Java model classes](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/java/com/github/nexmark/flink/model).
 
-pub type DateTime = std::time::SystemTime;
+use std::time::SystemTime;
+
+// TODO: update to u64.
 pub type Id = usize;
 
 /// The Nexmark Person model based on the [Nexmark Java Person class](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/java/com/github/nexmark/flink/model/Person.java).
@@ -17,7 +19,7 @@ pub struct Person {
     pub credit_card: String,
     pub city: String,
     pub state: String,
-    pub date_time: DateTime,
+    pub date_time: SystemTime,
     pub extra: String,
 }
 
@@ -32,8 +34,8 @@ pub struct Auction {
     pub description: String,
     pub initial_bid: usize,
     pub reserve: usize,
-    pub date_time: DateTime,
-    pub expires: DateTime,
+    pub date_time: SystemTime,
+    pub expires: SystemTime,
     pub seller: Id,
     pub category: Id,
 }
@@ -47,5 +49,5 @@ pub struct Bid {
     pub auction: Id,
     pub bidder: Id,
     pub price: usize,
-    pub date_time: DateTime,
+    pub date_time: SystemTime,
 }


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

This continues the work that began in #101, this time adding the first function required for the Nexmark auction generation (which in turn requires new functions on the config object(s)), again, based closely on the Java implementation.

As part of this change, I also:
- separated out the general nexmark config from the individual generator config (individual in the sense that the original code is structured such that you can run multiple generators with different configs simultaneously), matching the java implementation (I didn't do this in the last PR as it wasn't yet obvious *why* it was separated, but it is now).
- removed the `DateTime` alias of the `std::time::SystemTime` (I'd done this at first as I wasn't sure which time implementation I'd use and wanted to be able to switch it later, but it seems the std system time is sufficient)

Note: I'm adding unit tests for the functions as I create them (which aren't in the original java implementation) mainly to help me ensure my understanding of the functions is correct (as it's not always obvious from the code, at least to me), though I think they're helpful as concise documentation of what the functions do with example values etc.

Next up: the other auction-related generation functionality before finally moving to the bid model generation.