### PR TITLE
[nexmark] Add last_base0_auction_id and next_base0_auction_id.

### DIFF
--- a/benches/nexmark/generator/auctions.rs
+++ b/benches/nexmark/generator/auctions.rs
@@ -11,6 +11,55 @@ use std::{
 };
 
 impl<R: Rng> NexmarkGenerator<R> {
+    /// Return the last valid auction id (ignoring FIRST_AUCTION_ID). Will be
+    /// the current auction id if due to generate an auction.
+    fn last_base0_auction_id(&self, event_id: u64) -> u64 {
+        let mut epoch = event_id / self.config.nexmark_config.total_proportion() as u64;
+        let mut offset = event_id % self.config.nexmark_config.total_proportion() as u64;
+
+        if offset < self.config.nexmark_config.person_proportion as u64 {
+            // About to generate a person.
+            // Go back to the last auction in the last epoch.
+            epoch = match epoch.checked_sub(1) {
+                Some(e) => e,
+                None => return 0,
+            };
+            offset = self.config.nexmark_config.auction_proportion as u64 - 1;
+        } else if offset
+            >= (self.config.nexmark_config.person_proportion
+                + self.config.nexmark_config.auction_proportion) as u64
+        {
+            // About to generate a bid.
+            // Go back to the last auction generated in this epoch.
+            offset = self.config.nexmark_config.auction_proportion as u64 - 1;
+        } else {
+            // About to generate an auction.
+            offset -= self.config.nexmark_config.person_proportion as u64;
+        }
+        epoch * self.config.nexmark_config.auction_proportion as u64 + offset
+    }
+
+    /// Return a random auction id (base 0).
+    fn next_base0_auction_id(&mut self, next_event_id: u64) -> u64 {
+        // Choose a random auction for any of those which are likely to still be in
+        // flight, plus a few 'leads'.
+        // Note that ideally we'd track non-expired auctions exactly, but that state
+        // is difficult to split.
+        let min_auction = cmp::max(
+            match self
+                .last_base0_auction_id(next_event_id)
+                .checked_sub(self.config.nexmark_config.num_in_flight_auctions as u64)
+            {
+                Some(e) => e,
+                None => 0,
+            },
+            0,
+        );
+        let max_auction = self.last_base0_auction_id(next_event_id);
+        min_auction + self.rng.gen_range(0..(max_auction - min_auction + 1))
+    }
+
+    /// Return a random time delay, in milliseconds, for length of auctions.
     fn next_auction_length_ms(
         &mut self,
         event_count_so_far: usize,
@@ -45,6 +94,62 @@ mod tests {
     use super::*;
     use crate::generator::config::Config;
     use rand::rngs::mock::StepRng;
+    use rstest::rstest;
+
+    #[rstest]
+    // By default an epoch is 50 events and event 0 is a person, events 1, 2 and 3
+    // are auctions, then 4-49 are bids.
+    // Epoch 0 emits the (zero-based) auctions 0, 1 and 2.
+    #[case(0, 0)]
+    #[case(1, 0)]
+    #[case(2, 1)]
+    #[case(3, 2)]
+    #[case(23, 2)]
+    #[case(49, 2)]
+    // Epoch 1: When we're about to generate a person, we return the last auction from
+    // the previous epoch.
+    #[case(50*1, 2)] // About to generate a person again
+    #[case(50*1 + 1, 3)]
+    #[case(50*1 + 2, 4)]
+    #[case(50*1 + 3, 5)]
+    #[case(50*1 + 23, 5)]
+    // After the 1st person is generated in the 33rd epoch, we have 99 auctions.
+    #[case(50*33 + 1, 99)]
+    fn test_last_base0_auction_id(#[case] event_id: u64, #[case] expected_id: u64) {
+        let ng = NexmarkGenerator {
+            rng: StepRng::new(0, 1),
+            config: Config::default(),
+        };
+
+        let last_auction_id = ng.last_base0_auction_id(event_id);
+
+        assert_eq!(last_auction_id, expected_id);
+    }
+
+    #[rstest]
+    // Since the default number of inflight auctions is 100, we need to get above an event
+    // id of 50*33 events (ie. 33 epochs, since there are 3 auction events per epoch)
+    #[case(2, 0)]
+    #[case(50*33 + 1, 0)] // last_base0_auction_id is 33*3 + 1 - 1 = 99
+    #[case(50*33 + 2, 0)] // last_base0_auction_id is 33*3 + 2 - 1 = 100
+    #[case(50*33 + 3, 1)] // last_base0_auction_id is 33*3 + 3 - 1 = 101
+    #[case(50*34 + 0, 1)] // last_base0_auction_id is 34*3 + 0 - 1 = 101
+    #[case(50*34 + 1, 2)] // last_base0_auction_id is 34*3 + 1 - 1 = 102
+    #[case(50*34 + 2, 3)] // last_base0_auction_id is 34*3 + 2 - 1 = 103
+    #[case(50*34 + 3, 4)] // last_base0_auction_id is 34*3 + 3 - 1 = 104
+    #[case(50*34 + 49, 4)] // last_base0_auction_id is still 104 (all extra are bids)
+    #[case(50*35 + 0, 4)] // last_base0_auction_id is 35*3 + 0 - 1 = 104
+    #[case(50*35 + 1, 5)] // last_base0_auction_id is 35*3 + 1 - 1 = 105
+    fn test_next_base0_auction_id(#[case] next_event_id: u64, #[case] expected_id: u64) {
+        let mut ng = NexmarkGenerator {
+            rng: StepRng::new(0, 1),
+            config: Config::default(),
+        };
+
+        let next_auction_id = ng.next_base0_auction_id(next_event_id);
+
+        assert_eq!(next_auction_id, expected_id);
+    }
 
     #[test]
     fn test_next_auction_length_ms() {


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

Follows #108 , adding two more of the auction generation helper functions. Pushing separately as it took me quite a while to understand what they are actually doing, so assume it'll be similar for reviewing, though hopefully the unit test-cases that I've added make it clearer.

Next up: the actual next_auction method.