### PR TITLE
[nexmark] Add next_auction generator to the nexmark data source.

### DIFF
--- a/benches/nexmark/config.rs
+++ b/benches/nexmark/config.rs
@@ -21,9 +21,28 @@ pub struct Config {
     #[clap(long, default_value = "46", env = "NEXMARK_BID_PROPORTION")]
     pub bid_proportion: usize,
 
-    /// Specify the proportion of events that will be new people.
-    #[clap(long, default_value = "1", env = "NEXMARK_PERSON_PROPORTION")]
-    pub person_proportion: usize,
+    /// Initial overall event rate (per second).
+    #[clap(long, default_value = "10000", env = "NEXMARK_FIRST_EVENT_RATE")]
+    pub first_event_rate: usize,
+
+    /// Ration of auctions for 'hot' sellers compared to all other people.
+    #[clap(long, default_value = "4", env = "NEXMARK_HOT_SELLERS_RATIO")]
+    pub hot_sellers_ratio: usize,
+
+    /// Maximum number of people to consider as active for placing auctions or
+    /// bids.
+    #[clap(long, default_value = "1000", env = "NEXMARK_NUM_ACTIVE_PEOPLE")]
+    pub num_active_people: usize,
+
+    /// Number of event generators to use. Each generates events in its own
+    /// timeline.
+    #[clap(long, default_value = "1", env = "NEXMARK_NUM_EVENT_GENERATORS")]
+    pub num_event_generators: usize,
+
+    /// Average number of auctions which should be inflight at any time, per
+    /// generator.
+    #[clap(long, default_value = "100", env = "NEXMARK_NUM_IN_FLIGHT_AUCTIONS")]
+    pub num_in_flight_auctions: usize,
 
     /// Number of events in out-of-order groups. 1 implies no out-of-order
     /// events. 1000 implies every 1000 events per generator are emitted in
@@ -31,24 +50,9 @@ pub struct Config {
     #[clap(long, default_value = "1", env = "NEXMARK_OUT_OF_ORDER_GROUP_SIZE")]
     pub out_of_order_group_size: usize,
 
-    /// Average number of auctions which should be inflight at any time, per
-    /// generator.
-    #[clap(long, default_value = "100", env = "NEXMARK_NUM_IN_FLIGHT_AUCTIONS")]
-    pub num_in_flight_auctions: usize,
-
-    /// Maximum number of people to consider as active for placing auctions or
-    /// bids.
-    #[clap(long, default_value = "1000", env = "NEXMARK_NUM_ACTIVE_PEOPLE")]
-    pub num_active_people: usize,
-
-    /// Initial overall event rate (per second).
-    #[clap(long, default_value = "10000", env = "NEXMARK_FIRST_EVENT_RATE")]
-    pub first_event_rate: usize,
-
-    /// Number of event generators to use. Each generates events in its own
-    /// timeline.
-    #[clap(long, default_value = "1", env = "NEXMARK_NUM_EVENT_GENERATORS")]
-    pub num_event_generators: usize,
+    /// Specify the proportion of events that will be new people.
+    #[clap(long, default_value = "1", env = "NEXMARK_PERSON_PROPORTION")]
+    pub person_proportion: usize,
 }
 
 /// Implementation of config methods based on the Java implementation at
@@ -64,12 +68,13 @@ impl Default for Config {
         Config {
             auction_proportion: 3,
             bid_proportion: 46,
-            person_proportion: 1,
-            num_in_flight_auctions: 100,
-            num_active_people: 1000,
-            out_of_order_group_size: 1,
             first_event_rate: 10_000,
+            hot_sellers_ratio: 4,
+            num_active_people: 1000,
             num_event_generators: 1,
+            num_in_flight_auctions: 100,
+            out_of_order_group_size: 1,
+            person_proportion: 1,
         }
     }
 }

--- a/benches/nexmark/generator/mod.rs
+++ b/benches/nexmark/generator/mod.rs
@@ -8,6 +8,7 @@ use rand::Rng;
 mod auctions;
 mod config;
 mod people;
+mod price;
 mod strings;
 
 pub struct NexmarkGenerator<R: Rng> {

--- a/benches/nexmark/generator/price.rs
+++ b/benches/nexmark/generator/price.rs
@@ -1,0 +1,31 @@
+//! Generates prices for the Nexmark streaming data source.
+//!
+//! API based on the equivalent [Nexmark Flink PriceGenerator API](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/model/PriceGenerator.java).
+
+use super::NexmarkGenerator;
+use rand::Rng;
+
+impl<R: Rng> NexmarkGenerator<R> {
+    pub fn next_price(&mut self) -> usize {
+        (10.0_f32.powf(self.rng.gen_range(0.0..1.0) * 6.0) * 100.0).ceil() as usize
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::generator::config::Config;
+    use rand::rngs::mock::StepRng;
+
+    #[test]
+    fn test_next_price() {
+        let mut ng = NexmarkGenerator {
+            rng: StepRng::new(0, 1),
+            config: Config::default(),
+        };
+
+        let p = ng.next_price();
+
+        assert_eq!(p, 10_usize.pow(0) * 100);
+    }
+}

--- a/benches/nexmark/model.rs
+++ b/benches/nexmark/model.rs
@@ -4,15 +4,13 @@
 
 use std::time::SystemTime;
 
-pub type Id = usize;
-
 /// The Nexmark Person model based on the [Nexmark Java Person class](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/java/com/github/nexmark/flink/model/Person.java).
 ///
 /// Note that Rust can simply derive the equivalent methods on the Java
 /// class.
 #[derive(Debug, Eq, Hash, PartialEq)]
 pub struct Person {
-    pub id: Id,
+    pub id: u64,
     pub name: String,
     pub email_address: String,
     pub credit_card: String,
@@ -28,15 +26,15 @@ pub struct Person {
 /// class.
 #[derive(Debug, Eq, Hash, PartialEq)]
 pub struct Auction {
-    pub id: Id,
+    pub id: u64,
     pub item_name: String,
     pub description: String,
     pub initial_bid: usize,
     pub reserve: usize,
     pub date_time: SystemTime,
     pub expires: SystemTime,
-    pub seller: Id,
-    pub category: Id,
+    pub seller: u64,
+    pub category: usize,
 }
 
 /// The Nexmark Bid model based on the [Nexmark Java Bid class](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/java/com/github/nexmark/flink/model/Bid.java).
@@ -45,8 +43,8 @@ pub struct Auction {
 /// class.
 #[derive(Debug, Eq, Hash, PartialEq)]
 pub struct Bid {
-    pub auction: Id,
-    pub bidder: Id,
+    pub auction: u64,
+    pub bidder: u64,
     pub price: usize,
     pub date_time: SystemTime,
 }


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

Follows #109 and adds the `next_auction` generator function for the Nexmark data source, which depends on the new `next_price` generator function (also direct from the java implementation).

A couple of fly-by fixes included in this PR:
- Just ordered the Nexmark config fields alphabetically as they grow.
- Removed the `model::Id` type alias since it seems u64 makes sense for the generated event ids.

Next up: bid generator.