### PR TITLE
[nexmark] Add supporting functions for the bids generator.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
+name = "async-trait"
+version = "0.1.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async_once"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce4f10ea3abcd6617873bae9f91d1c5332b4a778bd9ce34d0cd517474c1de82"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,6 +156,43 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "cached"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d9447b2a367383a918fbbe62f6892da68000170c7331003d132b4805b63214"
+dependencies = [
+ "async-trait",
+ "async_once",
+ "cached_proc_macro",
+ "cached_proc_macro_types",
+ "futures",
+ "hashbrown",
+ "instant",
+ "lazy_static",
+ "once_cell",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "cached_proc_macro"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4797df465f7409b55bab9ccd1edbf1d279ffdf763772c2804b96740ee72f3b82"
+dependencies = [
+ "cached_proc_macro_types",
+ "darling",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cached_proc_macro_types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a4f925191b4367301851c6d99b09890311d74b0d43f274c0b34c86d308a3663"
 
 [[package]]
 name = "cc"
@@ -280,6 +334,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,6 +385,7 @@ name = "dbsp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "cached",
  "clap",
  "crossbeam-utils",
  "csv",
@@ -308,6 +398,7 @@ dependencies = [
  "petgraph",
  "priority-queue",
  "rand",
+ "regex",
  "rstest",
  "serde",
  "textwrap",
@@ -362,6 +453,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
@@ -522,6 +619,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "impl-trait-for-tuples"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +643,15 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -674,6 +786,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -866,9 +988,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -883,9 +1005,9 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "rstest"
@@ -1052,6 +1174,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "time"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1114,6 +1256,30 @@ name = "timely_logging"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9046af28827ac831479d245eb8afd9522599a3cbb22d6c42a82cb9e4ccdf858"
+
+[[package]]
+name = "tokio"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57aec3cfa4c296db7255446efb4928a6be304b431a806216105542a67b6ca82e"
+dependencies = [
+ "autocfg",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "typedmap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,7 +398,6 @@ dependencies = [
  "petgraph",
  "priority-queue",
  "rand",
- "regex",
  "rstest",
  "serde",
  "textwrap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ anyhow = "1.0.57"
 rand = "0.8"
 clap = { version = "3.2", features = ["derive", "env"] }
 rstest = "0.15"
+cached = "0.36"
+regex = "1.6"
 
 [[bench]]
 name = "galen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ rand = "0.8"
 clap = { version = "3.2", features = ["derive", "env"] }
 rstest = "0.15"
 cached = "0.36"
-regex = "1.6"
 
 [[bench]]
 name = "galen"

--- a/benches/nexmark/generator/auctions.rs
+++ b/benches/nexmark/generator/auctions.rs
@@ -140,16 +140,12 @@ impl<R: Rng> NexmarkGenerator<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::generator::config::Config;
-    use rand::rngs::mock::StepRng;
+    use crate::generator::tests::make_test_generator;
     use rstest::rstest;
 
     #[test]
     fn test_next_auction() {
-        let mut ng = NexmarkGenerator {
-            rng: StepRng::new(0, 1),
-            config: Config::default(),
-        };
+        let mut ng = make_test_generator();
 
         let auction = ng.next_auction(0, 0, 0).unwrap();
 
@@ -189,10 +185,7 @@ mod tests {
     // After the 1st person is generated in the 33rd epoch, we have 99 auctions.
     #[case(50*33 + 1, 99)]
     fn test_last_base0_auction_id(#[case] event_id: u64, #[case] expected_id: u64) {
-        let ng = NexmarkGenerator {
-            rng: StepRng::new(0, 1),
-            config: Config::default(),
-        };
+        let ng = make_test_generator();
 
         let last_auction_id = ng.last_base0_auction_id(event_id);
 
@@ -214,10 +207,7 @@ mod tests {
     #[case(50*35 + 0, 4)] // last_base0_auction_id is 35*3 + 0 - 1 = 104
     #[case(50*35 + 1, 5)] // last_base0_auction_id is 35*3 + 1 - 1 = 105
     fn test_next_base0_auction_id(#[case] next_event_id: u64, #[case] expected_id: u64) {
-        let mut ng = NexmarkGenerator {
-            rng: StepRng::new(0, 1),
-            config: Config::default(),
-        };
+        let mut ng = make_test_generator();
 
         let next_auction_id = ng.next_base0_auction_id(next_event_id);
 
@@ -226,10 +216,7 @@ mod tests {
 
     #[test]
     fn test_next_auction_length_ms() {
-        let mut ng = NexmarkGenerator {
-            rng: StepRng::new(0, 5),
-            config: Config::default(),
-        };
+        let mut ng = make_test_generator();
 
         let len_ms = ng
             .next_auction_length_ms(0, SystemTime::UNIX_EPOCH)

--- a/benches/nexmark/generator/auctions.rs
+++ b/benches/nexmark/generator/auctions.rs
@@ -1,4 +1,4 @@
-//! Generates people for the Nexmark streaming data source.
+//! Generates auctions for the Nexmark streaming data source.
 //!
 //! API based on the equivalent [Nexmark Flink PersonGenerator API](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/model/AuctionGenerator.java).
 

--- a/benches/nexmark/generator/bids.rs
+++ b/benches/nexmark/generator/bids.rs
@@ -1,0 +1,99 @@
+//! Generates bids for the Nexmark streaming data source.
+//!
+//! API based on the equivalent [Nexmark Flink PersonGenerator API](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/model/BidGenerator.java).
+use super::strings::next_string;
+use cached::{proc_macro::cached, SizedCache};
+use rand::{thread_rng, Rng};
+
+const CHANNELS_NUMBER: usize = 10_000;
+
+const BASE_URL_PATH_LENGTH: usize = 5;
+
+// Similar to the Java implementation, the cached version of
+// `get_new_channel_instance` needs to create its own Rng, as it's not currently
+// possible to pass a generic Rng in while using the cached macro.
+#[cached(
+    type = "SizedCache<usize, (String, String)>",
+    create = "{ SizedCache::with_size(CHANNELS_NUMBER) }"
+)]
+fn get_new_channel_instance(channel_number: usize) -> (String, String) {
+    let mut rng = thread_rng();
+    let mut url = get_base_url(&mut rng);
+    // Just following the Java implementation: 1 in 10 chance that
+    // the URL is returned as is, otherwise a channel_id query param is added to the
+    // URL. Also following the Java implementation which uses `Integer.reverse` to
+    // get a deterministic channel id.
+    url = match rng.gen_range(0..10) {
+        9 => url,
+        _ => format!("{}&channel_id={}", url, channel_number.reverse_bits()),
+    };
+
+    (format!("channel-{}", channel_number), url)
+}
+
+fn get_base_url<R: Rng>(rng: &mut R) -> String {
+    format!(
+        "https://www.nexmark.com/{}/item.htm?query=1",
+        next_string(rng, BASE_URL_PATH_LENGTH)
+    )
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use rand::rngs::mock::StepRng;
+    use regex::Regex;
+
+    #[test]
+    fn test_get_base_url() {
+        let mut rng = StepRng::new(0, 1);
+        assert_eq!(
+            get_base_url(&mut rng),
+            String::from("https://www.nexmark.com/AAA/item.htm?query=1")
+        );
+    }
+
+    #[test]
+    fn test_get_new_channel_instance_cached() {
+        let channel = get_new_channel_instance(1234);
+        let re = Regex::new(
+            r"^https://www.nexmark.com/(\w+)/item.htm\?query=1(&channel_id=5413326752099336192)?$",
+        )
+        .unwrap();
+
+        assert_eq!(channel.0, "channel-1234");
+
+        assert!(
+            re.is_match(&channel.1),
+            "{} did not match {}",
+            channel.1,
+            re
+        );
+
+        // Ensure the length of the captured base path is correct.
+        let caps = re.captures(&channel.1).unwrap();
+
+        // Three captures - first is the complete string, second is the random channel
+        // URL path and the third is the optional channel id query param.
+        // The random URL path which should be between 3 and 5 characters.
+        assert_eq!(caps.len(), 3);
+        let url_path = caps.get(1).unwrap().as_str();
+        assert!(
+            match url_path.len() {
+                3..=5 => true,
+                _ => false,
+            },
+            "got: {}, want: 3..=5",
+            url_path.len()
+        );
+
+        // Finally, since the function is using a memory cache, the same result
+        // should be returned on subsequent calls for the same channel number.
+        let channel_cached = get_new_channel_instance(1234);
+        assert_eq!(
+            channel.1, channel_cached.1,
+            "got: {}, want: {}",
+            channel_cached.1, channel.1
+        );
+    }
+}

--- a/benches/nexmark/generator/config.rs
+++ b/benches/nexmark/generator/config.rs
@@ -1,4 +1,4 @@
-use super::super::config::Config as NexmarkConfig;
+use crate::config::Config as NexmarkConfig;
 use std::time::{Duration, SystemTime};
 
 // We start the ids at specific values to help ensure the queries find a match

--- a/benches/nexmark/generator/mod.rs
+++ b/benches/nexmark/generator/mod.rs
@@ -3,6 +3,7 @@
 //! Based on the equivalent [Nexmark Flink generator API](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/java/com/github/nexmark/flink/generator).
 
 use self::config::Config;
+use cached::SizedCache;
 use rand::Rng;
 
 mod auctions;
@@ -15,4 +16,20 @@ mod strings;
 pub struct NexmarkGenerator<R: Rng> {
     config: Config,
     rng: R,
+    bid_channel_cache: SizedCache<usize, (String, String)>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bids::CHANNELS_NUMBER;
+    use rand::rngs::mock::StepRng;
+
+    pub fn make_test_generator() -> NexmarkGenerator<StepRng> {
+        NexmarkGenerator {
+            config: Config::default(),
+            rng: StepRng::new(0, 1),
+            bid_channel_cache: SizedCache::with_size(CHANNELS_NUMBER),
+        }
+    }
 }

--- a/benches/nexmark/generator/mod.rs
+++ b/benches/nexmark/generator/mod.rs
@@ -6,6 +6,7 @@ use self::config::Config;
 use rand::Rng;
 
 mod auctions;
+mod bids;
 mod config;
 mod people;
 mod price;

--- a/benches/nexmark/generator/people.rs
+++ b/benches/nexmark/generator/people.rs
@@ -137,16 +137,11 @@ impl<R: Rng> NexmarkGenerator<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::Config as NexmarkConfig;
-    use config::Config;
-    use rand::rngs::mock::StepRng;
+    use crate::generator::tests::make_test_generator;
 
     #[test]
     fn test_next_person() {
-        let mut ng = NexmarkGenerator {
-            rng: StepRng::new(0, 5),
-            config: Config::default(),
-        };
+        let mut ng = make_test_generator();
 
         let p = ng.next_person(105, 1_000_000_000_000);
 
@@ -167,10 +162,7 @@ mod tests {
 
     #[test]
     fn test_next_base0_person_id() {
-        let mut ng = NexmarkGenerator {
-            rng: StepRng::new(0, 5),
-            config: Config::default(),
-        };
+        let mut ng = make_test_generator();
 
         // When one more than the last person id is less than the configured
         // active people (1000), the id returned is a random id from one of
@@ -199,10 +191,7 @@ mod tests {
 
     #[test]
     fn test_last_base0_person_id_default() {
-        let ng = NexmarkGenerator {
-            rng: StepRng::new(0, 5),
-            config: Config::default(),
-        };
+        let ng = make_test_generator();
 
         // With the default config, the first 50 events will only include one
         // person
@@ -221,16 +210,8 @@ mod tests {
         // Set the configured bid proportion to 21,
         // which together with the other defaults for person and auction
         // proportion, makes the total 25.
-        let ng = NexmarkGenerator {
-            rng: StepRng::new(0, 5),
-            config: Config {
-                nexmark_config: NexmarkConfig {
-                    bid_proportion: 21,
-                    ..NexmarkConfig::default()
-                },
-                ..Config::default()
-            },
-        };
+        let mut ng = make_test_generator();
+        ng.config.nexmark_config.bid_proportion = 21;
 
         // With the total proportion at 25, there will be a new person
         // at every 25th event.
@@ -242,10 +223,7 @@ mod tests {
 
     #[test]
     fn test_next_us_state() {
-        let mut ng = NexmarkGenerator {
-            rng: StepRng::new(0, 5),
-            config: Config::default(),
-        };
+        let mut ng = make_test_generator();
 
         let s = ng.next_us_state();
 
@@ -254,10 +232,7 @@ mod tests {
 
     #[test]
     fn test_next_us_city() {
-        let mut ng = NexmarkGenerator {
-            rng: StepRng::new(0, 5),
-            config: Config::default(),
-        };
+        let mut ng = make_test_generator();
 
         let c = ng.next_us_city();
 
@@ -266,10 +241,7 @@ mod tests {
 
     #[test]
     fn test_next_person_name() {
-        let mut ng = NexmarkGenerator {
-            rng: StepRng::new(0, 5),
-            config: Config::default(),
-        };
+        let mut ng = make_test_generator();
 
         let n = ng.next_person_name();
 
@@ -278,10 +250,7 @@ mod tests {
 
     #[test]
     fn test_next_email() {
-        let mut ng = NexmarkGenerator {
-            rng: StepRng::new(0, 5),
-            config: Config::default(),
-        };
+        let mut ng = make_test_generator();
 
         let e = ng.next_email();
 
@@ -290,10 +259,7 @@ mod tests {
 
     #[test]
     fn test_next_credit_card() {
-        let mut ng = NexmarkGenerator {
-            rng: StepRng::new(0, 5),
-            config: Config::default(),
-        };
+        let mut ng = make_test_generator();
 
         let e = ng.next_credit_card();
 

--- a/benches/nexmark/generator/price.rs
+++ b/benches/nexmark/generator/price.rs
@@ -13,16 +13,11 @@ impl<R: Rng> NexmarkGenerator<R> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::generator::config::Config;
-    use rand::rngs::mock::StepRng;
+    use crate::generator::tests::make_test_generator;
 
     #[test]
     fn test_next_price() {
-        let mut ng = NexmarkGenerator {
-            rng: StepRng::new(0, 1),
-            config: Config::default(),
-        };
+        let mut ng = make_test_generator();
 
         let p = ng.next_price();
 

--- a/benches/nexmark/generator/strings.rs
+++ b/benches/nexmark/generator/strings.rs
@@ -7,14 +7,24 @@ use rand::{distributions::Alphanumeric, Rng};
 
 const MIN_STRING_LENGTH: usize = 3;
 
+/// Return a random string of up to `max_length`.
+pub(super) fn next_string<R: Rng>(rng: &mut R, max_length: usize) -> String {
+    let len = rng.gen_range(MIN_STRING_LENGTH..=max_length);
+    rng.sample_iter(&Alphanumeric)
+        .take(len)
+        .map(char::from)
+        .collect()
+}
+
 impl<R: Rng> NexmarkGenerator<R> {
+    /// Return a random string of up to `max_length`.
+    ///
+    /// Note: The original java implementation selects from lower-case letters
+    /// only adds a special spacer char with a 1 in 13 chance (' ' by default)
+    /// If both are necessary, we can update to a less optimized version, but
+    /// otherwise it's simpler to use the Alphanumeric distribution.
     pub fn next_string(&mut self, max_length: usize) -> String {
-        let len = self.rng.gen_range(MIN_STRING_LENGTH..=max_length);
-        (&mut self.rng)
-            .sample_iter(&Alphanumeric)
-            .take(len)
-            .map(char::from)
-            .collect()
+        next_string(&mut self.rng, max_length)
     }
 }
 

--- a/benches/nexmark/generator/strings.rs
+++ b/benches/nexmark/generator/strings.rs
@@ -3,17 +3,14 @@
 //! API based on the equivalent [Nexmark Flink StringsGenerator API](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/model/StringsGenerator.java).
 
 use super::NexmarkGenerator;
-use rand::{distributions::Alphanumeric, Rng};
+use rand::{distributions::Alphanumeric, distributions::DistString, Rng};
 
 const MIN_STRING_LENGTH: usize = 3;
 
 /// Return a random string of up to `max_length`.
 pub(super) fn next_string<R: Rng>(rng: &mut R, max_length: usize) -> String {
     let len = rng.gen_range(MIN_STRING_LENGTH..=max_length);
-    rng.sample_iter(&Alphanumeric)
-        .take(len)
-        .map(char::from)
-        .collect()
+    Alphanumeric.sample_string(rng, len)
 }
 
 impl<R: Rng> NexmarkGenerator<R> {
@@ -30,16 +27,11 @@ impl<R: Rng> NexmarkGenerator<R> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::generator::config::Config;
-    use rand::rngs::mock::StepRng;
+    use crate::generator::tests::make_test_generator;
 
     #[test]
     fn next_string_length() {
-        let mut ng = NexmarkGenerator {
-            rng: StepRng::new(0, 5),
-            config: Config::default(),
-        };
+        let mut ng = make_test_generator();
 
         let s = ng.next_string(5);
 


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

Following #110, this PR adds the supporting functions for generating a bid.

The main difference in this PR is that, following the Java implementation, I've used an in-memory cache for the function that generates a new channel URL - `get_new_channel_instance` - and, similar to the Java implementation, I'm not able to cache a function with a generic trait (`Rng`). So the function itself creates a `thread_local` `Rng` which means that the test has to ensure consistent and accurate test results while using a real Rng.

See what you think. 

Next PR will add the `next_bid` implementation to the `NexmarkGenerator` struct, just like the other models.