### PR TITLE
[nexmark] Add implementation of next_bid for nexmark data source.

### DIFF
--- a/benches/nexmark/config.rs
+++ b/benches/nexmark/config.rs
@@ -25,6 +25,14 @@ pub struct Config {
     #[clap(long, default_value = "10000", env = "NEXMARK_FIRST_EVENT_RATE")]
     pub first_event_rate: usize,
 
+    /// Ratio of bids to 'hot' auctions compared to all other auctions.
+    #[clap(long, default_value = "2", env = "NEXMARK_HOT_AUCTION_RATIO")]
+    pub hot_auction_ratio: usize,
+
+    /// Ratio of bids for 'hot' bidders compared to all other people.
+    #[clap(long, default_value = "4", env = "NEXMARK_HOT_BIDDERS_RATIO")]
+    pub hot_bidders_ratio: usize,
+
     /// Ration of auctions for 'hot' sellers compared to all other people.
     #[clap(long, default_value = "4", env = "NEXMARK_HOT_SELLERS_RATIO")]
     pub hot_sellers_ratio: usize,
@@ -69,6 +77,8 @@ impl Default for Config {
             auction_proportion: 3,
             bid_proportion: 46,
             first_event_rate: 10_000,
+            hot_auction_ratio: 2,
+            hot_bidders_ratio: 4,
             hot_sellers_ratio: 4,
             num_active_people: 1000,
             num_event_generators: 1,

--- a/benches/nexmark/generator/auctions.rs
+++ b/benches/nexmark/generator/auctions.rs
@@ -69,7 +69,7 @@ impl<R: Rng> NexmarkGenerator<R> {
 
     /// Return the last valid auction id (ignoring FIRST_AUCTION_ID). Will be
     /// the current auction id if due to generate an auction.
-    fn last_base0_auction_id(&self, event_id: u64) -> u64 {
+    pub fn last_base0_auction_id(&self, event_id: u64) -> u64 {
         let mut epoch = event_id / self.config.nexmark_config.total_proportion() as u64;
         let mut offset = event_id % self.config.nexmark_config.total_proportion() as u64;
         let person_proportion = self.config.nexmark_config.person_proportion as u64;
@@ -95,7 +95,7 @@ impl<R: Rng> NexmarkGenerator<R> {
     }
 
     /// Return a random auction id (base 0).
-    fn next_base0_auction_id(&mut self, next_event_id: u64) -> u64 {
+    pub fn next_base0_auction_id(&mut self, next_event_id: u64) -> u64 {
         // Choose a random auction for any of those which are likely to still be in
         // flight, plus a few 'leads'.
         // Note that ideally we'd track non-expired auctions exactly, but that state

--- a/benches/nexmark/generator/bids.rs
+++ b/benches/nexmark/generator/bids.rs
@@ -1,13 +1,29 @@
 //! Generates bids for the Nexmark streaming data source.
 //!
 //! API based on the equivalent [Nexmark Flink PersonGenerator API](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/model/BidGenerator.java).
+use super::config::{FIRST_AUCTION_ID, FIRST_PERSON_ID};
 use super::strings::next_string;
 use super::NexmarkGenerator;
+use crate::model::Bid;
 use cached::Cached;
 use rand::Rng;
+use std::time::{Duration, SystemTime};
+
+/// Fraction of people/auctions which may be 'hot' sellers/bidders/auctions are
+/// 1 over these values.
+const HOT_AUCTON_RATIO: usize = 100;
+const HOT_BIDDER_RATIO: usize = 100;
+const HOT_CHANNELS_RATIO: usize = 100;
 
 pub const CHANNELS_NUMBER: usize = 10_000;
 
+const HOT_CHANNELS: [&str; 4] = ["Google", "Facebook", "Baidu", "Apple"];
+const HOT_URLS: [&str; 4] = [
+    "https://www.nexmark.com/googl/item.htm?query=1",
+    "https://www.nexmark.com/meta/item.htm?query=1",
+    "https://www.nexmark.com/bidu/item.htm?query=1",
+    "https://www.nexmark.com/aapl/item.htm?query=1",
+];
 const BASE_URL_PATH_LENGTH: usize = 5;
 
 impl<R: Rng> NexmarkGenerator<R> {
@@ -40,11 +56,93 @@ fn get_base_url<R: Rng>(rng: &mut R) -> String {
     )
 }
 
+impl<R: Rng> NexmarkGenerator<R> {
+    fn next_bid(&mut self, event_id: u64, timestamp: u64) -> Bid {
+        let auction = match self
+            .rng
+            .gen_range(0..self.config.nexmark_config.hot_auction_ratio)
+        {
+            0 => self.next_base0_auction_id(event_id),
+            _ => {
+                // Choose the first auction in the batch of last HOT_AUCTION_RATIO auctions.
+                (self.last_base0_auction_id(event_id) / HOT_AUCTON_RATIO as u64)
+                    * HOT_AUCTON_RATIO as u64
+            }
+        } + FIRST_AUCTION_ID as u64;
+
+        let bidder = match self
+            .rng
+            .gen_range(0..self.config.nexmark_config.hot_bidders_ratio)
+        {
+            0 => self.next_base0_person_id(event_id),
+            _ => {
+                // Choose the second person (so hot bidders and hot sellers don't collide) in
+                // the batch of last HOT_BIDDER_RATIO people.
+                (self.last_base0_person_id(event_id) / HOT_BIDDER_RATIO as u64)
+                    * HOT_BIDDER_RATIO as u64
+                    + 1
+            }
+        } + FIRST_PERSON_ID as u64;
+
+        let price = self.next_price();
+
+        // NOTE: Shifted the start and finish of the range here simply so that when
+        // testing with the StepRng, we can test the deterministic case where the first
+        // hot channel (Google) is used.
+        let channel_number = self.rng.gen_range(0..CHANNELS_NUMBER);
+        let (channel, url) = match self.rng.gen_range(1..=HOT_CHANNELS_RATIO) {
+            HOT_CHANNELS_RATIO => self.get_new_channel_instance(channel_number),
+            _ => {
+                let hot_index = self.rng.gen_range(0..HOT_CHANNELS.len());
+                (HOT_CHANNELS[hot_index].into(), HOT_URLS[hot_index].into())
+            }
+        };
+
+        Bid {
+            auction,
+            bidder,
+            price,
+            channel,
+            url,
+            date_time: SystemTime::UNIX_EPOCH + Duration::from_millis(timestamp),
+            extra: "".into(),
+        }
+    }
+}
+
 #[cfg(test)]
 pub mod tests {
     use super::*;
     use crate::generator::tests::make_test_generator;
     use rand::rngs::mock::StepRng;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(0, 1_000, 1_000)]
+    #[case(50*34 + 3, 1_004, 1_000)]
+    #[case(50*1500, 5_399, 1_501)]
+    fn test_next_bid(
+        #[case] event_id: u64,
+        #[case] expected_auction_id: u64,
+        #[case] expected_bidder_id: u64,
+    ) {
+        let mut ng = make_test_generator();
+
+        let bid = ng.next_bid(event_id, 1_000_000_000_000);
+
+        assert_eq!(
+            Bid {
+                auction: expected_auction_id,
+                bidder: expected_bidder_id,
+                price: 100,
+                channel: "Google".into(),
+                url: "https://www.nexmark.com/googl/item.htm?query=1".into(),
+                date_time: SystemTime::UNIX_EPOCH + Duration::from_millis(1_000_000_000_000),
+                extra: "".into(),
+            },
+            bid
+        );
+    }
 
     #[test]
     fn test_get_base_url() {

--- a/benches/nexmark/generator/bids.rs
+++ b/benches/nexmark/generator/bids.rs
@@ -105,7 +105,7 @@ impl<R: Rng> NexmarkGenerator<R> {
             channel,
             url,
             date_time: SystemTime::UNIX_EPOCH + Duration::from_millis(timestamp),
-            extra: "".into(),
+            extra: String::new(),
         }
     }
 }
@@ -138,7 +138,7 @@ pub mod tests {
                 channel: "Google".into(),
                 url: "https://www.nexmark.com/googl/item.htm?query=1".into(),
                 date_time: SystemTime::UNIX_EPOCH + Duration::from_millis(1_000_000_000_000),
-                extra: "".into(),
+                extra: String::new(),
             },
             bid
         );

--- a/benches/nexmark/model.rs
+++ b/benches/nexmark/model.rs
@@ -43,8 +43,19 @@ pub struct Auction {
 /// class.
 #[derive(Debug, Eq, Hash, PartialEq)]
 pub struct Bid {
+    /// Id of auction this bid is for.
     pub auction: u64,
+    /// Id of the person bidding in auction.
     pub bidder: u64,
+    /// Price of bid, in cents.
     pub price: usize,
+    /// The channel that introduced this bidding.
+    pub channel: String,
+    /// The url of this [channel].
+    pub url: String,
+    /// Instant at which this bid was made. NOTE: This may be earlier than teh
+    /// system's event time.
     pub date_time: SystemTime,
+    /// Additional arbitrary payload for performance testing.
+    pub extra: String,
 }


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

Follows #112 and adds the `next_bid` generator function with relevant tests.

Spotted a [small issue in upstream Java implementation](https://github.com/nexmark/nexmark/issues/30) while writing the test.

Next up: ~~investigate using the generators in an actual DBSP source.~~ Creating the nexmarkgenerator that emits the events.