### PR TITLE
Switch to simple u64 (matching Java long) for timestamps.

### DIFF
--- a/benches/nexmark/generator/bids.rs
+++ b/benches/nexmark/generator/bids.rs
@@ -7,7 +7,6 @@ use super::NexmarkGenerator;
 use crate::model::Bid;
 use cached::Cached;
 use rand::Rng;
-use std::time::{Duration, SystemTime};
 
 /// Fraction of people/auctions which may be 'hot' sellers/bidders/auctions are
 /// 1 over these values.
@@ -104,7 +103,7 @@ impl<R: Rng> NexmarkGenerator<R> {
             price,
             channel,
             url,
-            date_time: SystemTime::UNIX_EPOCH + Duration::from_millis(timestamp),
+            date_time: timestamp,
             extra: String::new(),
         }
     }
@@ -137,7 +136,7 @@ pub mod tests {
                 price: 100,
                 channel: "Google".into(),
                 url: "https://www.nexmark.com/googl/item.htm?query=1".into(),
-                date_time: SystemTime::UNIX_EPOCH + Duration::from_millis(1_000_000_000_000),
+                date_time: 1_000_000_000_000,
                 extra: String::new(),
             },
             bid

--- a/benches/nexmark/generator/people.rs
+++ b/benches/nexmark/generator/people.rs
@@ -8,7 +8,6 @@ use crate::config as nexmark_config;
 use crate::model::Person;
 use rand::{seq::SliceRandom, Rng};
 use std::cmp::min;
-use std::time::{Duration, SystemTime};
 
 // Keep the number of states small so that the example queries will find
 // results even with a small batch of events.
@@ -53,7 +52,7 @@ impl<R: Rng> NexmarkGenerator<R> {
             credit_card: self.next_credit_card(),
             city: self.next_us_city(),
             state: self.next_us_state(),
-            date_time: SystemTime::UNIX_EPOCH + Duration::from_millis(timestamp),
+            date_time: timestamp,
             extra: String::new(),
         }
     }
@@ -154,7 +153,7 @@ mod tests {
                 credit_card: "0000 0000 0000 0000".into(),
                 city: "Phoenix".into(),
                 state: "AZ".into(),
-                date_time: SystemTime::UNIX_EPOCH + Duration::from_millis(1_000_000_000_000),
+                date_time: 1_000_000_000_000,
                 extra: String::new(),
             }
         );

--- a/benches/nexmark/model.rs
+++ b/benches/nexmark/model.rs
@@ -2,8 +2,6 @@
 //!
 //! Based on the equivalent [Nexmark Flink Java model classes](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/java/com/github/nexmark/flink/model).
 
-use std::time::SystemTime;
-
 /// The Nexmark Person model based on the [Nexmark Java Person class](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/java/com/github/nexmark/flink/model/Person.java).
 ///
 /// Note that Rust can simply derive the equivalent methods on the Java
@@ -16,7 +14,7 @@ pub struct Person {
     pub credit_card: String,
     pub city: String,
     pub state: String,
-    pub date_time: SystemTime,
+    pub date_time: u64,
     pub extra: String,
 }
 
@@ -31,8 +29,8 @@ pub struct Auction {
     pub description: String,
     pub initial_bid: usize,
     pub reserve: usize,
-    pub date_time: SystemTime,
-    pub expires: SystemTime,
+    pub date_time: u64,
+    pub expires: u64,
     pub seller: u64,
     pub category: usize,
 }
@@ -55,7 +53,7 @@ pub struct Bid {
     pub url: String,
     /// Instant at which this bid was made. NOTE: This may be earlier than teh
     /// system's event time.
-    pub date_time: SystemTime,
+    pub date_time: u64,
     /// Additional arbitrary payload for performance testing.
     pub extra: String,
 }


### PR DESCRIPTION
While implementing the generation (in a subsequent branch) I realised that the models *need* to use `u64` (equivalent of the Java `long`) for timestamps to have any chance of maintaining similar data for processing.

Rather than polluting the generator branch, I've done this prequel branch with a single, focused intent.

Leaving as a draft until I push the generator branch.