### PR TITLE
Add initial DBSP Nexmark source.

### DIFF
--- a/benches/nexmark/generator/mod.rs
+++ b/benches/nexmark/generator/mod.rs
@@ -12,7 +12,7 @@ use std::time::SystemTime;
 
 mod auctions;
 mod bids;
-mod config;
+pub mod config;
 mod people;
 mod price;
 mod strings;
@@ -36,7 +36,7 @@ pub struct NexmarkGenerator<R: Rng> {
 }
 
 impl<R: Rng> NexmarkGenerator<R> {
-    fn new(config: Config, rng: R) -> NexmarkGenerator<R> {
+    pub fn new(config: Config, rng: R) -> NexmarkGenerator<R> {
         NexmarkGenerator {
             config,
             rng,
@@ -44,6 +44,20 @@ impl<R: Rng> NexmarkGenerator<R> {
             events_count_so_far: 0,
             wallclock_base_time: None,
         }
+    }
+
+    /// Set the wallclock base time explicitly rather than leaving it
+    /// to be set when the first event is generated. Useful when testing.
+    pub fn set_wallclock_base_time(&mut self, base_time: u64) {
+        self.wallclock_base_time = match self.wallclock_base_time {
+            None => Some(base_time),
+            Some(t) => {
+                panic!(
+                    "attempt to set wallclock basetime to {} when already set at {}.",
+                    base_time, t
+                )
+            }
+        };
     }
 
     fn get_next_event_id(&self) -> u64 {
@@ -118,7 +132,7 @@ impl<R: Rng> NexmarkGenerator<R> {
 
 /// The next event and its various timestamps. Ordered by increasing wallclock
 /// timestamp, then (arbitrary but stable) event hash order.
-#[derive(Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct NextEvent {
     /// When, in wallclock time, should this event be emitted?
     pub wallclock_timestamp: u64,
@@ -134,12 +148,24 @@ pub struct NextEvent {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
     use rand::{rngs::mock::StepRng, thread_rng};
 
     pub fn make_test_generator() -> NexmarkGenerator<StepRng> {
         NexmarkGenerator::new(Config::default(), StepRng::new(0, 1))
+    }
+
+    /// Generates a specified number of next events using the default test
+    /// generator.
+    pub fn generate_expected_next_events(
+        wallclock_base_time: u64,
+        num_events: usize,
+    ) -> Vec<NextEvent> {
+        let mut ng = make_test_generator();
+        ng.set_wallclock_base_time(wallclock_base_time);
+
+        (0..num_events).map(|_| ng.next_event().unwrap()).collect()
     }
 
     #[test]
@@ -154,6 +180,8 @@ mod tests {
     }
 
     #[test]
+    // Tests the first five expected events without relying on any test
+    // helper for the data.
     fn test_next_event() {
         let mut ng = NexmarkGenerator::new(Config::default(), thread_rng());
 
@@ -199,6 +227,26 @@ mod tests {
             matches!(next_event.event, Event::NewPerson(_)),
             "got: {:?}, want: Event::NewPerson(_)",
             next_event.event
+        );
+    }
+
+    #[test]
+    // Verifies that the `generate_expected_next_events()` test helper does
+    // indeed output predictable results matching the order verified manually in
+    // the above `test_next_events` (at least for the first 5 events).  Together
+    // with the manual test above of next_events, this ensures the order is
+    // correct for external call-sites.
+    fn test_generate_expected_next_events() {
+        let mut ng = make_test_generator();
+        ng.set_wallclock_base_time(1_000_000);
+
+        let expected_events = generate_expected_next_events(1_000_000, 100);
+
+        assert_eq!(
+            (0..100)
+                .map(|_| ng.next_event().unwrap())
+                .collect::<Vec<NextEvent>>(),
+            expected_events
         );
     }
 }

--- a/benches/nexmark/generator/mod.rs
+++ b/benches/nexmark/generator/mod.rs
@@ -179,9 +179,9 @@ pub mod tests {
         assert_eq!(ng.get_next_event_id(), 2);
     }
 
-    #[test]
     // Tests the first five expected events without relying on any test
     // helper for the data.
+    #[test]
     fn test_next_event() {
         let mut ng = NexmarkGenerator::new(Config::default(), thread_rng());
 
@@ -230,12 +230,12 @@ pub mod tests {
         );
     }
 
-    #[test]
     // Verifies that the `generate_expected_next_events()` test helper does
     // indeed output predictable results matching the order verified manually in
     // the above `test_next_events` (at least for the first 5 events).  Together
     // with the manual test above of next_events, this ensures the order is
     // correct for external call-sites.
+    #[test]
     fn test_generate_expected_next_events() {
         let mut ng = make_test_generator();
         ng.set_wallclock_base_time(1_000_000);

--- a/benches/nexmark/main.rs
+++ b/benches/nexmark/main.rs
@@ -13,3 +13,4 @@
 mod config;
 mod generator;
 mod model;
+mod nexmark_dbsp_source;

--- a/benches/nexmark/model.rs
+++ b/benches/nexmark/model.rs
@@ -6,7 +6,7 @@
 ///
 /// Note that Rust can simply derive the equivalent methods on the Java
 /// class.
-#[derive(Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Person {
     pub id: u64,
     pub name: String,
@@ -22,7 +22,7 @@ pub struct Person {
 ///
 /// Note that Rust can simply derive the equivalent methods on the Java
 /// class.
-#[derive(Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Auction {
     pub id: u64,
     pub item_name: String,
@@ -39,7 +39,7 @@ pub struct Auction {
 ///
 /// Note that Rust can simply derive the equivalent methods on the Java
 /// class.
-#[derive(Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Bid {
     /// Id of auction this bid is for.
     pub auction: u64,
@@ -60,7 +60,7 @@ pub struct Bid {
 
 /// An event in the auction system, either a (new) `Person`, a (new) `Auction`,
 /// or a `Bid`.
-#[derive(Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum Event {
     NewPerson(Person),
     NewAuction(Auction),

--- a/benches/nexmark/nexmark_dbsp_source.rs
+++ b/benches/nexmark/nexmark_dbsp_source.rs
@@ -1,0 +1,120 @@
+//! DBSP Source operator that reads from a Nexmark Generator.
+
+use crate::generator::{NexmarkGenerator, NextEvent};
+use dbsp::{
+    algebra::{ZRingValue, ZSet},
+    circuit::{
+        operator_traits::{Data, Operator, SourceOperator},
+        Scope,
+    },
+};
+use rand::Rng;
+use std::{borrow::Cow, marker::PhantomData};
+
+pub struct NexmarkDBSPSource<R: Rng, W, C> {
+    /// The generator for events emitted by this source.
+    // TODO(absoludity): Longer-term, it'd be great to use a client (such as a gRPC client) here to
+    // completely separate the generator and allow the generator to be used with other languages
+    // etc.
+    generator: NexmarkGenerator<R>,
+    batch_size: usize,
+    _t: PhantomData<(C, W)>,
+}
+
+impl<R, W, C> NexmarkDBSPSource<R, W, C>
+where
+    R: Rng,
+{
+    pub fn from_generator(generator: NexmarkGenerator<R>, batch_size: usize) -> Self {
+        NexmarkDBSPSource {
+            generator,
+            batch_size,
+            _t: PhantomData,
+        }
+    }
+}
+
+impl<R, W, C> Operator for NexmarkDBSPSource<R, W, C>
+where
+    C: Data,
+    R: Rng + 'static,
+    W: 'static,
+{
+    fn name(&self) -> Cow<'static, str> {
+        Cow::from("NexmarkDBSPSource")
+    }
+
+    // Do clock_start and clock_end make sense for an infinite source? Or should
+    // the Nexmark generator use the max_events and stop generating events after
+    // that.
+    /// That would also mean then that the fixed point for this data source
+    /// would be at max_events?  Currently the generator will keep spitting out
+    /// events, but maybe `next_event` could be updated to return a
+    /// `Result<Option<NextEvent>>` and return Ok(None) after max events?
+    fn fixedpoint(&self, _scope: Scope) -> bool {
+        false
+    }
+}
+
+impl<R, W, C> SourceOperator<C> for NexmarkDBSPSource<R, W, C>
+where
+    R: Rng + 'static,
+    W: ZRingValue + 'static,
+    C: Data + ZSet<Key = NextEvent, R = W>,
+{
+    fn eval(&mut self) -> C {
+        // Q: Why is the time argument expecting ()? Same for the key tuple's second el?
+        C::from_tuples(
+            (),
+            (0..self.batch_size)
+                .map(|_| ((self.generator.next_event().unwrap(), ()), W::one()))
+                .collect(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::generator::{config::Config, tests::generate_expected_next_events};
+    use dbsp::{circuit::Root, trace::ord::OrdZSet, trace::Batch};
+    use rand::rngs::mock::StepRng;
+
+    // Generates a zset manually using the default test NexmarkGenerator
+    fn generate_expected_zset(
+        wallclock_base_time: u64,
+        num_events: usize,
+    ) -> OrdZSet<NextEvent, isize> {
+        let expected_events = generate_expected_next_events(wallclock_base_time, num_events);
+        let expected_zset_tuples = expected_events
+            .into_iter()
+            .map(|event| ((event, ()), 1))
+            .collect();
+
+        OrdZSet::<NextEvent, isize>::from_tuples((), expected_zset_tuples)
+    }
+
+    #[test]
+    fn test_nexmark_dbsp_source_batch_10() {
+        let root = Root::build(move |circuit| {
+            let mut source = NexmarkDBSPSource::from_generator(
+                NexmarkGenerator::new(Config::default(), StepRng::new(0, 1)),
+                10,
+            );
+            source.generator.set_wallclock_base_time(1_000_000);
+
+            let expected_zset = generate_expected_zset(1_000_000, 10);
+
+            circuit
+                .add_source(source)
+                .inspect(move |data: &OrdZSet<NextEvent, isize>| {
+                    assert_eq!(data, &expected_zset);
+                });
+        })
+        .unwrap();
+
+        root.step().unwrap();
+    }
+
+    // TODO: test multiple batches from a source.
+}


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

Just a draft, following on from #116 , this is basically me learning a bit about ZSets, how to create them for expected data in tests, and creating an example DBSP source. Also refactored the generator test a little so I can generate test data for the source to use (while staying DRY).

I don't yet have enough understanding of a lot of details (eg, whether using `NextEvent` for the source is ok - perhaps should be `Event`, or whether the source should be batchable (as I've done) or should emit one event for each time increment).

Anyway, I've left a few questions and things that aren't clear to me inline, if anyone has time.

Thanks!