### PR TITLE
[nexmark] Nexmark source returns empty zsets when exhausted.

### DIFF
--- a/benches/nexmark/nexmark_dbsp_source.rs
+++ b/benches/nexmark/nexmark_dbsp_source.rs
@@ -1,6 +1,7 @@
 //! DBSP Source operator that reads from a Nexmark Generator.
 
-use crate::generator::{NexmarkGenerator, NextEvent};
+use crate::generator::NexmarkGenerator;
+use crate::model::Event;
 use dbsp::{
     algebra::{ZRingValue, ZSet},
     circuit::{
@@ -44,15 +45,17 @@ where
         Cow::from("NexmarkDBSPSource")
     }
 
-    // Do clock_start and clock_end make sense for an infinite source? Or should
-    // the Nexmark generator use the max_events and stop generating events after
-    // that.
-    /// That would also mean then that the fixed point for this data source
-    /// would be at max_events?  Currently the generator will keep spitting out
-    /// events, but maybe `next_event` could be updated to return a
-    /// `Result<Option<NextEvent>>` and return Ok(None) after max events?
+    // For the ability to reset the circuit and run it from clean state without
+    // rebuilding it, then clock_start resets the generator to the beginning of the
+    // sequence.
+    fn clock_start(&mut self, _scope: Scope) {
+        self.generator.reset();
+    }
+
+    // Returns true if the generator has no more data (and so this source will
+    // return empty zsets from now on).
     fn fixedpoint(&self, _scope: Scope) -> bool {
-        false
+        !self.generator.has_next()
     }
 }
 
@@ -60,14 +63,15 @@ impl<R, W, C> SourceOperator<C> for NexmarkDBSPSource<R, W, C>
 where
     R: Rng + 'static,
     W: ZRingValue + 'static,
-    C: Data + ZSet<Key = NextEvent, R = W>,
+    C: Data + ZSet<Key = Event, R = W>,
 {
     fn eval(&mut self) -> C {
-        // Q: Why is the time argument expecting ()? Same for the key tuple's second el?
         C::from_tuples(
             (),
             (0..self.batch_size)
-                .map(|_| ((self.generator.next_event().unwrap(), ()), W::one()))
+                .map(|_| self.generator.next_event().unwrap())
+                .filter(|event| event.is_some())
+                .map(|event| ((event.unwrap().event, ()), W::one()))
                 .collect(),
         )
     }
@@ -80,34 +84,87 @@ mod test {
     use dbsp::{circuit::Root, trace::ord::OrdZSet, trace::Batch};
     use rand::rngs::mock::StepRng;
 
+    fn make_test_source(
+        wallclock_base_time: u64,
+        batch_size: usize,
+        max_events: u64,
+    ) -> NexmarkDBSPSource<StepRng, isize, OrdZSet<Event, isize>> {
+        let mut source = NexmarkDBSPSource::from_generator(
+            NexmarkGenerator::new(
+                Config {
+                    max_events,
+                    ..Config::default()
+                },
+                StepRng::new(0, 1),
+            ),
+            batch_size,
+        );
+        source
+            .generator
+            .set_wallclock_base_time(wallclock_base_time);
+        source
+    }
+
     // Generates a zset manually using the default test NexmarkGenerator
     fn generate_expected_zset(
         wallclock_base_time: u64,
         num_events: usize,
-    ) -> OrdZSet<NextEvent, isize> {
+    ) -> OrdZSet<Event, isize> {
         let expected_events = generate_expected_next_events(wallclock_base_time, num_events);
         let expected_zset_tuples = expected_events
             .into_iter()
-            .map(|event| ((event, ()), 1))
+            .filter(|event| event.is_some())
+            .map(|event| ((event.unwrap().event, ()), 1))
             .collect();
 
-        OrdZSet::<NextEvent, isize>::from_tuples((), expected_zset_tuples)
+        OrdZSet::<Event, isize>::from_tuples((), expected_zset_tuples)
+    }
+
+    #[test]
+    fn test_start_clock() {
+        let expected_zset = generate_expected_zset(1_000_000, 2);
+
+        let mut source = make_test_source(1_000_000, 2, 5);
+
+        assert_eq!(source.eval(), expected_zset);
+
+        // Calling start_clock begins the events again (manually setting the
+        // wallclock base time again for the test).
+        source.clock_start(1);
+
+        assert_eq!(source.eval(), expected_zset);
+    }
+
+    // After exhausting events, the source indicates a fixed point.
+    #[test]
+    fn test_fixed_point() {
+        let mut source = make_test_source(1_000_000, 1, 1);
+
+        source.eval();
+
+        assert!(source.fixedpoint(1));
+    }
+
+    // After exhausting events, the source returns empty ZSets.
+    #[test]
+    fn test_eval_empty_zset() {
+        let mut source = make_test_source(1_000_000, 1, 1);
+
+        source.eval();
+
+        assert_eq!(source.eval(), OrdZSet::empty(()));
     }
 
     #[test]
     fn test_nexmark_dbsp_source_batch_10() {
         let root = Root::build(move |circuit| {
-            let mut source = NexmarkDBSPSource::from_generator(
-                NexmarkGenerator::new(Config::default(), StepRng::new(0, 1)),
-                10,
-            );
-            source.generator.set_wallclock_base_time(1_000_000);
+            let source = make_test_source(1_000_000, 10, 10);
 
             let expected_zset = generate_expected_zset(1_000_000, 10);
 
             circuit
                 .add_source(source)
-                .inspect(move |data: &OrdZSet<NextEvent, isize>| {
+                .inspect(move |data: &OrdZSet<Event, isize>| {
                     assert_eq!(data, &expected_zset);
                 });
         })

--- a/benches/nexmark/nexmark_dbsp_source.rs
+++ b/benches/nexmark/nexmark_dbsp_source.rs
@@ -70,8 +70,7 @@ where
             (),
             (0..self.batch_size)
                 .map(|_| self.generator.next_event().unwrap())
-                .filter(|event| event.is_some())
-                .map(|event| ((event.unwrap().event, ()), W::one()))
+                .filter_map(|event| event.map(|event| ((event.event, ()), W::one())))
                 .collect(),
         )
     }


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

This PR follows on from #117 and addresses and tests three of the four items mentioned in the discussion:

1. The source emits `model::Event`'s rather than the generator-specific `NextEvent` which just has extra metadata used by the source (only).
2. Updates the `clock_start` to reset the generator so that it begins the sequence again when called.
3. Updates `fixedpoint` to return true when the generator is exhausted. As part of this, I also updated the generator so that it's `next_event` returns a `Result<Option<NextEvent>>` rather than just `Result<NextEvent>` so that the source can then filter out `None` results and therefore automatically returns an empty ZSet once the generator is exhausted.

The fourth item will be to update the batching as discussed with Leonid, which I'll do and discuss in the next PR.