### PR TITLE
[nexmark] Update source eval to batch all events ready.

### DIFF
--- a/benches/nexmark/generator/mod.rs
+++ b/benches/nexmark/generator/mod.rs
@@ -35,6 +35,14 @@ pub struct NexmarkGenerator<R: Rng> {
     wallclock_base_time: Option<u64>,
 }
 
+pub fn wallclock_time() -> Result<u64> {
+    let millis: u64 = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_millis()
+        .try_into()?;
+    Ok(millis)
+}
+
 impl<R: Rng> NexmarkGenerator<R> {
     pub fn new(config: Config, rng: R) -> NexmarkGenerator<R> {
         NexmarkGenerator {
@@ -82,12 +90,7 @@ impl<R: Rng> NexmarkGenerator<R> {
             return Ok(None);
         }
         if self.wallclock_base_time == None {
-            self.wallclock_base_time = Some(
-                SystemTime::now()
-                    .duration_since(SystemTime::UNIX_EPOCH)?
-                    .as_millis()
-                    .try_into()?,
-            )
+            self.wallclock_base_time = Some(wallclock_time()?);
         }
 
         // When, in event time, we should generate the event. Monotonic.

--- a/benches/nexmark/generator/mod.rs
+++ b/benches/nexmark/generator/mod.rs
@@ -35,12 +35,11 @@ pub struct NexmarkGenerator<R: Rng> {
     wallclock_base_time: Option<u64>,
 }
 
-pub fn wallclock_time() -> Result<u64> {
-    let millis: u64 = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)?
-        .as_millis()
-        .try_into()?;
-    Ok(millis)
+pub fn wallclock_time() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
 }
 
 impl<R: Rng> NexmarkGenerator<R> {
@@ -90,7 +89,7 @@ impl<R: Rng> NexmarkGenerator<R> {
             return Ok(None);
         }
         if self.wallclock_base_time == None {
-            self.wallclock_base_time = Some(wallclock_time()?);
+            self.wallclock_base_time = Some(wallclock_time());
         }
 
         // When, in event time, we should generate the event. Monotonic.

--- a/benches/nexmark/main.rs
+++ b/benches/nexmark/main.rs
@@ -9,6 +9,7 @@
 //! so we can work with the wider community to improve it, but also because
 //! it will allow us later to extend it to support multiple data sources in
 //! parallel when DBSP can be scaled.
+#![feature(is_some_with)]
 
 mod config;
 mod generator;

--- a/benches/nexmark/nexmark_dbsp_source.rs
+++ b/benches/nexmark/nexmark_dbsp_source.rs
@@ -1,6 +1,6 @@
 //! DBSP Source operator that reads from a Nexmark Generator.
 
-use crate::generator::NexmarkGenerator;
+use crate::generator::{wallclock_time, NexmarkGenerator, NextEvent};
 use crate::model::Event;
 use dbsp::{
     algebra::{ZRingValue, ZSet},
@@ -10,6 +10,8 @@ use dbsp::{
     },
 };
 use rand::Rng;
+use std::thread::sleep;
+use std::time::Duration;
 use std::{borrow::Cow, marker::PhantomData};
 
 pub struct NexmarkDBSPSource<R: Rng, W, C> {
@@ -18,7 +20,10 @@ pub struct NexmarkDBSPSource<R: Rng, W, C> {
     // completely separate the generator and allow the generator to be used with other languages
     // etc.
     generator: NexmarkGenerator<R>,
-    batch_size: usize,
+    // next_event stores the next event during `eval` when `next_event()` is called but returns an
+    // event in the future, so that we can include it in the next call to eval.
+    next_event: Option<NextEvent>,
+
     _t: PhantomData<(C, W)>,
 }
 
@@ -26,10 +31,10 @@ impl<R, W, C> NexmarkDBSPSource<R, W, C>
 where
     R: Rng,
 {
-    pub fn from_generator(generator: NexmarkGenerator<R>, batch_size: usize) -> Self {
+    pub fn from_generator(generator: NexmarkGenerator<R>) -> Self {
         NexmarkDBSPSource {
             generator,
-            batch_size,
+            next_event: None,
             _t: PhantomData,
         }
     }
@@ -66,11 +71,45 @@ where
     C: Data + ZSet<Key = Event, R = W>,
 {
     fn eval(&mut self) -> C {
+        // Grab a next event, either the last event from the previous call that
+        // was saved because it couldn't yet be emitted, or the next generated
+        // event.
+        let next_event = match self.next_event.clone() {
+            Some(e) => Some(e),
+            None => self.generator.next_event().unwrap(),
+        };
+
+        // If there are no more events, we return an empty set.
+        if next_event.is_none() {
+            return C::empty(());
+        }
+
+        // Otherwise we want to emit at least one event, so if the next event
+        // is still in the future, we sleep until we can emit it.
+        let next_event = next_event.unwrap();
+        let wallclock_time_now = wallclock_time().unwrap();
+        if next_event.wallclock_timestamp > wallclock_time_now {
+            sleep(Duration::from_millis(
+                next_event.wallclock_timestamp - wallclock_time_now,
+            ));
+        }
+
+        // Collect as many next events as are ready.
+        let mut next_events = vec![next_event];
+        let mut next_event = self.generator.next_event().unwrap();
+        let wallclock_time_now = wallclock_time().unwrap();
+        while next_event
+            .is_some_and(|next_event| next_event.wallclock_timestamp.clone() < wallclock_time_now)
+        {
+            next_events.push(next_event.unwrap());
+            next_event = self.generator.next_event().unwrap();
+        }
+
         C::from_tuples(
             (),
-            (0..self.batch_size)
-                .map(|_| self.generator.next_event().unwrap())
-                .filter_map(|event| event.map(|event| ((event.event, ()), W::one())))
+            next_events
+                .into_iter()
+                .map(|next_event| ((next_event.event, ()), W::one()))
                 .collect(),
         )
     }
@@ -85,19 +124,15 @@ mod test {
 
     fn make_test_source(
         wallclock_base_time: u64,
-        batch_size: usize,
         max_events: u64,
     ) -> NexmarkDBSPSource<StepRng, isize, OrdZSet<Event, isize>> {
-        let mut source = NexmarkDBSPSource::from_generator(
-            NexmarkGenerator::new(
-                Config {
-                    max_events,
-                    ..Config::default()
-                },
-                StepRng::new(0, 1),
-            ),
-            batch_size,
-        );
+        let mut source = NexmarkDBSPSource::from_generator(NexmarkGenerator::new(
+            Config {
+                max_events,
+                ..Config::default()
+            },
+            StepRng::new(0, 1),
+        ));
         source
             .generator
             .set_wallclock_base_time(wallclock_base_time);
@@ -123,7 +158,7 @@ mod test {
     fn test_start_clock() {
         let expected_zset = generate_expected_zset(1_000_000, 2);
 
-        let mut source = make_test_source(1_000_000, 2, 5);
+        let mut source = make_test_source(1_000_000, 2);
 
         assert_eq!(source.eval(), expected_zset);
 
@@ -137,7 +172,7 @@ mod test {
     // After exhausting events, the source indicates a fixed point.
     #[test]
     fn test_fixed_point() {
-        let mut source = make_test_source(1_000_000, 1, 1);
+        let mut source = make_test_source(1_000_000, 1);
 
         source.eval();
 
@@ -147,7 +182,7 @@ mod test {
     // After exhausting events, the source returns empty ZSets.
     #[test]
     fn test_eval_empty_zset() {
-        let mut source = make_test_source(1_000_000, 1, 1);
+        let mut source = make_test_source(1_000_000, 1);
 
         source.eval();
 
@@ -155,9 +190,9 @@ mod test {
     }
 
     #[test]
-    fn test_nexmark_dbsp_source_batch_10() {
+    fn test_nexmark_dbsp_source_full_batch() {
         let root = Root::build(move |circuit| {
-            let source = make_test_source(1_000_000, 10, 10);
+            let source = make_test_source(1_000_000, 10);
 
             let expected_zset = generate_expected_zset(1_000_000, 10);
 
@@ -172,5 +207,7 @@ mod test {
         root.step().unwrap();
     }
 
-    // TODO: test multiple batches from a source.
+    // TODO: Figure out best way to test when not all events are in the past,
+    // given that the code uses `now()` - perhaps pass in implementation so
+    // tests can use a canned `now()`?
 }

--- a/benches/nexmark/nexmark_dbsp_source.rs
+++ b/benches/nexmark/nexmark_dbsp_source.rs
@@ -87,7 +87,7 @@ where
         // Otherwise we want to emit at least one event, so if the next event
         // is still in the future, we sleep until we can emit it.
         let next_event = next_event.unwrap();
-        let wallclock_time_now = wallclock_time().unwrap();
+        let wallclock_time_now = wallclock_time();
         if next_event.wallclock_timestamp > wallclock_time_now {
             sleep(Duration::from_millis(
                 next_event.wallclock_timestamp - wallclock_time_now,
@@ -97,7 +97,7 @@ where
         // Collect as many next events as are ready.
         let mut next_events = vec![next_event];
         let mut next_event = self.generator.next_event().unwrap();
-        let wallclock_time_now = wallclock_time().unwrap();
+        let wallclock_time_now = wallclock_time();
         while next_event
             .is_some_and(|next_event| next_event.wallclock_timestamp.clone() < wallclock_time_now)
         {
@@ -224,7 +224,7 @@ mod test {
     // are returned one at a time.
     #[test]
     fn test_eval_current_time() {
-        let wallclock_time = wallclock_time().unwrap();
+        let wallclock_time = wallclock_time();
         let mut source = make_test_source(wallclock_time, 5);
         let expected_zset_tuples = generate_expected_zset_tuples(wallclock_time, 10);
 

--- a/benches/nexmark/nexmark_dbsp_source.rs
+++ b/benches/nexmark/nexmark_dbsp_source.rs
@@ -105,6 +105,10 @@ where
             next_event = self.generator.next_event().unwrap();
         }
 
+        // Ensure we remember the last event that was generated but not emitted for the
+        // next call.
+        self.next_event = next_event;
+
         C::from_tuples(
             (),
             next_events


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

After chatting with @ryzhyk  about the batching in the nexmark source, where he says:

> OTOH, this gives as a natural apples-to-apples comparison: DBSP will grab all the data buffered at its input by the generator, up to some fixed bound, and process it as one batch.
> This way we'll be doing natural batching simulating how the system would run in the real world, rather than introducing an artificial batch size, which may affect the performance.

So pushing this PR to discuss further. It updates the NexmarkDBSPSource's `eval` method so that it:
- Waits until it has at least one event to emit, and
- returns a batch with as many generated events as are ready (ie. in the past according to the wallclock),

~~Still need to (work out how to) test it properly (given the use of `now()`). I'll probably inject the function into the struct during a `::new()` constructor, while tests can manually set a canned version. Or even just show that when the wallclock is set automatically, only a few results are returned in each batch. But I'll wait until I chat with Leonid before going further on this PR.~~