### PR TITLE
Shard batches across multiple workers.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.8"
+version = "3.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190814073e85d238f31ff738fcb0bf6910cedeb73376c87cd69291028966fd83"
+checksum = "ac2bd7a1eb07da9ac757c923f69373deb7bc2ba5efc951b873bcb5e693992dca"
 dependencies = [
  "atty",
  "bitflags",
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5999502d32b9c48d492abe66392408144895020ec4709e549e840799f3bb74c0"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -391,6 +391,7 @@ dependencies = [
  "csv",
  "deepsize",
  "deepsize_derive",
+ "fxhash",
  "hashbrown",
  "impl-trait-for-tuples",
  "num",
@@ -439,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -555,6 +556,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
@@ -808,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "opaque-debug"
@@ -820,9 +830,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.1.0"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
 
 [[package]]
 name = "parking_lot_core"
@@ -1062,15 +1072,15 @@ checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
 
 [[package]]
 name = "serde"
-version = "1.0.138"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1578c6245786b9d168c5447eeacfb96856573ca56c9d68fdcf394be134882a47"
+checksum = "fc855a42c7967b7c369eb5860f7164ef1f6f81c20c7cc1141f2a604e18723b03"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.138"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023e9b1467aef8a10fb88f25611870ada9800ef7e22afce356bb0d2387b6f27c"
+checksum = "6f2122636b9fe3b81f1cb25099fcf2d3f542cdb1d45940d56c713158884a05da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1101,9 +1111,12 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "smallvec"
@@ -1297,9 +1310,9 @@ checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "15c61ba63f9235225a22310255a29b806b907c9b8c964bcbd0a2c70f3f2deea7"
 
 [[package]]
 name = "unicode-linebreak"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ impl-trait-for-tuples = "0.2"
 deepsize = "0.2.0"
 deepsize_derive = "0.1.2"
 textwrap = "0.15.0"
+fxhash = "0.2"
 
 # TODO: eliminate dependency on timely-dataflow by cloning relevant
 # parts.

--- a/benches/path.rs
+++ b/benches/path.rs
@@ -1,111 +1,133 @@
 use dbsp::{
-    circuit::{trace::SchedulerEvent, GlobalNodeId, Root, Stream},
-    monitor::TraceMonitor,
+    circuit::{Root, Stream},
     operator::{FilterMap, Generator},
-    profile::CPUProfiler,
     time::NestedTimestamp32,
-    trace::{ord::OrdZSet, Batch},
+    trace::{ord::OrdZSet, Batch, BatchReader},
+    Runtime,
 };
-use std::{collections::HashMap, fmt::Write, fs};
 
 fn main() {
-    let monitor = TraceMonitor::new_panic_on_error();
-    let root = Root::build(|circuit| {
-        let cpu_profiler = CPUProfiler::new();
-        cpu_profiler.attach(circuit, "cpu profiler");
+    let hruntime = Runtime::run(16, || {
+        let root = Root::build(|circuit| {
+            /*
+            use dbsp::{
+                circuit::{trace::SchedulerEvent, GlobalNodeId},
+                monitor::TraceMonitor,
+                profile::CPUProfiler,
+            };
+            use std::{collections::HashMap, fmt::Write, fs};
 
-        monitor.attach(circuit, "monitor");
-        let mut metadata = <HashMap<GlobalNodeId, String>>::new();
-        let mut nsteps = 0;
-        let monitor_clone = monitor.clone();
-        circuit.register_scheduler_event_handler("metadata", move |event: &SchedulerEvent| {
-            match event {
-                SchedulerEvent::EvalEnd { node } => {
-                    let metadata_string = metadata.entry(node.global_id().clone()).or_default();
-                    metadata_string.clear();
-                    node.summary(metadata_string);
-                }
-                SchedulerEvent::StepEnd => {
-                    let graph = monitor_clone.visualize_circuit_annotate(|node_id| {
-                        let mut metadata_string = metadata
-                            .get(node_id)
-                            .map(ToString::to_string)
-                            .unwrap_or_else(|| "".to_string());
+            let monitor = TraceMonitor::new_panic_on_error();
+            let cpu_profiler = CPUProfiler::new();
+            cpu_profiler.attach(circuit, "cpu profiler");
 
-                        if let Some(cpu_profile) = cpu_profiler.operator_profile(node_id) {
-                            writeln!(
-                                metadata_string,
-                                "invocations: {}",
-                                cpu_profile.invocations()
-                            )
-                            .unwrap();
-                            writeln!(metadata_string, "time: {:?}", cpu_profile.total_time())
+            monitor.attach(circuit, "monitor");
+            let mut metadata = <HashMap<GlobalNodeId, String>>::new();
+            let mut nsteps = 0;
+            let monitor_clone = monitor.clone();
+            circuit.register_scheduler_event_handler("metadata", move |event: &SchedulerEvent| {
+                match event {
+                    SchedulerEvent::EvalEnd { node } => {
+                        let metadata_string = metadata.entry(node.global_id().clone()).or_default();
+                        metadata_string.clear();
+                        node.summary(metadata_string);
+                    }
+                    SchedulerEvent::StepEnd => {
+                        let graph = monitor_clone.visualize_circuit_annotate(|node_id| {
+                            let mut metadata_string = metadata
+                                .get(node_id)
+                                .map(ToString::to_string)
+                                .unwrap_or_else(|| "".to_string());
+
+                            if let Some(cpu_profile) = cpu_profiler.operator_profile(node_id) {
+                                writeln!(
+                                    metadata_string,
+                                    "invocations: {}",
+                                    cpu_profile.invocations()
+                                )
                                 .unwrap();
-                        };
-                        metadata_string
-                    });
+                                writeln!(metadata_string, "time: {:?}", cpu_profile.total_time())
+                                    .unwrap();
+                            };
+                            metadata_string
+                        });
 
-                    fs::write(format!("path.{}.dot", nsteps), graph.to_dot()).unwrap();
-                    nsteps += 1;
+                        fs::write(format!("path.{}.dot", nsteps), graph.to_dot()).unwrap();
+                        nsteps += 1;
+                    }
+                    _ => {}
                 }
-                _ => {}
-            }
-        });
+            });
+            */
 
-        const LAYER: u32 = 200;
+            const LAYER: u32 = 200;
 
-        let mut tuples = Vec::new();
-        for layer in 0..5 {
-            for from in 0..LAYER {
-                for to in 0..LAYER {
-                    tuples.push((((from + (LAYER * layer), to + LAYER * (layer + 1)), ()), 1));
+            let mut tuples = Vec::new();
+            if Runtime::worker_index() == 0 {
+                for layer in 0..5 {
+                    for from in 0..LAYER {
+                        for to in 0..LAYER {
+                            tuples.push((
+                                ((from + (LAYER * layer), to + LAYER * (layer + 1)), ()),
+                                1,
+                            ));
+                        }
+                    }
                 }
             }
-        }
 
-        let edges = <OrdZSet<(u32, u32), i32>>::from_tuples((), tuples);
+            let edges = <OrdZSet<(u32, u32), i32>>::from_tuples((), tuples);
 
-        let edges: Stream<_, OrdZSet<(u32, u32), i32>> =
-            circuit.add_source(Generator::new(move || edges.clone()));
+            let edges: Stream<_, OrdZSet<(u32, u32), i32>> =
+                circuit.add_source(Generator::new(move || edges.clone()));
 
-        let _paths = circuit
-            .recursive(|child, paths: Stream<_, OrdZSet<(u32, u32), i32>>| {
-                // ```text
-                //                      distinct_trace
-                //               ┌───┐          ┌───┐
-                // edges         │   │          │   │  paths
-                // ────┬────────►│ + ├──────────┤   ├────────┬───►
-                //     │         │   │          │   │        │
-                //     │         └───┘          └───┘        │
-                //     │           ▲                         │
-                //     │           │                         │
-                //     │         ┌─┴─┐                       │
-                //     │         │   │                       │
-                //     └────────►│ X │ ◄─────────────────────┘
-                //               │   │
-                //               └───┘
-                //               join
-                // ```
-                let edges = edges.delta0(child);
+            let paths = circuit
+                .recursive(|child, paths: Stream<_, OrdZSet<(u32, u32), i32>>| {
+                    // ```text
+                    //                      distinct_trace
+                    //               ┌───┐          ┌───┐
+                    // edges         │   │          │   │  paths
+                    // ────┬────────►│ + ├──────────┤   ├────────┬───►
+                    //     │         │   │          │   │        │
+                    //     │         └───┘          └───┘        │
+                    //     │           ▲                         │
+                    //     │           │                         │
+                    //     │         ┌─┴─┐                       │
+                    //     │         │   │                       │
+                    //     └────────►│ X │ ◄─────────────────────┘
+                    //               │   │
+                    //               └───┘
+                    //               join
+                    // ```
+                    let edges = edges.delta0(child);
 
-                let paths_inverted = paths.map(|&(x, y)| (y, x));
+                    let paths_inverted = paths.map(|&(x, y)| (y, x));
 
-                let paths_inverted_indexed = paths_inverted.index();
-                let edges_indexed = edges.index();
+                    let paths_inverted_indexed = paths_inverted.index();
+                    let edges_indexed = edges.index();
 
-                Ok(edges.plus(
-                    &paths_inverted_indexed
-                        .join::<NestedTimestamp32, _, _, _>(&edges_indexed, |_via, from, to| {
-                            (*from, *to)
-                        }),
-                ))
-            })
-            .unwrap();
-    })
-    .unwrap();
+                    Ok(edges.plus(
+                        &paths_inverted_indexed.join::<NestedTimestamp32, _, _, _>(
+                            &edges_indexed,
+                            |_via, from, to| (*from, *to),
+                        ),
+                    ))
+                })
+                .unwrap();
 
-    let graph = monitor.visualize_circuit();
-    fs::write("path.dot", graph.to_dot()).unwrap();
+            paths.gather(0).inspect(|zs: &OrdZSet<_, _>| {
+                if Runtime::worker_index() == 0 {
+                    println!("paths: {}", zs.len())
+                }
+            });
+        })
+        .unwrap();
 
-    root.step().unwrap();
+        //let graph = monitor.visualize_circuit();
+        //fs::write("path.dot", graph.to_dot()).unwrap();
+
+        root.step().unwrap();
+    });
+
+    hruntime.join().unwrap();
 }

--- a/src/algebra/mod.rs
+++ b/src/algebra/mod.rs
@@ -63,18 +63,6 @@ where
     }
 }
 
-impl<T> HasZero for Rc<T>
-where
-    T: HasZero,
-{
-    fn is_zero(&self) -> bool {
-        T::is_zero(self.as_ref())
-    }
-    fn zero() -> Self {
-        Rc::new(T::zero())
-    }
-}
-
 /// A trait for types that have a one value.
 /// This is similar to the standard One trait, but that
 /// trait depends on Mul and HasOne doesn't.

--- a/src/circuit/schedule/mod.rs
+++ b/src/circuit/schedule/mod.rs
@@ -97,7 +97,7 @@ impl<F, S> IterativeExecutor<F, S> {
 
 impl<P, F, S> Executor<P> for IterativeExecutor<F, S>
 where
-    F: Fn() -> bool + 'static,
+    F: Fn() -> Result<bool, Error> + 'static,
     P: Clone + 'static,
     S: Scheduler + 'static,
 {
@@ -107,7 +107,7 @@ where
 
         loop {
             self.scheduler.step(circuit)?;
-            if (self.termination_check)() {
+            if (self.termination_check)()? {
                 break;
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,5 +19,5 @@ pub use ref_pair::RefPair;
 pub use shared_ref::SharedRef;
 pub use time::Timestamp;
 
-pub use circuit::{Circuit, Stream};
+pub use circuit::{Circuit, Runtime, Stream};
 pub use trace::ord::{OrdIndexedZSet, OrdZSet};

--- a/src/operator/aggregate.rs
+++ b/src/operator/aggregate.rs
@@ -1,6 +1,6 @@
 //! Aggregation operators.
 
-use std::{borrow::Cow, hash::Hash, marker::PhantomData, ops::Neg, rc::Rc};
+use std::{borrow::Cow, hash::Hash, marker::PhantomData, ops::Neg};
 
 use crate::{
     algebra::{HasOne, IndexedZSet, ZRingValue, ZSet},
@@ -39,7 +39,7 @@ where
     /// * `O` - output Z-set type.
     pub fn aggregate<F, O>(&self, f: F) -> Stream<Circuit<P>, O>
     where
-        Z: IndexedZSet<R = O::R> + Send + TryFrom<Rc<Z>> + 'static,
+        Z: IndexedZSet<R = O::R> + Send + 'static,
         Z::Key: Ord + Clone + Hash,
         Z::Val: Ord + Clone,
         F: Fn(&Z::Key, &mut Vec<(&Z::Val, Z::R)>) -> O::Key + 'static,
@@ -56,7 +56,7 @@ where
     /// but is more efficient.
     pub fn aggregate_incremental<F, O>(&self, f: F) -> Stream<Circuit<P>, O>
     where
-        Z: IndexedZSet<R = O::R> + DeepSizeOf + NumEntries + Send + TryFrom<Rc<Z>>,
+        Z: IndexedZSet<R = O::R> + DeepSizeOf + NumEntries + Send,
         Z::Key: PartialEq + Ord + Hash + Clone,
         Z::Val: Ord + Clone,
         F: Fn(&Z::Key, &mut Vec<(&Z::Val, Z::R)>) -> O::Key + Clone + 'static,
@@ -99,7 +99,7 @@ where
     /// differentiate()`, but is more efficient.
     pub fn aggregate_incremental_nested<F, O>(&self, f: F) -> Stream<Circuit<P>, O>
     where
-        Z: IndexedZSet<R = O::R> + DeepSizeOf + NumEntries + Send + TryFrom<Rc<Z>>,
+        Z: IndexedZSet<R = O::R> + DeepSizeOf + NumEntries + Send,
         Z::Key: PartialEq + Ord + Clone + Hash,
         Z::Val: Ord + Clone,
         F: Fn(&Z::Key, &mut Vec<(&Z::Val, Z::R)>) -> O::Key + Clone + 'static,

--- a/src/operator/communication/mod.rs
+++ b/src/operator/communication/mod.rs
@@ -1,2 +1,4 @@
 mod exchange;
 pub use exchange::*;
+
+mod shard;

--- a/src/operator/communication/shard.rs
+++ b/src/operator/communication/shard.rs
@@ -1,0 +1,290 @@
+//! Operators to shard batches across multiple worker threads based on keys
+//! and to gather sharded batches in one worker.
+
+// TODOs:
+// - different sharding modes.
+
+use crate::{
+    circuit::GlobalNodeId,
+    circuit_cache_key,
+    trace::{cursor::Cursor, spine_fueled::Spine, Batch, BatchReader, Builder, Trace},
+    Circuit, Runtime, Stream,
+};
+use fxhash::hash32;
+use std::{hash::Hash, rc::Rc};
+
+circuit_cache_key!(ShardId<C, D>((GlobalNodeId, ShardingPolicy) => Stream<C, D>));
+circuit_cache_key!(GatherId<C, D>((GlobalNodeId, usize) => Stream<C, D>));
+
+// An attempt to future-proof the design for when we support multiple sharding
+// disciplines.
+#[derive(Hash, PartialEq, Eq)]
+pub struct ShardingPolicy;
+
+fn sharding_policy<P>(_circuit: &Circuit<P>) -> ShardingPolicy {
+    ShardingPolicy
+}
+
+impl<P, IB> Stream<Circuit<P>, IB>
+where
+    P: Clone + 'static,
+    IB: BatchReader<Time = ()> + Clone + 'static,
+    IB::Key: Ord + Clone + Hash,
+    IB::Val: Ord + Clone,
+{
+    /// Shard batches across multiple worker threads based on keys.
+    ///
+    /// # Theory
+    ///
+    /// We parallelize processing across `N` worker threads by creating a
+    /// replica of the same circuit per thread and sharding data across
+    /// replicas.  To ensure correctness (i.e., that the sum of outputs
+    /// produced by individual workers is equal to the output produced
+    /// by processing the entire dataset by one worker), sharding must satisfy
+    /// certain requirements determined by each operator.  In particular,
+    /// for `distinct`, and `aggregate` all tuples that share the same key
+    /// must be processed by the same worker.  For `join`, tuples from both
+    /// input streams with the same key must be processed by the same worker.
+    ///
+    /// Other operators, e.g., `filter` and `flat_map`, impose no restrictions
+    /// on the sharding scheme: as long as each tuple in a batch is
+    /// processed by some worker, the correct result will be produced.  This
+    /// is true for all linear operators.
+    ///
+    /// The `shard` operator shards input batches based on the hash of the key,
+    /// making sure that tuples with the same key always end up at the same
+    /// worker.  More precisely, the operator **re-shards** its input by
+    /// partitioning batches in the input stream of each worker based on the
+    /// hash of the key, distributing resulting fragments amond peers
+    /// and re-assembling fragments at each peer:
+    ///
+    /// ```text
+    ///         ┌──────────────────┐
+    /// worker1 │                  │
+    /// ───────►├─────┬───────────►├──────►
+    ///         │     │            │
+    /// ───────►├─────┴───────────►├──────►
+    /// worker2 │                  │
+    ///         └──────────────────┘
+    /// ```
+    ///
+    /// # Usage
+    ///
+    /// Most users do not need to invoke `shard` directly (and doing so is
+    /// likely to lead to incorrect results unless you know exactly what you
+    /// are doing).  Instead, each operator re-shards its inputs as
+    /// necessary, e.g., `join` applies `shard` to both of its
+    /// input streams, while `filter` consumes its input directly without
+    /// re-sharding.
+    ///
+    /// # Performance considerations
+    ///
+    /// In the current implementation, the `shard` operator introduces a
+    /// synchronization barrier across all workers: its output at any worker
+    /// is only produced once input batches have been collected from all
+    /// workers.  This limits the scalability since a slow worker (e.g., running
+    /// on a busy CPU core or sharing the core with other workers) or uneven
+    /// sharding can slow down the whole system and reduce gains from
+    /// parallelization.
+    pub fn shard(&self) -> Stream<Circuit<P>, IB>
+    where
+        IB: Batch + TryFrom<Rc<IB>> + Send,
+    {
+        // `shard_generic` returns `None` if there is only one worker thread
+        // and hence sharding is a no-op.  In this case, we simply return the
+        // input stream.  This allows us to use `shard` unconditionally without
+        // incurring any overhead in the single-threaded case.
+        self.shard_generic().unwrap_or_else(|| self.clone())
+    }
+
+    /// Like [`Self::shard`], but can assemble the results into any output batch
+    /// type `OB`.
+    ///
+    /// Returns `None` when the circuit is not running inside a multithreaded
+    /// rutime or is running in a runtime with a single worker thread.
+    pub fn shard_generic<OB>(&self) -> Option<Stream<Circuit<P>, OB>>
+    where
+        OB: Batch<Key = IB::Key, Val = IB::Val, Time = (), R = IB::R>
+            + Clone
+            + TryFrom<Rc<OB>>
+            + Send
+            + 'static,
+    {
+        Runtime::runtime().and_then(|runtime| {
+            let num_workers = runtime.num_workers();
+
+            if num_workers == 1 {
+                None
+            } else {
+                let output = self
+                    .circuit()
+                    .cache_get_or_insert_with(
+                        ShardId::new((
+                            self.origin_node_id().clone(),
+                            sharding_policy(self.circuit()),
+                        )),
+                        move || {
+                            // As a minor optimization, we reuse this array across all invocations
+                            // of the sharding operator.
+                            let mut builders = Vec::with_capacity(runtime.num_workers());
+                            let (sender, receiver) = self.circuit().new_exchange_operators(
+                                &runtime,
+                                Runtime::worker_index(),
+                                move |batch: IB, batches: &mut Vec<OB>| {
+                                    Self::shard_batch(&batch, num_workers, &mut builders, batches);
+                                },
+                                |trace: &mut Spine<Rc<OB>>, batch: OB| trace.insert(Rc::new(batch)),
+                            );
+                            // Is `consolidate` always necessary? Some (all?) consumers may be happy
+                            // working with traces.
+                            self.circuit()
+                                .add_exchange(sender, receiver, self)
+                                .consolidate()
+                        },
+                    )
+                    .clone();
+                Some(output)
+            }
+        })
+    }
+
+    /// Collect all shards of a stream at the same worker.
+    ///
+    /// The output stream in `receiver_worker` will contain a union of all
+    /// input batches across all workers.  The output streams in all other
+    /// workers will contain empty batches.
+    pub fn gather(&self, receiver_worker: usize) -> Stream<Circuit<P>, IB>
+    where
+        IB: Batch + TryFrom<Rc<IB>> + Send,
+    {
+        match Runtime::runtime() {
+            None => self.clone(),
+            Some(runtime) => {
+                let num_workers = runtime.num_workers();
+                assert!(receiver_worker < num_workers);
+
+                if num_workers == 1 {
+                    self.clone()
+                } else {
+                    self.circuit()
+                        .cache_get_or_insert_with(
+                            GatherId::new((self.origin_node_id().clone(), receiver_worker)),
+                            move || {
+                                let (sender, receiver) = self.circuit().new_exchange_operators(
+                                    &runtime,
+                                    Runtime::worker_index(),
+                                    move |batch: IB, batches: &mut Vec<IB>| {
+                                        for _ in 0..num_workers {
+                                            batches.push(IB::empty(()));
+                                        }
+                                        batches[receiver_worker] = batch;
+                                    },
+                                    |trace: &mut Spine<Rc<IB>>, batch: IB| {
+                                        trace.insert(Rc::new(batch))
+                                    },
+                                );
+                                // Is `consolidate` always necessary? Some (all?) consumers may be
+                                // happy working with traces.
+                                self.circuit()
+                                    .add_exchange(sender, receiver, self)
+                                    .consolidate()
+                            },
+                        )
+                        .clone()
+                }
+            }
+        }
+    }
+
+    // Partitions the batch into `nshards` partitions based on the hash of the key.
+    fn shard_batch<OB>(
+        batch: &IB,
+        nshards: usize,
+        builders: &mut Vec<OB::Builder>,
+        outputs: &mut Vec<OB>,
+    ) where
+        OB: Batch<Key = IB::Key, Val = IB::Val, Time = (), R = IB::R>,
+    {
+        builders.clear();
+
+        for _ in 0..nshards {
+            // We iterate over tuples in the batch in order; hence tuples added
+            // to each shard are also ordered, so we can use the more efficient
+            // `Builder` API (instead of `Batcher`) to construct output batches.
+            builders.push(OB::Builder::with_capacity((), batch.len() / nshards));
+        }
+
+        let mut cursor = batch.cursor();
+
+        while cursor.key_valid() {
+            let batch_index = (hash32(cursor.key()) as usize) % nshards;
+            while cursor.val_valid() {
+                builders[batch_index].push((
+                    cursor.key().clone(),
+                    cursor.val().clone(),
+                    cursor.weight(),
+                ));
+                cursor.step_val();
+            }
+            cursor.step_key();
+        }
+
+        for builder in builders.drain(..) {
+            outputs.push(builder.done());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        circuit::Root,
+        operator::Generator,
+        trace::{Batch, BatchReader},
+        OrdIndexedZSet, Runtime,
+    };
+
+    #[test]
+    fn test_shard() {
+        do_test_shard(2);
+        do_test_shard(4);
+        do_test_shard(16);
+    }
+
+    fn test_data(worker_index: usize, num_workers: usize) -> OrdIndexedZSet<usize, usize, isize> {
+        let tuples: Vec<_> = (0..1000)
+            .filter(|n| n % num_workers == worker_index)
+            .flat_map(|n| vec![((n, n), 1), ((n, 1000 * n), 1)])
+            .collect();
+        <OrdIndexedZSet<usize, usize, isize>>::from_tuples((), tuples)
+    }
+
+    fn do_test_shard(workers: usize) {
+        let hruntime = Runtime::run(workers, || {
+            let root = Root::build(move |circuit| {
+                let input = circuit.add_source(Generator::new(|| {
+                    let worker_index = Runtime::worker_index();
+                    let num_workers = Runtime::runtime().unwrap().num_workers();
+                    test_data(worker_index, num_workers)
+                }));
+                input
+                    .shard()
+                    .gather(0)
+                    .inspect(|batch: &OrdIndexedZSet<usize, usize, isize>| {
+                        if Runtime::worker_index() == 0 {
+                            assert_eq!(batch, &test_data(0, 1))
+                        } else {
+                            assert_eq!(batch.len(), 0);
+                        }
+                    });
+            })
+            .unwrap();
+
+            for _ in 0..3 {
+                root.step().unwrap();
+            }
+        });
+
+        hruntime.join().unwrap();
+    }
+}

--- a/src/operator/condition.rs
+++ b/src/operator/condition.rs
@@ -51,7 +51,7 @@ where
     {
         self.iterate(|child| {
             let (condition, res) = constructor(child)?;
-            Ok((move || condition.check(), res))
+            Ok((move || Ok(condition.check()), res))
         })
     }
 
@@ -67,7 +67,7 @@ where
     {
         self.iterate_with_scheduler::<_, _, _, S>(|child| {
             let (condition, res) = constructor(child)?;
-            Ok((move || condition.check(), res))
+            Ok((move || Ok(condition.check()), res))
         })
     }
 
@@ -83,7 +83,7 @@ where
     {
         self.iterate(|child| {
             let (conditions, res) = constructor(child)?;
-            Ok((move || conditions.iter().all(Condition::check), res))
+            Ok((move || Ok(conditions.iter().all(Condition::check)), res))
         })
     }
 
@@ -99,7 +99,7 @@ where
     {
         self.iterate_with_scheduler::<_, _, _, S>(|child| {
             let (conditions, res) = constructor(child)?;
-            Ok((move || conditions.iter().all(Condition::check), res))
+            Ok((move || Ok(conditions.iter().all(Condition::check)), res))
         })
     }
 }

--- a/src/operator/csv.rs
+++ b/src/operator/csv.rs
@@ -6,7 +6,7 @@
 //   error).
 // - Batching (don't read the whole file in one clock cycle)
 // - Async implementation (wait for data to become available in the reader)
-// - Sharded implementation.
+// - Sharded implementation (currently we feed all data on worker 0).
 
 use crate::{
     algebra::{ZRingValue, ZSet},
@@ -14,6 +14,7 @@ use crate::{
         operator_traits::{Data, Operator, SourceOperator},
         Scope,
     },
+    Runtime,
 };
 use csv::Reader as CsvReader;
 use serde::Deserialize;
@@ -76,7 +77,7 @@ where
     C: Data + ZSet<Key = T, R = W>,
 {
     fn eval(&mut self) -> C {
-        let source = if self.time == 0 {
+        let source = if self.time == 0 && Runtime::worker_index() == 0 {
             let data: Vec<_> = self
                 .reader
                 .deserialize()

--- a/src/operator/distinct.rs
+++ b/src/operator/distinct.rs
@@ -9,7 +9,6 @@ use std::{
     marker::PhantomData,
     mem::take,
     ops::{Add, Neg},
-    rc::Rc,
 };
 
 use crate::{
@@ -36,7 +35,7 @@ where
     /// Apply [`Distinct`] operator to `self`.
     pub fn distinct(&self) -> Stream<Circuit<P>, Z>
     where
-        Z: ZSet + Send + TryFrom<Rc<Z>>,
+        Z: ZSet + Send,
         Z::Key: Ord + Clone + Hash,
     {
         self.circuit()
@@ -53,7 +52,7 @@ where
     /// is more efficient.
     pub fn distinct_incremental(&self) -> Stream<Circuit<P>, Z>
     where
-        Z: DeepSizeOf + NumEntries + ZSet + Send + TryFrom<Rc<Z>>,
+        Z: DeepSizeOf + NumEntries + ZSet + Send,
         Z::Key: Clone + PartialEq + Ord + Hash,
         Z::R: ZRingValue,
     {
@@ -84,7 +83,7 @@ where
     // TODO: remove this method.
     pub fn distinct_incremental_nested(&self) -> Stream<Circuit<P>, Z>
     where
-        Z: DeepSizeOf + NumEntries + Send + ZSet + TryFrom<Rc<Z>>,
+        Z: DeepSizeOf + NumEntries + Send + ZSet,
         Z::Key: Clone + PartialEq + Ord + Hash,
         Z::R: ZRingValue,
     {
@@ -109,7 +108,7 @@ where
     /// [`Stream::distinct_incremental_nested`].
     pub fn distinct_trace(&self) -> Stream<Circuit<P>, Z>
     where
-        Z: NumEntries + ZSet + DeepSizeOf + Send + TryFrom<Rc<Z>>,
+        Z: NumEntries + ZSet + DeepSizeOf + Send,
         Z::Key: Clone + Ord + DeepSizeOf + Hash,
         Z::R: ZRingValue + DeepSizeOf,
     {

--- a/src/operator/join.rs
+++ b/src/operator/join.rs
@@ -22,7 +22,6 @@ use std::{
     hash::Hash,
     marker::PhantomData,
     mem::take,
-    rc::Rc,
 };
 use timely::PartialOrder;
 
@@ -53,10 +52,10 @@ where
         f: F,
     ) -> Stream<Circuit<P>, Z>
     where
-        I1: Batch<Time = (), R = Z::R> + Clone + Send + TryFrom<Rc<I1>> + 'static,
+        I1: Batch<Time = (), R = Z::R> + Clone + Send + 'static,
         I1::Key: Ord + Hash + Clone,
         I1::Val: Ord + Clone,
-        I2: Batch<Key = I1::Key, Time = (), R = Z::R> + Send + Clone + TryFrom<Rc<I2>> + 'static,
+        I2: Batch<Key = I1::Key, Time = (), R = Z::R> + Send + Clone + 'static,
         I2::Val: Ord + Clone,
         Z: Clone + ZSet + 'static,
         Z::R: MulByRef,
@@ -105,11 +104,11 @@ impl<I1> Stream<Circuit<()>, I1> {
         join_func: F,
     ) -> Stream<Circuit<()>, Z>
     where
-        I1: IndexedZSet + DeepSizeOf + Send + TryFrom<Rc<I1>>,
+        I1: IndexedZSet + DeepSizeOf + Send,
         I1::Key: Ord + Clone + Hash + DeepSizeOf,
         I1::Val: Ord + Clone,
         I1::R: DeepSizeOf,
-        I2: IndexedZSet<Key = I1::Key, R = I1::R> + DeepSizeOf + Send + TryFrom<Rc<I2>>,
+        I2: IndexedZSet<Key = I1::Key, R = I1::R> + DeepSizeOf + Send,
         I2::Val: Ord + Clone,
         F: Clone + Fn(&I1::Key, &I1::Val, &I2::Val) -> Z::Key + 'static,
         Z: ZSet<R = I1::R>,
@@ -127,7 +126,7 @@ impl<I1> Stream<Circuit<()>, I1> {
 impl<P, I1> Stream<Circuit<P>, I1>
 where
     P: Clone + 'static,
-    I1: IndexedZSet + Send + TryFrom<Rc<I1>>,
+    I1: IndexedZSet + Send,
 {
     // TODO: Derive `TS` type from circuit.
     /// Incremental join two streams of batches.
@@ -155,8 +154,8 @@ where
         I1::Val: DeepSizeOf + Clone + Ord,        /* + ::std::fmt::Display */
         I1::R: DeepSizeOf,                        /* + ::std::fmt::Display */
         I2::Val: DeepSizeOf + Clone + Ord,        /* + ::std::fmt::Display */
-        I2: IndexedZSet<Key = I1::Key, R = I1::R> + Send + TryFrom<Rc<I2>>, /* + ::std::fmt::Display */
-        Z: ZSet<R = I1::R>, /* + ::std::fmt::Display */
+        I2: IndexedZSet<Key = I1::Key, R = I1::R> + Send, /* + ::std::fmt::Display */
+        Z: ZSet<R = I1::R>,                       /* + ::std::fmt::Display */
         Z::Batcher: DeepSizeOf,
         Z::Key: Clone + Default,
         Z::R: MulByRef + Default,
@@ -803,7 +802,7 @@ mod test {
             })
             .unwrap();
 
-        computed_labels.consolidate::<OrdZSet<_, _>>()
+        computed_labels.consolidate()
     }
 
     #[test]

--- a/src/operator/recursive.rs
+++ b/src/operator/recursive.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use deepsize::DeepSizeOf;
 use impl_trait_for_tuples::impl_for_tuples;
-use std::{rc::Rc, result::Result};
+use std::{hash::Hash, rc::Rc, result::Result};
 
 /// Generalizes stream operators to groups of streams.
 ///
@@ -55,8 +55,8 @@ impl<B> RecursiveStreams<Circuit<Circuit<()>>> for Stream<Circuit<Circuit<()>>, 
 where
     //P: Clone +
     // 'static,
-    B: ZSet + DeepSizeOf + TryFrom<Rc<B>> + 'static,
-    B::Key: Clone + Ord + DeepSizeOf,
+    B: ZSet + DeepSizeOf + Send + TryFrom<Rc<B>> + 'static,
+    B::Key: Clone + Ord + Hash + DeepSizeOf,
     B::R: DeepSizeOf + ZRingValue,
 {
     type Feedback = DelayedFeedback<Circuit<()>, B>;

--- a/src/operator/recursive.rs
+++ b/src/operator/recursive.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use deepsize::DeepSizeOf;
 use impl_trait_for_tuples::impl_for_tuples;
-use std::{hash::Hash, rc::Rc, result::Result};
+use std::{hash::Hash, result::Result};
 
 /// Generalizes stream operators to groups of streams.
 ///
@@ -55,12 +55,12 @@ impl<B> RecursiveStreams<Circuit<Circuit<()>>> for Stream<Circuit<Circuit<()>>, 
 where
     //P: Clone +
     // 'static,
-    B: ZSet + DeepSizeOf + Send + TryFrom<Rc<B>> + 'static,
+    B: ZSet + DeepSizeOf + Send + 'static,
     B::Key: Clone + Ord + Hash + DeepSizeOf,
     B::R: DeepSizeOf + ZRingValue,
 {
     type Feedback = DelayedFeedback<Circuit<()>, B>;
-    type Export = Stream<Circuit<()>, Spine<Rc<B>>>;
+    type Export = Stream<Circuit<()>, Spine<B>>;
     type Output = Stream<Circuit<()>, B>;
 
     fn new(circuit: &Circuit<Circuit<()>>) -> (Self::Feedback, Self) {

--- a/src/operator/window.rs
+++ b/src/operator/window.rs
@@ -9,7 +9,7 @@ use crate::{
     trace::{cursor::Cursor, ord::OrdZSet, spine_fueled::Spine, Batch, BatchReader},
 };
 use deepsize::DeepSizeOf;
-use std::{borrow::Cow, cmp::max, marker::PhantomData, rc::Rc};
+use std::{borrow::Cow, cmp::max, marker::PhantomData};
 
 impl<P, B> Stream<Circuit<P>, B>
 where
@@ -118,7 +118,7 @@ where
     }
 }
 
-impl<B> TernaryOperator<Spine<Rc<B>>, B, (B::Key, B::Key), OrdZSet<B::Val, B::R>> for Window<B>
+impl<B> TernaryOperator<Spine<B>, B, (B::Key, B::Key), OrdZSet<B::Val, B::R>> for Window<B>
 where
     B: IndexedZSet,
     B::Val: Ord + Clone,
@@ -132,7 +132,7 @@ where
     /// * `bounds` - window bounds.  The lower bound must grow monotonically.
     fn eval(
         &mut self,
-        trace: Cow<'_, Spine<Rc<B>>>,
+        trace: Cow<'_, Spine<B>>,
         batch: Cow<'_, B>,
         bounds: Cow<'_, (B::Key, B::Key)>,
     ) -> OrdZSet<B::Val, B::R> {

--- a/src/trace/layers/mod.rs
+++ b/src/trace/layers/mod.rs
@@ -4,8 +4,6 @@
 //! elements in the next layer. Similarly, ranges of elements in the layer
 //! itself may correspond to single elements in the layer above.
 
-use crate::algebra::HasZero;
-
 pub mod ordered;
 pub mod ordered_leaf;
 // pub mod hashed;
@@ -60,15 +58,6 @@ pub trait Trie: Sized {
         // println!("{:?} and {:?}", self.keys(), other.keys());
         merger.push_merge(self.cursor(), other.cursor());
         merger.done()
-    }
-}
-
-impl<T: Trie> HasZero for T {
-    fn is_zero(&self) -> bool {
-        self.keys() == 0
-    }
-    fn zero() -> Self {
-        <Self as Trie>::TupleBuilder::new().done()
     }
 }
 

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -16,7 +16,11 @@ pub mod layers;
 pub mod ord;
 pub mod spine_fueled;
 
-use crate::{algebra::MonoidValue, lattice::Lattice, time::Timestamp};
+use crate::{
+    algebra::{HasZero, MonoidValue},
+    lattice::Lattice,
+    time::Timestamp,
+};
 use timely::progress::Antichain;
 
 pub use cursor::Cursor;
@@ -202,7 +206,7 @@ where
         merger.done()
     }
 
-    /// Creates an empty batch with timestamp `time`.
+    /// Creates an empty batch.
     fn empty(time: Self::Time) -> Self {
         <Self::Builder>::new(time).done()
     }
@@ -212,6 +216,19 @@ where
     /// Modifies all timestamps `t` that are not less than or equal to
     /// `frontier` to `t.meet(frontier)`.  See [`Trace::recede_to`].
     fn recede_to(&mut self, frontier: &Self::Time);
+}
+
+impl<B> HasZero for B
+where
+    B: Batch<Time = ()>,
+{
+    fn zero() -> Self {
+        Self::empty(())
+    }
+
+    fn is_zero(&self) -> bool {
+        self.is_empty()
+    }
 }
 
 /// Functionality for collecting and batching updates.

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -34,9 +34,7 @@ pub use cursor::Cursor;
 /// underlying trace and cause work to happen).
 pub trait TraceReader: BatchReader {
     /// The type of an immutable collection of updates.
-    type Batch: Batch<Key = Self::Key, Val = Self::Val, Time = Self::Time, R = Self::R>
-        + Clone
-        + 'static;
+    type Batch: Batch<Key = Self::Key, Val = Self::Val, Time = Self::Time, R = Self::R> + 'static;
 
     // TODO: Do we want a version of `cursor` with an upper bound on time?  E.g., it
     // could help in `distinct` to avoid iterating into the future (and then
@@ -168,7 +166,7 @@ where
 }
 
 /// An immutable collection of updates.
-pub trait Batch: BatchReader
+pub trait Batch: BatchReader + Clone
 where
     Self: Sized,
 {

--- a/src/trace/ord/indexed_zset_batch.rs
+++ b/src/trace/ord/indexed_zset_batch.rs
@@ -60,24 +60,6 @@ where
     }
 }
 
-impl<K, V, R, O> HasZero for OrdIndexedZSet<K, V, R, O>
-where
-    K: Ord + Clone + 'static,
-    V: Ord + Clone,
-    R: MonoidValue,
-    O: OrdOffset,
-    <O as TryFrom<usize>>::Error: Debug,
-    <O as TryInto<usize>>::Error: Debug,
-{
-    fn zero() -> Self {
-        Self::empty(())
-    }
-
-    fn is_zero(&self) -> bool {
-        self.is_empty()
-    }
-}
-
 impl<K, V, R, O> SharedRef for OrdIndexedZSet<K, V, R, O>
 where
     K: Ord + Clone,

--- a/src/trace/ord/indexed_zset_batch.rs
+++ b/src/trace/ord/indexed_zset_batch.rs
@@ -108,22 +108,6 @@ where
     }
 }
 
-impl<K, V, R, O> TryFrom<Rc<OrdIndexedZSet<K, V, R, O>>> for OrdIndexedZSet<K, V, R, O>
-where
-    K: Ord,
-    V: Ord,
-    R: Clone,
-    O: OrdOffset,
-    <O as TryFrom<usize>>::Error: Debug,
-    <O as TryInto<usize>>::Error: Debug,
-{
-    type Error = Rc<OrdIndexedZSet<K, V, R, O>>;
-
-    fn try_from(batch: Rc<OrdIndexedZSet<K, V, R, O>>) -> Result<Self, Self::Error> {
-        Rc::try_unwrap(batch)
-    }
-}
-
 impl<K, V, R, O> DeepSizeOf for OrdIndexedZSet<K, V, R, O>
 where
     K: DeepSizeOf + Ord,

--- a/src/trace/ord/key_batch.rs
+++ b/src/trace/ord/key_batch.rs
@@ -24,7 +24,7 @@ use deepsize::DeepSizeOf;
 
 /// An immutable collection of update tuples, from a contiguous interval of
 /// logical times.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct OrdKeyBatch<K, T, R, O = usize>
 where
     K: Ord,

--- a/src/trace/ord/mod.rs
+++ b/src/trace/ord/mod.rs
@@ -23,7 +23,6 @@
 //! `OrdKey` respectively, but are more light-weight.
 
 use crate::trace::spine_fueled::Spine;
-use std::rc::Rc;
 
 mod merge_batcher;
 
@@ -31,21 +30,21 @@ pub mod val_batch;
 pub use val_batch::OrdValBatch;
 
 /// A trace implementation using a spine of ordered lists.
-pub type OrdValSpine<K, V, T, R, O = usize> = Spine<Rc<OrdValBatch<K, V, T, R, O>>>;
+pub type OrdValSpine<K, V, T, R, O = usize> = Spine<OrdValBatch<K, V, T, R, O>>;
 
 pub mod key_batch;
 pub use key_batch::OrdKeyBatch;
 
 /// A trace implementation for empty values using a spine of ordered lists.
-pub type OrdKeySpine<K, T, R, O = usize> = Spine<Rc<OrdKeyBatch<K, T, R, O>>>;
+pub type OrdKeySpine<K, T, R, O = usize> = Spine<OrdKeyBatch<K, T, R, O>>;
 
 pub mod zset_batch;
 pub use zset_batch::OrdZSet;
 
 /// A trace implementation using a [`Spine`] of [`OrdZSet`].
-pub type OrdZSetSpine<K, R> = Spine<Rc<OrdZSet<K, R>>>;
+pub type OrdZSetSpine<K, R> = Spine<OrdZSet<K, R>>;
 
 pub mod indexed_zset_batch;
 pub use indexed_zset_batch::OrdIndexedZSet;
 
-pub type OrdIndexedZSetSpine<K, V, R, O = usize> = Spine<Rc<OrdIndexedZSet<K, V, R, O>>>;
+pub type OrdIndexedZSetSpine<K, V, R, O = usize> = Spine<OrdIndexedZSet<K, V, R, O>>;

--- a/src/trace/ord/val_batch.rs
+++ b/src/trace/ord/val_batch.rs
@@ -24,7 +24,7 @@ pub type OrdValBatchLayer<K, V, T, R, O> =
 
 /// An immutable collection of update tuples, from a contiguous interval of
 /// logical times.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct OrdValBatch<K, V, T, R, O = usize>
 where
     K: Ord,

--- a/src/trace/ord/zset_batch.rs
+++ b/src/trace/ord/zset_batch.rs
@@ -109,20 +109,6 @@ where
     const CONST_NUM_ENTRIES: Option<usize> = <OrderedLeaf<K, R>>::CONST_NUM_ENTRIES;
 }
 
-impl<K, R> HasZero for OrdZSet<K, R>
-where
-    K: Ord + Clone + 'static,
-    R: MonoidValue,
-{
-    fn zero() -> Self {
-        Self::empty(())
-    }
-
-    fn is_zero(&self) -> bool {
-        self.is_empty()
-    }
-}
-
 impl<K, R> Default for OrdZSet<K, R>
 where
     K: Ord + Clone + 'static,

--- a/src/trace/ord/zset_batch.rs
+++ b/src/trace/ord/zset_batch.rs
@@ -1,6 +1,5 @@
 use std::{
     cmp::max,
-    convert::TryFrom,
     fmt::{Debug, Display},
     ops::{Add, AddAssign, Neg},
     rc::Rc,
@@ -69,17 +68,6 @@ where
 {
     fn from(layer: OrderedLeaf<K, R>) -> Self {
         Rc::new(From::from(layer))
-    }
-}
-
-impl<K, R> TryFrom<Rc<OrdZSet<K, R>>> for OrdZSet<K, R>
-where
-    K: Ord,
-{
-    type Error = Rc<OrdZSet<K, R>>;
-
-    fn try_from(batch: Rc<OrdZSet<K, R>>) -> Result<Self, Self::Error> {
-        Rc::try_unwrap(batch)
     }
 }
 

--- a/src/trace/spine_fueled.rs
+++ b/src/trace/spine_fueled.rs
@@ -364,6 +364,17 @@ where
     }
 }
 
+impl<B> Default for Spine<B>
+where
+    B: Batch + Clone + 'static,
+    B::Key: Ord,
+    B::Val: Ord,
+{
+    fn default() -> Self {
+        Self::new(None)
+    }
+}
+
 impl<B> Trace for Spine<B>
 where
     B: Batch + Clone + 'static,


### PR DESCRIPTION
Theory
======

We parallelize processing across `N` worker threads by creating a
replica of the same circuit per thread and sharding data across
replicas.  To ensure correctness (i.e., that the sum of outputs
produced by individual workers is equal to the output produced
by processing the entire dataset by one worker), sharding must satisfy
certain requirements determined by each operator.  In particular,
for `distinct`, and `aggregate` all tuples that share the same key
must be processed by the same worker.  For `join`, tuples from both
input streams with the same key must be processed by the same worker.

Other operators, e.g., `filter` and `flat_map`, impose no restrictions
on the sharding scheme: as long as each tuple in a batch is
processed by some worker, the correct result will be produced.  This
is true for all linear operators.

The `shard` operator
====================

This commit introduces the `shard` operator, which shards input batches
based on the hash of the key, making sure that tuples with the same key
always end up at the same worker.  More precisely, the operator
**re-shards** its input by partitioning batches in the input stream of
each worker based on the hash of the key, distributing resulting
fragments amond peers and re-assembling fragments at each peer.

I used the new operator to generalize `join`, `distinct` and `aggregate`
to work in the multithreaded environment.

Fixed point
==========

In a multithreaded environment the fixedpoint check cannot be performed
locally.  The circuit must iterate until all peers have reached a fixed
point.  I used the `Exchange` synchronization primitive to broadcast
the fixed point state from each worker to all peers.

TODOs
=====

We need to figure out how to parallelize non-equi joins.  At the moment
`range_join` will not work correctly with more than one worker thread.

Performance
===========

Very preliminary performance results:

- path benchmark: 10x speedup going from 0 to 16 threads
- galen benchmark: 3x speedup going from 0 to 8 threads, with little
  improvement beyond 4 threads.

This suggests that more complex programs with many operators that require
re-sharding input streams are harder to scale as every such operator introduces
a global barrier.

Interestingly, the DD version of galen only scales marginally better than DBSP,
with 4x speedup on 8 worker threads, but its absolute performance is still
slightly worse than DBSP.