### PR TITLE
[nexmark] Fix confusion of micro and milli-seconds.

### DIFF
--- a/benches/nexmark/generator/config.rs
+++ b/benches/nexmark/generator/config.rs
@@ -98,7 +98,7 @@ impl Config {
     // What timestamp should the event with `eventNumber` have for this
     // generator?
     pub fn timestamp_for_event(&self, event_number: u64) -> u64 {
-        return self.base_time + self.inter_event_delay_us[0] as u64 * event_number;
+        return self.base_time + self.inter_event_delay_us[0] as u64 * event_number / 1000;
     }
 }
 
@@ -169,11 +169,11 @@ pub mod tests {
 
     // With the default first event rate of 10_000 events per second and one
     // generator, there is 1_000_000 µs/s / 10_000 events/s = 100µs / event, so
-    // the timestamp increases by 100µs for each event.
+    // the timestamp increases by 100µs, ie. 0.1ms for each event.
     #[rstest]
-    #[case(1, 100*1)]
-    #[case(2, 100*2)]
-    #[case(5, 100*5)]
+    #[case(10, 1)]
+    #[case(20, 2)]
+    #[case(50, 5)]
     fn test_timestamp_for_event(#[case] event_number: u64, #[case] expected: u64) {
         assert_eq!(
             Config::default().timestamp_for_event(event_number),

--- a/benches/nexmark/nexmark_dbsp_source.rs
+++ b/benches/nexmark/nexmark_dbsp_source.rs
@@ -87,11 +87,11 @@ where
         // Otherwise we want to emit at least one event, so if the next event
         // is still in the future, we sleep until we can emit it.
         let next_event = next_event.unwrap();
-        let wallclock_time_now = self.generator.wallclock_time();
+        let mut wallclock_time_now = self.generator.wallclock_time();
         if next_event.wallclock_timestamp > wallclock_time_now {
-            sleep(Duration::from_millis(
-                next_event.wallclock_timestamp - wallclock_time_now,
-            ));
+            let millis_to_sleep = next_event.wallclock_timestamp - wallclock_time_now;
+            sleep(Duration::from_millis(millis_to_sleep));
+            wallclock_time_now += millis_to_sleep;
         }
 
         // Collect as many next events as are ready.

--- a/benches/nexmark/nexmark_dbsp_source.rs
+++ b/benches/nexmark/nexmark_dbsp_source.rs
@@ -1,6 +1,6 @@
 //! DBSP Source operator that reads from a Nexmark Generator.
 
-use crate::generator::{wallclock_time, NexmarkGenerator, NextEvent};
+use crate::generator::{NexmarkGenerator, NextEvent};
 use crate::model::Event;
 use dbsp::{
     algebra::{ZRingValue, ZSet},
@@ -87,7 +87,7 @@ where
         // Otherwise we want to emit at least one event, so if the next event
         // is still in the future, we sleep until we can emit it.
         let next_event = next_event.unwrap();
-        let wallclock_time_now = wallclock_time();
+        let wallclock_time_now = self.generator.wallclock_time();
         if next_event.wallclock_timestamp > wallclock_time_now {
             sleep(Duration::from_millis(
                 next_event.wallclock_timestamp - wallclock_time_now,
@@ -97,9 +97,8 @@ where
         // Collect as many next events as are ready.
         let mut next_events = vec![next_event];
         let mut next_event = self.generator.next_event().unwrap();
-        let wallclock_time_now = wallclock_time();
         while next_event
-            .is_some_and(|next_event| next_event.wallclock_timestamp.clone() < wallclock_time_now)
+            .is_some_and(|next_event| next_event.wallclock_timestamp.clone() <= wallclock_time_now)
         {
             next_events.push(next_event.unwrap());
             next_event = self.generator.next_event().unwrap();
@@ -220,37 +219,31 @@ mod test {
         root.step().unwrap();
     }
 
-    // When keeping up with the input, there is no buffering and results
-    // are returned one at a time.
+    // With the default rate of 10_000 events per second, or 10 per millisecond,
+    // and then using canned milliseconds for the wallclock time, we can expect
+    // batches of 10 events per call to eval.
     #[test]
-    fn test_eval_current_time() {
-        let wallclock_time = wallclock_time();
-        let mut source = make_test_source(wallclock_time, 5);
-        let expected_zset_tuples = generate_expected_zset_tuples(wallclock_time, 10);
+    fn test_eval_batched() {
+        let wallclock_time = 0;
+        let mut source = make_test_source(wallclock_time, 30);
+        source
+            .generator
+            .set_wallclock_time_iterator((0..30).into_iter());
+        let expected_zset_tuples = generate_expected_zset_tuples(wallclock_time, 30);
 
         assert_eq!(
             source.eval(),
-            OrdZSet::from_tuples((), Vec::from(&expected_zset_tuples[0..1]))
+            OrdZSet::from_tuples((), Vec::from(&expected_zset_tuples[0..10]))
         );
 
         assert_eq!(
             source.eval(),
-            OrdZSet::from_tuples((), Vec::from(&expected_zset_tuples[1..2]))
+            OrdZSet::from_tuples((), Vec::from(&expected_zset_tuples[10..20]))
         );
 
         assert_eq!(
             source.eval(),
-            OrdZSet::from_tuples((), Vec::from(&expected_zset_tuples[2..3]))
-        );
-
-        assert_eq!(
-            source.eval(),
-            OrdZSet::from_tuples((), Vec::from(&expected_zset_tuples[3..4]))
-        );
-
-        assert_eq!(
-            source.eval(),
-            OrdZSet::from_tuples((), Vec::from(&expected_zset_tuples[4..5]))
+            OrdZSet::from_tuples((), Vec::from(&expected_zset_tuples[20..30]))
         );
     }
 }

--- a/benches/nexmark/nexmark_dbsp_source.rs
+++ b/benches/nexmark/nexmark_dbsp_source.rs
@@ -74,10 +74,10 @@ where
         // Grab a next event, either the last event from the previous call that
         // was saved because it couldn't yet be emitted, or the next generated
         // event.
-        let next_event = match self.next_event.clone() {
-            Some(e) => Some(e),
-            None => self.generator.next_event().unwrap(),
-        };
+        let next_event = self
+            .next_event
+            .clone()
+            .or_else(|| self.generator.next_event().unwrap());
 
         // If there are no more events, we return an empty set.
         if next_event.is_none() {


### PR DESCRIPTION
After people pointed out that 100ms between each event was obviously odd as a default (even if configurable), I rechecked and found I'd missed a point where the java code specifically uses *micro* seconds rather than *milli* seconds.

The actual fix was obviously trivial (and now matches the upstream java code), but testing the batching of results was trickier... I've injected an optional iterator for wallclock times that can be used in tests. Not sure if there's a better way. See what you think. FWIW, the working test then found another small issue (the change from `<` to `<=` when including events in a batch).

Signed-off-by: Michael Nelson <minelson@vmware.com>