### PR TITLE
[nexmark] Add q2 and refactor for better testing.

### DIFF
--- a/src/nexmark/queries/mod.rs
+++ b/src/nexmark/queries/mod.rs
@@ -3,8 +3,10 @@ use super::model::Event;
 use crate::{Circuit, OrdZSet, Stream};
 pub use q0::q0;
 pub use q1::q1;
+pub use q2::q2;
 
 type NexmarkStream = Stream<Circuit<()>, OrdZSet<Event, isize>>;
 
 mod q0;
 mod q1;
+mod q2;

--- a/src/nexmark/queries/q0.rs
+++ b/src/nexmark/queries/q0.rs
@@ -10,13 +10,12 @@ pub fn q0(input: NexmarkStream) -> NexmarkStream {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::nexmark::tests::{generate_expected_zset_tuples, make_test_source};
+    use crate::nexmark::tests::{generate_expected_zset_tuples, make_source_with_wallclock_times};
     use crate::{circuit::Root, trace::ord::OrdZSet, trace::Batch};
 
     #[test]
     fn test_q0() {
-        let mut source = make_test_source(0, 10);
-        source.set_wallclock_time_iterator((0..1).into_iter());
+        let source = make_source_with_wallclock_times(1..3, 10);
 
         let root = Root::build(move |circuit| {
             let input = circuit.add_source(source);

--- a/src/nexmark/queries/q1.rs
+++ b/src/nexmark/queries/q1.rs
@@ -18,13 +18,12 @@ pub fn q1(input: NexmarkStream) -> NexmarkStream {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::nexmark::tests::{generate_expected_zset_tuples, make_test_source};
+    use crate::nexmark::tests::{generate_expected_zset_tuples, make_source_with_wallclock_times};
     use crate::{circuit::Root, trace::ord::OrdZSet, trace::Batch};
 
     #[test]
     fn test_q1() {
-        let mut source = make_test_source(0, 10);
-        source.set_wallclock_time_iterator((0..1).into_iter());
+        let source = make_source_with_wallclock_times(0..2, 10);
 
         let root = Root::build(move |circuit| {
             let input = circuit.add_source(source);

--- a/src/nexmark/queries/q2.rs
+++ b/src/nexmark/queries/q2.rs
@@ -1,0 +1,130 @@
+use super::NexmarkStream;
+use crate::{nexmark::model::Event, operator::FilterMap, Circuit, OrdZSet, Stream};
+
+/// Selection
+///
+/// Find bids with specific auction ids and show their bid price.
+/// See https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/resources/queries/q2.sql
+const AUCTION_ID_MODULO: u64 = 123;
+
+pub fn q2(input: NexmarkStream) -> Stream<Circuit<()>, OrdZSet<(u64, usize), isize>> {
+    input
+        .filter(|event| match event {
+            Event::Bid(b) => b.auction % AUCTION_ID_MODULO == 0,
+            _ => false,
+        })
+        .map(|bid_event| match bid_event {
+            Event::Bid(b) => (b.auction, b.price),
+            _ => panic!("bid expected but not found."),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nexmark::{
+        generator::{tests::CannedEventGenerator, NextEvent},
+        model::{Auction, Bid},
+        NexmarkSource,
+    };
+    use crate::{circuit::Root, trace::ord::OrdZSet, trace::Batch};
+    use rand::rngs::mock::StepRng;
+
+    fn default_bid() -> Bid {
+        Bid {
+            auction: AUCTION_ID_MODULO,
+            bidder: 0,
+            price: 99,
+            channel: String::from("my-channel"),
+            url: String::from("https://example.com"),
+            date_time: 0,
+            extra: String::new(),
+        }
+    }
+
+    fn default_auction() -> Auction {
+        Auction {
+            id: 1,
+            item_name: String::from("item-name"),
+            description: String::from("description"),
+            initial_bid: 5,
+            reserve: 10,
+            date_time: 0,
+            expires: 0,
+            seller: 1,
+            category: 1,
+        }
+    }
+
+    fn default_next_event() -> NextEvent {
+        NextEvent {
+            wallclock_timestamp: 0,
+            event_timestamp: 0,
+            event: Event::Bid(default_bid()),
+            watermark: 0,
+        }
+    }
+
+    #[test]
+    fn test_q2() {
+        let canned_events: Vec<NextEvent> = vec![
+            NextEvent {
+                event: Event::Bid(Bid {
+                    auction: AUCTION_ID_MODULO,
+                    price: 99,
+                    ..default_bid()
+                }),
+                ..default_next_event()
+            },
+            NextEvent {
+                event: Event::Bid(Bid {
+                    auction: 125,
+                    price: 101,
+                    ..default_bid()
+                }),
+                ..default_next_event()
+            },
+            NextEvent {
+                event: Event::Auction(default_auction()),
+                ..default_next_event()
+            },
+            NextEvent {
+                event: Event::Bid(Bid {
+                    auction: 5 * AUCTION_ID_MODULO,
+                    price: 125,
+                    ..default_bid()
+                }),
+                ..default_next_event()
+            },
+        ];
+        let source: NexmarkSource<StepRng, isize, OrdZSet<Event, isize>> =
+            NexmarkSource::from_generator(CannedEventGenerator::new(canned_events));
+
+        let root = Root::build(move |circuit| {
+            let input = circuit.add_source(source);
+
+            let output = q2(input);
+
+            output.inspect(move |e| {
+                // Only the two bids with an auction (id) that is modulo
+                // AUCTION_ID_MODULO are included in the tuple results of
+                // id and price.
+                assert_eq!(
+                    e,
+                    &OrdZSet::from_tuples(
+                        (),
+                        vec![
+                            (((AUCTION_ID_MODULO, 99), ()), 1),
+                            (((5 * AUCTION_ID_MODULO, 125), ()), 1),
+                        ]
+                    )
+                )
+            });
+        })
+        .unwrap();
+
+        for _ in 0..1 {
+            root.step().unwrap();
+        }
+    }
+}

--- a/src/nexmark/queries/q2.rs
+++ b/src/nexmark/queries/q2.rs
@@ -8,15 +8,13 @@ use crate::{nexmark::model::Event, operator::FilterMap, Circuit, OrdZSet, Stream
 const AUCTION_ID_MODULO: u64 = 123;
 
 pub fn q2(input: NexmarkStream) -> Stream<Circuit<()>, OrdZSet<(u64, usize), isize>> {
-    input
-        .filter(|event| match event {
-            Event::Bid(b) => b.auction % AUCTION_ID_MODULO == 0,
-            _ => false,
-        })
-        .map(|bid_event| match bid_event {
-            Event::Bid(b) => (b.auction, b.price),
-            _ => panic!("bid expected but not found."),
-        })
+    input.flat_map(|event| match event {
+        Event::Bid(b) => match b.auction % AUCTION_ID_MODULO == 0 {
+            true => Some((b.auction, b.price)),
+            false => None,
+        },
+        _ => None,
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

Adding the Nexmark q2 query itself was trivial, but unit testing it was not, but is now. Up until now, I've been testing the nexmark source only, so it was fine to test against the generated events of a (non-random) Nexmark generator. But the q2 query (and subsequent ones that I'll be implementing) require a lot of iterations to test (and even then, not obviously), so this PR:

1. Updates the `NexmarkSource` struct to expect an object that implements the `EventGenerator` trait (rather than expecting a `NexmarkGenerator` always.
2. Adds the test-only `CannedEventGenerator` and uses it to test the `q2` query succinctly,
3. Removes the test-only code from the actual `NexmarkGenerator` for creating a generator that emits wallclock times from a range and put it into another test-only generator `RangedTimeGenerator`.

This was a pain (as in, felt unproductive to be refactoring test code so much for a single query), but should make subsequent queries simple to test as well.
