### PR TITLE
[nexmark] Add failing q3 test until I better understand the join.

### DIFF
--- a/src/nexmark/generator/mod.rs
+++ b/src/nexmark/generator/mod.rs
@@ -178,6 +178,7 @@ pub struct NextEvent {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use crate::nexmark::model::{Auction, Bid, Person};
     use rand::{rngs::mock::StepRng, thread_rng};
 
     /// A NexmarkGenerator with an iterator for the wallclock time.
@@ -270,6 +271,54 @@ pub mod tests {
 
     pub fn make_test_generator() -> NexmarkGenerator<StepRng> {
         NexmarkGenerator::new(Config::default(), StepRng::new(0, 1))
+    }
+
+    pub fn make_person() -> Person {
+        Person {
+            id: 1,
+            name: String::from("AAA BBBB"),
+            email_address: String::from("AAABBB@example.com"),
+            credit_card: String::from("1111 2222 3333 4444"),
+            city: String::from("Phoenix"),
+            state: String::from("OR"),
+            date_time: 0,
+            extra: String::from(""),
+        }
+    }
+
+    pub fn make_bid() -> Bid {
+        Bid {
+            auction: 1,
+            bidder: 1,
+            price: 99,
+            channel: String::from("my-channel"),
+            url: String::from("https://example.com"),
+            date_time: 0,
+            extra: String::new(),
+        }
+    }
+
+    pub fn make_auction() -> Auction {
+        Auction {
+            id: 1,
+            item_name: String::from("item-name"),
+            description: String::from("description"),
+            initial_bid: 5,
+            reserve: 10,
+            date_time: 0,
+            expires: 0,
+            seller: 1,
+            category: 1,
+        }
+    }
+
+    pub fn make_next_event() -> NextEvent {
+        NextEvent {
+            wallclock_timestamp: 0,
+            event_timestamp: 0,
+            event: Event::Bid(make_bid()),
+            watermark: 0,
+        }
     }
 
     /// Generates a specified number of next events using the default test

--- a/src/nexmark/queries/mod.rs
+++ b/src/nexmark/queries/mod.rs
@@ -4,9 +4,11 @@ use crate::{Circuit, OrdZSet, Stream};
 pub use q0::q0;
 pub use q1::q1;
 pub use q2::q2;
+pub use q3::q3;
 
 type NexmarkStream = Stream<Circuit<()>, OrdZSet<Event, isize>>;
 
 mod q0;
 mod q1;
 mod q2;
+mod q3;

--- a/src/nexmark/queries/q0.rs
+++ b/src/nexmark/queries/q0.rs
@@ -3,6 +3,7 @@ use crate::operator::FilterMap;
 /// Passthrough
 ///
 /// Measures the monitoring overhead including the source generator.
+/// See https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/resources/queries/q0.sql
 pub fn q0(input: NexmarkStream) -> NexmarkStream {
     input.map(|event| event.clone())
 }

--- a/src/nexmark/queries/q0.rs
+++ b/src/nexmark/queries/q0.rs
@@ -3,7 +3,7 @@ use crate::operator::FilterMap;
 /// Passthrough
 ///
 /// Measures the monitoring overhead including the source generator.
-/// See https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/resources/queries/q0.sql
+/// See [Nexmark q0.sql](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/resources/queries/q0.sql)
 pub fn q0(input: NexmarkStream) -> NexmarkStream {
     input.map(|event| event.clone())
 }

--- a/src/nexmark/queries/q1.rs
+++ b/src/nexmark/queries/q1.rs
@@ -7,7 +7,8 @@ use crate::operator::FilterMap;
 /// Convert each bid value from dollars to euros. Illustrates a simple
 /// transformation.
 ///
-/// From https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/resources/queries/q1.sql
+/// From [Nexmark q1.sql](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/resources/queries/q1.sql):
+///
 /// CREATE TABLE discard_sink (
 ///   auction  BIGINT,
 ///   bidder  BIGINT,

--- a/src/nexmark/queries/q1.rs
+++ b/src/nexmark/queries/q1.rs
@@ -4,7 +4,28 @@ use crate::operator::FilterMap;
 
 /// Currency Conversion
 ///
-/// Convert each bid value from dollars to euros.
+/// Convert each bid value from dollars to euros. Illustrates a simple
+/// transformation.
+///
+/// From https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/resources/queries/q1.sql
+/// CREATE TABLE discard_sink (
+///   auction  BIGINT,
+///   bidder  BIGINT,
+///   price  DECIMAL(23, 3),
+///   dateTime  TIMESTAMP(3),
+///   extra  VARCHAR
+/// ) WITH (
+///   'connector' = 'blackhole'
+/// );
+///
+/// INSERT INTO discard_sink
+/// SELECT
+///     auction,
+///     bidder,
+///     0.908 * price as price, -- convert dollar to euro
+///     dateTime,
+///     extra
+/// FROM bid;
 pub fn q1(input: NexmarkStream) -> NexmarkStream {
     input.map(|event| match event {
         Event::Bid(b) => Event::Bid(Bid {

--- a/src/nexmark/queries/q2.rs
+++ b/src/nexmark/queries/q2.rs
@@ -5,7 +5,7 @@ use crate::{nexmark::model::Event, operator::FilterMap, Circuit, OrdZSet, Stream
 ///
 /// Find bids with specific auction ids and show their bid price.
 ///
-/// From https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/resources/queries/q2.sql
+/// From [Nexmark q2.sql](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/resources/queries/q2.sql):
 ///
 /// CREATE TABLE discard_sink (
 ///   auction  BIGINT,

--- a/src/nexmark/queries/q2.rs
+++ b/src/nexmark/queries/q2.rs
@@ -21,47 +21,15 @@ pub fn q2(input: NexmarkStream) -> Stream<Circuit<()>, OrdZSet<(u64, usize), isi
 mod tests {
     use super::*;
     use crate::nexmark::{
-        generator::{tests::CannedEventGenerator, NextEvent},
-        model::{Auction, Bid},
+        generator::{
+            tests::{make_auction, make_bid, make_next_event, CannedEventGenerator},
+            NextEvent,
+        },
+        model::Bid,
         NexmarkSource,
     };
     use crate::{circuit::Root, trace::ord::OrdZSet, trace::Batch};
     use rand::rngs::mock::StepRng;
-
-    fn default_bid() -> Bid {
-        Bid {
-            auction: AUCTION_ID_MODULO,
-            bidder: 0,
-            price: 99,
-            channel: String::from("my-channel"),
-            url: String::from("https://example.com"),
-            date_time: 0,
-            extra: String::new(),
-        }
-    }
-
-    fn default_auction() -> Auction {
-        Auction {
-            id: 1,
-            item_name: String::from("item-name"),
-            description: String::from("description"),
-            initial_bid: 5,
-            reserve: 10,
-            date_time: 0,
-            expires: 0,
-            seller: 1,
-            category: 1,
-        }
-    }
-
-    fn default_next_event() -> NextEvent {
-        NextEvent {
-            wallclock_timestamp: 0,
-            event_timestamp: 0,
-            event: Event::Bid(default_bid()),
-            watermark: 0,
-        }
-    }
 
     #[test]
     fn test_q2() {
@@ -70,29 +38,29 @@ mod tests {
                 event: Event::Bid(Bid {
                     auction: AUCTION_ID_MODULO,
                     price: 99,
-                    ..default_bid()
+                    ..make_bid()
                 }),
-                ..default_next_event()
+                ..make_next_event()
             },
             NextEvent {
                 event: Event::Bid(Bid {
                     auction: 125,
                     price: 101,
-                    ..default_bid()
+                    ..make_bid()
                 }),
-                ..default_next_event()
+                ..make_next_event()
             },
             NextEvent {
-                event: Event::Auction(default_auction()),
-                ..default_next_event()
+                event: Event::Auction(make_auction()),
+                ..make_next_event()
             },
             NextEvent {
                 event: Event::Bid(Bid {
                     auction: 5 * AUCTION_ID_MODULO,
                     price: 125,
-                    ..default_bid()
+                    ..make_bid()
                 }),
-                ..default_next_event()
+                ..make_next_event()
             },
         ];
         let source: NexmarkSource<StepRng, isize, OrdZSet<Event, isize>> =
@@ -121,8 +89,6 @@ mod tests {
         })
         .unwrap();
 
-        for _ in 0..1 {
-            root.step().unwrap();
-        }
+        root.step().unwrap();
     }
 }

--- a/src/nexmark/queries/q2.rs
+++ b/src/nexmark/queries/q2.rs
@@ -4,7 +4,18 @@ use crate::{nexmark::model::Event, operator::FilterMap, Circuit, OrdZSet, Stream
 /// Selection
 ///
 /// Find bids with specific auction ids and show their bid price.
-/// See https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/resources/queries/q2.sql
+///
+/// From https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/resources/queries/q2.sql
+///
+/// CREATE TABLE discard_sink (
+///   auction  BIGINT,
+///   price  BIGINT
+/// ) WITH (
+///   'connector' = 'blackhole'
+/// );
+///
+/// INSERT INTO discard_sink
+/// SELECT auction, price FROM bid WHERE MOD(auction, 123) = 0;
 const AUCTION_ID_MODULO: u64 = 123;
 
 pub fn q2(input: NexmarkStream) -> Stream<Circuit<()>, OrdZSet<(u64, usize), isize>> {

--- a/src/nexmark/queries/q3.rs
+++ b/src/nexmark/queries/q3.rs
@@ -6,7 +6,7 @@ use crate::{nexmark::model::Event, operator::FilterMap, Circuit, OrdZSet, Stream
 /// Who is selling in OR, ID or CA in category 10, and for what auction ids?
 /// Illustrates an incremental join (using per-key state and timer) and filter.
 ///
-/// From https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/resources/queries/q3.sql
+/// From [Nexmark q3.sql](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/resources/queries/q3.sql)
 ///
 /// CREATE TABLE discard_sink (
 ///   name  VARCHAR,

--- a/src/nexmark/queries/q3.rs
+++ b/src/nexmark/queries/q3.rs
@@ -1,0 +1,157 @@
+use super::NexmarkStream;
+use crate::{nexmark::model::Event, operator::FilterMap, Circuit, OrdZSet, Stream};
+
+/// Local Item Suggestion
+///
+/// Who is selling in OR, ID or CA in category 10, and for what auction ids?
+/// Illustrates an incremental join (using per-key state and timer) and filter.
+///
+/// See https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/resources/queries/q3.sql
+
+const STATES_OF_INTEREST: &[&str] = &["OR", "ID", "CA"];
+const CATEGORY_OF_INTEREST: usize = 10;
+
+pub fn q3(
+    input: NexmarkStream,
+) -> Stream<Circuit<()>, OrdZSet<(String, String, String, u64), isize>> {
+    // TODO: It's unclear to me how I'd using the DBSP join here (which seems
+    // more like a zip). In particular, how is state maintained for the people
+    // to look up the person when a related auction is found? Looks like it
+    // may be related to an indexed zset - but how would it be indexed on the person
+    // id?
+    //
+    // let auctions = input.filter(|event| match event {
+    //     Event::Auction(a) => a.category == 10,
+    //     _ => false,
+    // });
+
+    // For now, just return the people matching the states regardless of
+    // the join on auction.seller.
+    input.flat_map(|event| match event {
+        Event::Person(p) => match STATES_OF_INTEREST.contains(&p.state.as_str()) {
+            true => Some((p.name.clone(), p.city.clone(), p.state.clone(), 0)),
+            false => None,
+        },
+        _ => None,
+    })
+    // let people_indexed = people.index();
+
+    // Look at join_trace_test for an example that uses same input (edges).
+    // auctions.join(&people, |_via, not, sure| {})
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::nexmark::{
+        generator::{
+            tests::{make_auction, make_next_event, make_person, CannedEventGenerator},
+            NextEvent,
+        },
+        model::{Auction, Person},
+        NexmarkSource,
+    };
+    use crate::{circuit::Root, trace::ord::OrdZSet, trace::Batch};
+    use rand::rngs::mock::StepRng;
+
+    #[test]
+    fn test_q3_people() {
+        let canned_events: Vec<NextEvent> = vec![
+            NextEvent {
+                event: Event::Person(Person {
+                    id: 1,
+                    name: String::from("NL Seller"),
+                    state: String::from("NL"),
+                    ..make_person()
+                }),
+                ..make_next_event()
+            },
+            NextEvent {
+                event: Event::Person(Person {
+                    id: 2,
+                    name: String::from("CA Seller"),
+                    state: String::from("CA"),
+                    ..make_person()
+                }),
+                ..make_next_event()
+            },
+            NextEvent {
+                event: Event::Person(Person {
+                    id: 3,
+                    name: String::from("ID Seller"),
+                    state: String::from("ID"),
+                    ..make_person()
+                }),
+                ..make_next_event()
+            },
+            NextEvent {
+                event: Event::Auction(Auction {
+                    id: 999,
+                    seller: 2,
+                    category: CATEGORY_OF_INTEREST,
+                    ..make_auction()
+                }),
+                ..make_next_event()
+            },
+            NextEvent {
+                event: Event::Auction(Auction {
+                    id: 452,
+                    seller: 3,
+                    category: CATEGORY_OF_INTEREST,
+                    ..make_auction()
+                }),
+                ..make_next_event()
+            },
+        ];
+
+        let source: NexmarkSource<StepRng, isize, OrdZSet<Event, isize>> =
+            NexmarkSource::from_generator(CannedEventGenerator::new(canned_events));
+
+        let root = Root::build(move |circuit| {
+            let input = circuit.add_source(source);
+
+            let output = q3(input);
+
+            output.inspect(move |e| {
+                // This is failing currently because it's just returning the sellers and not
+                // joining to get the correct auction ids, until I go back and learn more about
+                // DBSP joins.
+                assert_eq!(
+                    e,
+                    &OrdZSet::from_tuples(
+                        (),
+                        vec![
+                            (
+                                (
+                                    (
+                                        String::from("CA Seller"),
+                                        String::from("Phoenix"),
+                                        String::from("CA"),
+                                        999,
+                                    ),
+                                    ()
+                                ),
+                                1
+                            ),
+                            (
+                                (
+                                    (
+                                        String::from("ID Seller"),
+                                        String::from("Phoenix"),
+                                        String::from("ID"),
+                                        452,
+                                    ),
+                                    ()
+                                ),
+                                1
+                            ),
+                        ]
+                    )
+                )
+            });
+        })
+        .unwrap();
+
+        root.step().unwrap();
+    }
+}


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

Help :) . I've written a test for the q3 nexmark query, which features an incremental join, but... I don't yet know enough about DBSP to see how I would achieve an incremental join with the single input stream. I've been through a few of the tests in `join.rs`, but don't see anything similar (most similar is the `join_trace_test`, which uses the input for two different operators, but it also has a recursive input (which I don't think I'd need here). I assume I need to split the input into auctions and people then join those (after indexing people so they can be looked up while going through the auctions?), but I'm still searching there.

Anyway, I've left a few questions inline. I'd be happy just to be pointed in the right direction - I may need to go back and keep working through the spec.pdf, not sure.

No rush, in the mean-time, I'll start improving the test harness itself.