### PR TITLE
[nexmark] Add initial macros for running nexmark queries.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c91f1f46651137be86f3a2b9a8359f9ab421d04d941c62b5982e1ca21113adf9"
 
 [[package]]
+name = "arrayvec"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
+dependencies = [
+ "nodrop",
+]
+
+[[package]]
+name = "ascii_table"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75054ce561491263d7b80dc2f6f6c6f8cdfd0c7a7c17c5cf3b8117829fa72ae1"
+
+[[package]]
 name = "async-trait"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,6 +541,7 @@ name = "dbsp"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "ascii_table",
  "cached",
  "clap 3.2.16",
  "criterion",
@@ -538,6 +554,7 @@ dependencies = [
  "impl-trait-for-tuples",
  "indicatif",
  "num",
+ "num-format",
  "once_cell",
  "ordered-float",
  "petgraph",
@@ -1141,6 +1158,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
 name = "num"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,6 +1195,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "num-format"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465"
+dependencies = [
+ "arrayvec",
+ "itoa 0.4.8",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ indicatif = "0.17.0-rc.11"
 ordered-float = "3.0.0"
 clap = { version = "3.2.8", features = ["derive", "env"] }
 reqwest = { version = "0.11.11", features = ["blocking"] }
+ascii_table = "4.0.2"
+num-format = "0.4.0"
 
 [target.'cfg(windows)'.dev-dependencies]
 winapi = { version = "0.3.9", features = ["psapi"] }

--- a/benches/nexmark/main.rs
+++ b/benches/nexmark/main.rs
@@ -2,9 +2,13 @@
 //!
 //! CLI for running Nexmark benchmarks with DBSP.
 #![feature(is_some_with)]
-use std::{cell::Cell, rc::Rc, time::Instant};
+use std::{
+    sync::{mpsc, mpsc::TryRecvError},
+    time::{Duration, Instant},
+};
 
 use anyhow::Result;
+use ascii_table::AsciiTable;
 use clap::Parser;
 use dbsp::{
     circuit::{Circuit, Root},
@@ -17,6 +21,7 @@ use dbsp::{
     },
     trace::{ord::OrdZSet, BatchReader},
 };
+use num_format::{Locale, ToFormattedString};
 use rand::prelude::ThreadRng;
 
 // TODO: Ideally these macros would be in a separate `lib.rs` in this benchmark
@@ -27,68 +32,116 @@ use rand::prelude::ThreadRng;
 /// Returns a closure for a circuit with the nexmark source that sets
 /// `max_events_reached` once no more data is available.
 macro_rules! nexmark_circuit {
-    ( $q:expr, $generator_config:expr, $max_events_reached:expr ) => {
+    ( $q:expr, $generator_config:expr, $output_fixedpoint_tx:expr ) => {
         |circuit: &mut Circuit<()>| {
-            let source =
-                NexmarkSource::<ThreadRng, isize, OrdZSet<Event, isize>>::new($generator_config);
+            // We need the source to signal when it has reached its fixedpoint.
+            let (fixedpoint_tx, fixedpoint_rx) = mpsc::channel();
+            let mut num_events_generated = 0;
+
+            let source = NexmarkSource::<ThreadRng, isize, OrdZSet<Event, isize>>::new(
+                $generator_config,
+                fixedpoint_tx,
+            );
             let input = circuit.add_source(source);
+
+            // Need to somehow have access to the generator's events_count_so_far ? Or have
+            // a signal sent - have a fn on the source which returns a channel that
+            // can be watched for when the source is exhausted - though will this
+            // also be a borrow?
 
             let output = $q(input);
 
             output.inspect(move |zs: &OrdZSet<_, _>| {
-                // Turns out we can't count events by accumulating the lengths of
-                // the `OrdZSet` since duplicate bids are not that difficult to produce in the
-                // generator (0-3 per 1000), which get merged to a single Item in the `OrdZSet`
-                // with an adjusted weight. Instead, stop when we get empty sets.
-                // TODO(absoludity): Nope, can't do that either as some streams
-                // return empty sets for initial data (eg, q2 doesn't emit data until the 123rd
-                // auction, which is well beyond 1000 generated events).
-                if zs.len() == 0 {
-                    $max_events_reached.set(true);
+                // Turns out we can't get an exact count of events by accumulating the lengths
+                // of the `OrdZSet` since duplicate bids are not that difficult to
+                // produce in the generator (0-3 per 1000), which get merged to a
+                // single Item in the `OrdZSet` with an adjusted weight. Nor does
+                // the number of output events even correspond with the input events
+                // necessarily. Nor can we rely on empty sets as an indicator that
+                // it's finished (since they'll be returned in queries that don't
+                // emit data often). So, for simplicity, the source sends a message
+                // on it's fixedpoint_sync channel when it reaches its fixed point, which we can
+                // read here.
+                match fixedpoint_rx.try_recv() {
+                    Ok(num_events) => {
+                        num_events_generated = num_events;
+                    }
+                    Err(TryRecvError::Empty) => (),
+                    _ => panic!("unexpected result from fixedpoint_sync channel"),
+                };
+                // The source may reach its fixed point for inputs before they have been
+                // processed.
+                if num_events_generated > 0 && zs.len() == 0 {
+                    $output_fixedpoint_tx.send(num_events_generated).unwrap();
                 }
             });
         }
     };
 }
 
-macro_rules! run_query {
-    ( $q:expr, $generator_config:expr ) => {{
-        // Until we have the I/O API to control the running of circuits,
-        // use an Rc<Cell<bool>> to communicate when the test is finished (ie. all
-        // events processed).
-        let max_events_reached = Rc::new(Cell::new(false));
-        let max_events_reached_cloned = max_events_reached.clone();
+/// Currently just the elapsed time, but later add CPU and Mem.
+#[derive(Debug)]
+struct NexmarkResult {
+    name: String,
+    num_events: u64,
+    elapsed: Duration,
+}
 
-        let circuit = nexmark_circuit!($q, $generator_config, max_events_reached);
+macro_rules! run_query {
+    ( $q_name:expr, $q:expr, $generator_config:expr, $max_events:expr ) => {{
+        // Until we have the I/O API to control the running of circuits,
+        // use an empty channel to signal when the test is finished (all events emitted
+        // by the generator).
+        let (fixedpoint_tx, fixedpoint_rx): (mpsc::Sender<u64>, mpsc::Receiver<u64>) =
+            mpsc::channel();
+
+        let circuit = nexmark_circuit!($q, $generator_config, fixedpoint_tx);
 
         let root = Root::build(circuit).unwrap();
 
+        let mut num_events_generated = 0;
         let start = Instant::now();
         loop {
-            if max_events_reached_cloned.get() {
-                break;
+            match fixedpoint_rx.try_recv() {
+                Ok(num_events) => {
+                    num_events_generated = num_events;
+                    break;
+                }
+                Err(TryRecvError::Empty) => root.step().unwrap(),
+                _ => panic!("unexpected result from fixedpoint sync channel"),
             }
-            root.step().unwrap();
         }
-        start.elapsed().as_millis()
+        NexmarkResult {
+            name: $q_name.clone(),
+            num_events: num_events_generated,
+            elapsed: start.elapsed(),
+        }
     }};
 }
 
 macro_rules! run_queries {
     ( $generator_config:expr, $max_events:expr, $queries_to_run:expr, $( ($q_name:expr, $q:expr) ),+ ) => {{
+        let mut results: Vec<NexmarkResult> = Vec::new();
         $(
         if $queries_to_run.len() == 0 || $queries_to_run.contains(&$q_name) {
             println!("Starting {} bench of {} events...", $q_name, $max_events);
 
-            let elapsed_ms = run_query!($q, $generator_config.clone());
-
-            println!(
-                "{} completed {} events in {}ms",
-                $q_name, $max_events, elapsed_ms
-            );
+            results.push(run_query!($q_name, $q, $generator_config.clone(), $max_events));
         }
         )+
+        results
     }};
+}
+
+fn create_ascii_table() -> AsciiTable {
+    let mut ascii_table = AsciiTable::default();
+    ascii_table.column(0).set_header("Nexmark Query");
+    ascii_table.column(1).set_header("Events Num");
+    ascii_table.column(2).set_header("Cores");
+    ascii_table.column(3).set_header("Time(s)");
+    ascii_table.column(4).set_header("Cores * Time(s)");
+    ascii_table.column(5).set_header("Throughput/Cores");
+    ascii_table
 }
 
 // TODO(absoludity): Some tools mentioned at
@@ -107,7 +160,7 @@ fn main() -> Result<()> {
     let queries_to_run = nexmark_config.query.clone();
     let generator_config = GeneratorConfig::new(nexmark_config, 0, 0, 0);
 
-    run_queries!(
+    let results = run_queries!(
         generator_config,
         max_events,
         queries_to_run,
@@ -117,6 +170,21 @@ fn main() -> Result<()> {
         (String::from("q3"), q3),
         (String::from("q4"), q4)
     );
+
+    let ascii_table = create_ascii_table();
+    ascii_table.print(results.into_iter().map(|r| {
+        vec![
+            r.name,
+            format!("{}", r.num_events.to_formatted_string(&Locale::en)),
+            String::from("1"),
+            format!("{0:.3}", r.elapsed.as_secs_f32()),
+            format!("{0:.3}", r.elapsed.as_secs_f32()),
+            format!(
+                "{0:.3} K/s",
+                r.num_events as f32 / r.elapsed.as_secs_f32() / 1000.0
+            ),
+        ]
+    }));
 
     Ok(())
 }

--- a/benches/nexmark/main.rs
+++ b/benches/nexmark/main.rs
@@ -117,9 +117,8 @@ macro_rules! run_query {
 macro_rules! run_queries {
     ( $generator_config:expr, $max_events:expr, $queries_to_run:expr, $( ($q_name:expr, $q:expr) ),+ ) => {{
         let mut results: Vec<NexmarkResult> = Vec::new();
-        let queries: Vec<&str> = $queries_to_run.iter().map(|s| s.as_str()).collect();
         $(
-        if $queries_to_run.len() == 0 || queries.contains(&$q_name) {
+        if $queries_to_run.len() == 0 || $queries_to_run.contains(&$q_name.to_string()) {
             println!("Starting {} bench of {} events...", $q_name, $max_events);
 
             results.push(run_query!($q_name, $q, $generator_config.clone(), $max_events));

--- a/benches/nexmark/main.rs
+++ b/benches/nexmark/main.rs
@@ -43,7 +43,6 @@ macro_rules! nexmark_circuit {
                 // TODO(absoludity): Nope, can't do that either as some streams
                 // return empty sets for initial data (eg, q2 doesn't emit data until the 123rd
                 // auction, which is well beyond 1000 generated events).
-                println!("zset: {:?}", zs);
                 if zs.len() == 0 {
                     $max_events_reached.set(true);
                 }

--- a/benches/nexmark/main.rs
+++ b/benches/nexmark/main.rs
@@ -107,7 +107,7 @@ macro_rules! run_query {
             }
         }
         NexmarkResult {
-            name: $q_name.clone(),
+            name: $q_name.to_string(),
             num_events: num_events_generated,
             elapsed: start.elapsed(),
         }
@@ -117,8 +117,9 @@ macro_rules! run_query {
 macro_rules! run_queries {
     ( $generator_config:expr, $max_events:expr, $queries_to_run:expr, $( ($q_name:expr, $q:expr) ),+ ) => {{
         let mut results: Vec<NexmarkResult> = Vec::new();
+        let queries: Vec<&str> = $queries_to_run.iter().map(|s| s.as_str()).collect();
         $(
-        if $queries_to_run.len() == 0 || $queries_to_run.contains(&$q_name) {
+        if $queries_to_run.len() == 0 || queries.contains(&$q_name) {
             println!("Starting {} bench of {} events...", $q_name, $max_events);
 
             results.push(run_query!($q_name, $q, $generator_config.clone(), $max_events));
@@ -159,11 +160,11 @@ fn main() -> Result<()> {
         generator_config,
         max_events,
         queries_to_run,
-        (String::from("q0"), q0),
-        (String::from("q1"), q1),
-        (String::from("q2"), q2),
-        (String::from("q3"), q3),
-        (String::from("q4"), q4)
+        ("q0", q0),
+        ("q1", q1),
+        ("q2", q2),
+        ("q3", q3),
+        ("q4", q4)
     );
 
     let ascii_table = create_ascii_table();

--- a/benches/nexmark/main.rs
+++ b/benches/nexmark/main.rs
@@ -94,7 +94,7 @@ macro_rules! run_query {
 
         let root = Root::build(circuit).unwrap();
 
-        let mut num_events_generated = 0;
+        let num_events_generated;
         let start = Instant::now();
         loop {
             match fixedpoint_rx.try_recv() {

--- a/benches/nexmark/main.rs
+++ b/benches/nexmark/main.rs
@@ -44,11 +44,6 @@ macro_rules! nexmark_circuit {
             );
             let input = circuit.add_source(source);
 
-            // Need to somehow have access to the generator's events_count_so_far ? Or have
-            // a signal sent - have a fn on the source which returns a channel that
-            // can be watched for when the source is exhausted - though will this
-            // also be a borrow?
-
             let output = $q(input);
 
             output.inspect(move |zs: &OrdZSet<_, _>| {
@@ -61,7 +56,7 @@ macro_rules! nexmark_circuit {
                 // it's finished (since they'll be returned in queries that don't
                 // emit data often). So, for simplicity, the source sends a message
                 // on it's fixedpoint_sync channel when it reaches its fixed point, which we can
-                // read here.
+                // read here and forward to the test harness.
                 match fixedpoint_rx.try_recv() {
                     Ok(num_events) => {
                         num_events_generated = num_events;

--- a/benches/nexmark/main.rs
+++ b/benches/nexmark/main.rs
@@ -2,63 +2,122 @@
 //!
 //! CLI for running Nexmark benchmarks with DBSP.
 #![feature(is_some_with)]
+use std::{cell::Cell, rc::Rc, time::Instant};
+
 use anyhow::Result;
 use clap::Parser;
 use dbsp::{
-    circuit::Root,
+    circuit::{Circuit, Root},
     nexmark::{
-        config::Config as NexmarkConfig, generator::config::Config as GeneratorConfig,
-        model::Event, queries::q1, NexmarkSource,
+        config::Config as NexmarkConfig,
+        generator::config::Config as GeneratorConfig,
+        model::Event,
+        queries::{q0, q1, q2, q3, q4},
+        NexmarkSource,
     },
     trace::{ord::OrdZSet, BatchReader},
 };
 use rand::prelude::ThreadRng;
 
-// TODO: Enable running specific tests
+// TODO: Ideally these macros would be in a separate `lib.rs` in this benchmark
+// crate, but benchmark binaries don't appear to work like that (in that, I
+// haven't yet found a way to import from a `lib.rs` in the same directory as
+// the benchmark's `main.rs`)
+
+/// Returns a closure for a circuit with the nexmark source that sets
+/// `max_events_reached` once no more data is available.
+macro_rules! nexmark_circuit {
+    ( $q:expr, $generator_config:expr, $max_events_reached:expr ) => {
+        |circuit: &mut Circuit<()>| {
+            let source =
+                NexmarkSource::<ThreadRng, isize, OrdZSet<Event, isize>>::new($generator_config);
+            let input = circuit.add_source(source);
+
+            let output = $q(input);
+
+            output.inspect(move |zs: &OrdZSet<_, _>| {
+                // Turns out we can't count events by accumulating the lengths of
+                // the `OrdZSet` since duplicate bids are not that difficult to produce in the
+                // generator (0-3 per 1000), which get merged to a single Item in the `OrdZSet`
+                // with an adjusted weight. Instead, stop when we get empty sets.
+                // TODO(absoludity): Nope, can't do that either as some streams
+                // return empty sets for initial data (eg, q2 doesn't emit data until the 123rd
+                // auction, which is well beyond 1000 generated events).
+                println!("zset: {:?}", zs);
+                if zs.len() == 0 {
+                    $max_events_reached.set(true);
+                }
+            });
+        }
+    };
+}
+
+macro_rules! run_query {
+    ( $q:expr, $generator_config:expr ) => {{
+        // Until we have the I/O API to control the running of circuits,
+        // use an Rc<Cell<bool>> to communicate when the test is finished (ie. all
+        // events processed).
+        let max_events_reached = Rc::new(Cell::new(false));
+        let max_events_reached_cloned = max_events_reached.clone();
+
+        let circuit = nexmark_circuit!($q, $generator_config, max_events_reached);
+
+        let root = Root::build(circuit).unwrap();
+
+        let start = Instant::now();
+        loop {
+            if max_events_reached_cloned.get() {
+                break;
+            }
+            root.step().unwrap();
+        }
+        start.elapsed().as_millis()
+    }};
+}
+
+macro_rules! run_queries {
+    ( $generator_config:expr, $max_events:expr, $queries_to_run:expr, $( ($q_name:expr, $q:expr) ),+ ) => {{
+        $(
+        if $queries_to_run.len() == 0 || $queries_to_run.contains(&$q_name) {
+            println!("Starting {} bench of {} events...", $q_name, $max_events);
+
+            let elapsed_ms = run_query!($q, $generator_config.clone());
+
+            println!(
+                "{} completed {} events in {}ms",
+                $q_name, $max_events, elapsed_ms
+            );
+        }
+        )+
+    }};
+}
+
+// TODO(absoludity): Some tools mentioned at
+// https://nnethercote.github.io/perf-book/benchmarking.html but as had been
+// said earlier, most are more suited to micro-benchmarking.  I assume that our
+// best option for comparable benchmarks will be to try to do exactly what the
+// Java implementation does: core(s) * time [see Run
+// Nexmark](https://github.com/nexmark/nexmark#run-nexmark).  Right now, just
+// grab elapsed time for each query run.  See
+// https://github.com/matklad/t-cmd/blob/master/src/main.rs Also CpuMonitor.java
+// in nexmark (binary that uses procfs to get cpu usage ever 100ms?)
+
 fn main() -> Result<()> {
     let nexmark_config = NexmarkConfig::parse();
-    let generator_config = GeneratorConfig::new(nexmark_config, 0, 0, 0, 0);
+    let max_events = nexmark_config.max_events;
+    let queries_to_run = nexmark_config.query.clone();
+    let generator_config = GeneratorConfig::new(nexmark_config, 0, 0, 0);
 
-    let root = Root::build(|circuit| {
-        // TODO(absoludity): CPUProfiler is not currently used in any of the
-        // other benchmarks, only commented out. Not yet sure whether it will be
-        // helpful either. Some tools mentioned at
-        // https://nnethercote.github.io/perf-book/benchmarking.html but as had
-        // been said earlier, most are more suited to micro-benchmarking.  I
-        // assume that our best option for comparable benchmarks will be to try
-        // to do exactly what the Java implementation does: core(s) * time [see
-        // Run Nexmark](https://github.com/nexmark/nexmark#run-nexmark).  Right
-        // now, just grab simple timestamp to do a duration for 100_000_000 events with
-        // a source generating 1M events/sec as per the Nexmark results.
-        let start_time = std::time::SystemTime::now();
+    run_queries!(
+        generator_config,
+        max_events,
+        queries_to_run,
+        (String::from("q0"), q0),
+        (String::from("q1"), q1),
+        (String::from("q2"), q2),
+        (String::from("q3"), q3),
+        (String::from("q4"), q4)
+    );
 
-        let source =
-            NexmarkSource::<ThreadRng, isize, OrdZSet<Event, isize>>::new(generator_config);
-        let input = circuit.add_source(source);
-
-        let output = q1(input);
-        let mut events_processed: u64 = 0;
-
-        output.inspect(move |zs: &OrdZSet<_, _>| {
-            events_processed += zs.len() as u64;
-            if events_processed >= 100_000_000 {
-                println!(
-                    "{} events processed in {}ms",
-                    events_processed,
-                    std::time::SystemTime::now()
-                        .duration_since(start_time)
-                        .unwrap()
-                        .as_millis()
-                );
-                // TODO: send signal through channel to stop iterating once
-                // sufficient data for test is processed?
-            }
-        });
-    })
-    .unwrap();
-
-    for _ in 0..100_000 {
-        root.step().unwrap();
-    }
     Ok(())
 }

--- a/src/nexmark/config.rs
+++ b/src/nexmark/config.rs
@@ -40,7 +40,7 @@ pub struct Config {
     pub bid_proportion: usize,
 
     /// Initial overall event rate (per second).
-    #[clap(long, default_value = "100000", env = "NEXMARK_FIRST_EVENT_RATE")]
+    #[clap(long, default_value = "10000", env = "NEXMARK_FIRST_EVENT_RATE")]
     pub first_event_rate: usize,
 
     /// Ratio of bids to 'hot' auctions compared to all other auctions.

--- a/src/nexmark/config.rs
+++ b/src/nexmark/config.rs
@@ -10,13 +10,14 @@ pub const PERSON_ID_LEAD: usize = 10;
 /// A Nexmark streaming data source generator
 ///
 /// Based on the Java/Flink generator found in the [Nexmark repository](https://github.com/nexmark/nexmark).
-#[derive(Parser, Debug)]
+#[derive(Clone, Debug, Parser)]
 #[clap(author, version, about)]
 pub struct Config {
     // Cargo passes any `--bench nexmark` (for example) through to our main
     // as an arg, so just ensure it's a valid arg option for now.
-    #[clap(long)]
-    pub bench: bool,
+    #[doc(hidden)]
+    #[clap(long = "bench", hide = true)]
+    pub __bench: bool,
 
     /// Specify the proportion of events that will be new auctions.
     #[clap(long, default_value = "3", env = "NEXMARK_AUCTION_PROPORTION")]
@@ -39,7 +40,7 @@ pub struct Config {
     pub bid_proportion: usize,
 
     /// Initial overall event rate (per second).
-    #[clap(long, default_value = "10000", env = "NEXMARK_FIRST_EVENT_RATE")]
+    #[clap(long, default_value = "100000", env = "NEXMARK_FIRST_EVENT_RATE")]
     pub first_event_rate: usize,
 
     /// Ratio of bids to 'hot' auctions compared to all other auctions.
@@ -53,6 +54,10 @@ pub struct Config {
     /// Ration of auctions for 'hot' sellers compared to all other people.
     #[clap(long, default_value = "4", env = "NEXMARK_HOT_SELLERS_RATIO")]
     pub hot_sellers_ratio: usize,
+
+    /// Max number of events to be generated. 0 is unlimited.
+    #[clap(long, default_value = "1000000", env = "NEXMARK_MAX_EVENTS")]
+    pub max_events: u64,
 
     /// Maximum number of people to consider as active for placing auctions or
     /// bids.
@@ -78,6 +83,10 @@ pub struct Config {
     /// Specify the proportion of events that will be new people.
     #[clap(long, default_value = "1", env = "NEXMARK_PERSON_PROPORTION")]
     pub person_proportion: usize,
+
+    /// Queries to run, all by default.
+    #[clap(long, env = "NEXMARK_QUERIES", multiple = true)]
+    pub query: Vec<String>,
 }
 
 /// Implementation of config methods based on the Java implementation at
@@ -91,7 +100,7 @@ impl Config {
 impl Default for Config {
     fn default() -> Self {
         Config {
-            bench: true,
+            __bench: true,
             auction_proportion: 3,
             avg_auction_byte_size: 500,
             avg_bid_byte_size: 100,
@@ -101,11 +110,13 @@ impl Default for Config {
             hot_auction_ratio: 2,
             hot_bidders_ratio: 4,
             hot_sellers_ratio: 4,
+            max_events: 1_000_000,
             num_active_people: 1000,
             num_event_generators: 1,
             num_in_flight_auctions: 100,
             out_of_order_group_size: 1,
             person_proportion: 1,
+            query: vec![],
         }
     }
 }

--- a/src/nexmark/generator/config.rs
+++ b/src/nexmark/generator/config.rs
@@ -8,6 +8,7 @@ pub const FIRST_CATEGORY_ID: usize = 10;
 
 /// The generator config is a combination of the CLI configuration and the
 /// options specific to this generator instantiation.
+#[derive(Clone)]
 pub struct Config {
     pub nexmark_config: NexmarkConfig,
 
@@ -38,7 +39,6 @@ impl Config {
         nexmark_config: NexmarkConfig,
         base_time: u64,
         first_event_id: u64,
-        max_events_or_zero: u64,
         first_event_number: usize,
     ) -> Config {
         let inter_event_delay =
@@ -47,7 +47,7 @@ impl Config {
         // Original Java implementation says:
         // "Scale maximum down to avoid overflow in getEstimatedSizeBytes."
         // but including to ensure similar behavior.
-        let max_events = match max_events_or_zero {
+        let max_events = match nexmark_config.max_events {
             0 => {
                 let max_average = *[
                     nexmark_config.avg_person_byte_size,
@@ -59,7 +59,7 @@ impl Config {
                 .unwrap();
                 u64::MAX / (nexmark_config.total_proportion() as u64 * max_average as u64)
             }
-            _ => max_events_or_zero,
+            _ => nexmark_config.max_events,
         };
         Config {
             nexmark_config,
@@ -116,7 +116,7 @@ impl Default for Config {
         // the Java output before creating an issue against their repo, but for
         // now I'm using defaults of 0 for both, which results in the expected
         // events (first event is a person with id 1000, etc.).
-        Config::new(NexmarkConfig::default(), 0, 0, 0, 0)
+        Config::new(NexmarkConfig::default(), 0, 0, 0)
     }
 }
 

--- a/src/nexmark/generator/mod.rs
+++ b/src/nexmark/generator/mod.rs
@@ -32,6 +32,9 @@ pub trait EventGenerator<R: Rng> {
     /// Returns whether the generator should continue to generate events.
     fn has_next(&self) -> bool;
 
+    /// Returns the number of events generated at the time of the call.
+    fn event_count(&self) -> u64;
+
     /// Returns the next generated event
     fn next_event(&mut self) -> Result<Option<NextEvent>>;
 }
@@ -65,6 +68,10 @@ impl<R: Rng> EventGenerator<R> for NexmarkGenerator<R> {
 
     fn has_next(&self) -> bool {
         self.events_count_so_far < self.config.max_events
+    }
+
+    fn event_count(&self) -> u64 {
+        self.events_count_so_far
     }
 
     fn wallclock_time(&mut self) -> u64 {
@@ -206,6 +213,10 @@ pub mod tests {
             self.generator.next_event()
         }
 
+        fn event_count(&self) -> u64 {
+            self.generator.event_count()
+        }
+
         fn wallclock_time(&mut self) -> u64 {
             match self.wallclock_iterator.next() {
                 Some(t) => t,
@@ -246,6 +257,10 @@ pub mod tests {
 
         fn has_next(&self) -> bool {
             self.current_event_index < self.next_events.len()
+        }
+
+        fn event_count(&self) -> u64 {
+            self.current_event_index as u64
         }
 
         fn next_event(&mut self) -> Result<Option<NextEvent>> {

--- a/src/nexmark/mod.rs
+++ b/src/nexmark/mod.rs
@@ -60,7 +60,7 @@ where
         NexmarkSource {
             generator: Box::new(generator),
             next_event: None,
-            fixedpoint_sync: fixedpoint_sync,
+            fixedpoint_sync,
             _t: PhantomData,
         }
     }

--- a/src/nexmark/mod.rs
+++ b/src/nexmark/mod.rs
@@ -223,7 +223,7 @@ pub mod tests {
     // After exhausting events, the source indicates a fixed point.
     #[test]
     fn test_fixed_point() {
-        let (mut source, _) = make_source_with_wallclock_times(0..1, 1);
+        let (mut source, _rx) = make_source_with_wallclock_times(0..1, 1);
         assert!(!source.fixedpoint(1));
 
         source.eval();
@@ -248,7 +248,7 @@ pub mod tests {
     // After exhausting events, the source returns empty ZSets.
     #[test]
     fn test_eval_empty_zset() {
-        let (mut source, _) = make_source_with_wallclock_times(0..2, 1);
+        let (mut source, _rx) = make_source_with_wallclock_times(0..2, 1);
 
         source.eval();
 

--- a/src/nexmark/mod.rs
+++ b/src/nexmark/mod.rs
@@ -22,6 +22,7 @@ use crate::{
 };
 use rand::prelude::ThreadRng;
 use rand::{thread_rng, Rng};
+use std::sync::mpsc::Sender;
 use std::thread::sleep;
 use std::time::Duration;
 use std::{borrow::Cow, marker::PhantomData};
@@ -40,6 +41,10 @@ pub struct NexmarkSource<R: Rng, W, C> {
     // next_event stores the next event during `eval` when `next_event()` is called but returns an
     // event in the future, so that we can include it in the next call to eval.
     next_event: Option<NextEvent>,
+    // fixedpoint_sync stores a channel transmitter so that when the source reaches its fixed
+    // point, it can communicate this by sending the number of events that have been generated,
+    // without sharing memory.
+    fixedpoint_sync: Sender<u64>,
 
     _t: PhantomData<(C, W)>,
 }
@@ -48,15 +53,22 @@ impl<R, W, C> NexmarkSource<R, W, C>
 where
     R: Rng + 'static,
 {
-    pub fn from_generator<G: EventGenerator<R> + 'static>(generator: G) -> Self {
+    pub fn from_generator<G: EventGenerator<R> + 'static>(
+        generator: G,
+        fixedpoint_sync: Sender<u64>,
+    ) -> Self {
         NexmarkSource {
             generator: Box::new(generator),
             next_event: None,
+            fixedpoint_sync: fixedpoint_sync,
             _t: PhantomData,
         }
     }
-    pub fn new(config: Config) -> NexmarkSource<ThreadRng, isize, OrdZSet<Event, isize>> {
-        NexmarkSource::from_generator(NexmarkGenerator::new(config, thread_rng()))
+    pub fn new(
+        config: Config,
+        fixedpoint_sync: Sender<u64>,
+    ) -> NexmarkSource<ThreadRng, isize, OrdZSet<Event, isize>> {
+        NexmarkSource::from_generator(NexmarkGenerator::new(config, thread_rng()), fixedpoint_sync)
     }
 }
 
@@ -98,6 +110,12 @@ where
             .next_event
             .clone()
             .or_else(|| self.generator.next_event().unwrap());
+
+        if self.fixedpoint(1) {
+            self.fixedpoint_sync
+                .send(self.generator.event_count())
+                .unwrap();
+        }
 
         // If there are no more events, we return an empty set.
         if next_event.is_none() {
@@ -145,14 +163,22 @@ pub mod tests {
     use crate::{circuit::Root, trace::ord::OrdZSet, trace::Batch};
     use core::ops::Range;
     use rand::rngs::mock::StepRng;
+    use std::sync::{mpsc, mpsc::Receiver};
 
-    /// Returns a source that generates 10_000 events/s with the specified
+    /// Returns a source that generates the default events/s with the specified
     /// range of wallclock time ticks.
     pub fn make_source_with_wallclock_times(
         times: Range<u64>,
         max_events: u64,
-    ) -> NexmarkSource<StepRng, isize, OrdZSet<Event, isize>> {
-        NexmarkSource::from_generator(RangedTimeGenerator::new(times, max_events))
+    ) -> (
+        NexmarkSource<StepRng, isize, OrdZSet<Event, isize>>,
+        Receiver<u64>,
+    ) {
+        let (tx, rx) = mpsc::channel();
+        (
+            NexmarkSource::from_generator(RangedTimeGenerator::new(times, max_events), tx),
+            rx,
+        )
     }
 
     pub fn generate_expected_zset_tuples(
@@ -183,7 +209,7 @@ pub mod tests {
     fn test_start_clock() {
         let expected_zset = generate_expected_zset(0, 2);
 
-        let mut source = make_source_with_wallclock_times(0..2, 2);
+        let (mut source, _) = make_source_with_wallclock_times(0..2, 2);
 
         assert_eq!(source.eval(), expected_zset);
 
@@ -197,7 +223,7 @@ pub mod tests {
     // After exhausting events, the source indicates a fixed point.
     #[test]
     fn test_fixed_point() {
-        let mut source = make_source_with_wallclock_times(0..1, 1);
+        let (mut source, _) = make_source_with_wallclock_times(0..1, 1);
         assert!(!source.fixedpoint(1));
 
         source.eval();
@@ -205,10 +231,24 @@ pub mod tests {
         assert!(source.fixedpoint(1));
     }
 
+    // After exhausting events, the source sends a message on the fixedpoint_sync
+    // channel.
+    #[test]
+    fn test_fixed_point_sync_channel() {
+        let (mut source, rx) = make_source_with_wallclock_times(0..3, 3);
+        assert!(rx.try_recv().is_err());
+
+        source.eval();
+        source.eval();
+        source.eval();
+
+        assert_eq!(rx.try_recv().unwrap(), 3);
+    }
+
     // After exhausting events, the source returns empty ZSets.
     #[test]
     fn test_eval_empty_zset() {
-        let mut source = make_source_with_wallclock_times(0..2, 1);
+        let (mut source, _) = make_source_with_wallclock_times(0..2, 1);
 
         source.eval();
 
@@ -218,7 +258,7 @@ pub mod tests {
     #[test]
     fn test_nexmark_dbsp_source_full_batch() {
         let root = Root::build(move |circuit| {
-            let source = make_source_with_wallclock_times(0..9, 10);
+            let (source, _) = make_source_with_wallclock_times(0..9, 10);
 
             let expected_zset = generate_expected_zset(0, 10);
 
@@ -239,7 +279,7 @@ pub mod tests {
     #[test]
     fn test_eval_batched() {
         let wallclock_time = 0;
-        let mut source = make_source_with_wallclock_times(0..3, 60);
+        let (mut source, _) = make_source_with_wallclock_times(0..3, 60);
         let expected_zset_tuples = generate_expected_zset_tuples(wallclock_time, 60);
 
         assert_eq!(

--- a/src/nexmark/queries/q0.rs
+++ b/src/nexmark/queries/q0.rs
@@ -16,7 +16,7 @@ mod tests {
 
     #[test]
     fn test_q0() {
-        let source = make_source_with_wallclock_times(1..3, 10);
+        let (source, _) = make_source_with_wallclock_times(1..3, 10);
 
         let root = Root::build(move |circuit| {
             let input = circuit.add_source(source);

--- a/src/nexmark/queries/q1.rs
+++ b/src/nexmark/queries/q1.rs
@@ -45,7 +45,7 @@ mod tests {
 
     #[test]
     fn test_q1() {
-        let source = make_source_with_wallclock_times(0..2, 10);
+        let (source, _) = make_source_with_wallclock_times(0..2, 10);
 
         let root = Root::build(move |circuit| {
             let input = circuit.add_source(source);

--- a/src/nexmark/queries/q2.rs
+++ b/src/nexmark/queries/q2.rs
@@ -41,6 +41,7 @@ mod tests {
     };
     use crate::{circuit::Root, trace::ord::OrdZSet, trace::Batch};
     use rand::rngs::mock::StepRng;
+    use std::sync::mpsc;
 
     #[test]
     fn test_q2() {
@@ -74,8 +75,9 @@ mod tests {
                 ..make_next_event()
             },
         ];
+        let (tx, _) = mpsc::channel();
         let source: NexmarkSource<StepRng, isize, OrdZSet<Event, isize>> =
-            NexmarkSource::from_generator(CannedEventGenerator::new(canned_events));
+            NexmarkSource::from_generator(CannedEventGenerator::new(canned_events), tx);
 
         let root = Root::build(move |circuit| {
             let input = circuit.add_source(source);

--- a/src/nexmark/queries/q3.rs
+++ b/src/nexmark/queries/q3.rs
@@ -74,6 +74,7 @@ mod tests {
     };
     use crate::{circuit::Root, trace::ord::OrdZSet, trace::Batch};
     use rand::rngs::mock::StepRng;
+    use std::sync::mpsc;
 
     #[test]
     fn test_q3_people() {
@@ -125,8 +126,9 @@ mod tests {
             },
         ];
 
+        let (tx, _) = mpsc::channel();
         let source: NexmarkSource<StepRng, isize, OrdZSet<Event, isize>> =
-            NexmarkSource::from_generator(CannedEventGenerator::new(canned_events));
+            NexmarkSource::from_generator(CannedEventGenerator::new(canned_events), tx);
 
         let root = Root::build(move |circuit| {
             let input = circuit.add_source(source);

--- a/src/nexmark/queries/q4.rs
+++ b/src/nexmark/queries/q4.rs
@@ -111,6 +111,7 @@ mod tests {
     };
     use crate::{circuit::Root, trace::ord::OrdZSet, trace::Batch};
     use rand::rngs::mock::StepRng;
+    use std::sync::mpsc;
 
     #[test]
     fn test_q4_average_final_bids_per_category() {
@@ -199,8 +200,9 @@ mod tests {
             },
         ];
 
+        let (tx, _) = mpsc::channel();
         let source: NexmarkSource<StepRng, isize, OrdZSet<Event, isize>> =
-            NexmarkSource::from_generator(CannedEventGenerator::new(canned_events));
+            NexmarkSource::from_generator(CannedEventGenerator::new(canned_events), tx);
 
         // Winning bids for auctions in category 1 are 100 and 300 - ie. AVG of 200
         // Winning (only) bid for auction in category 2 is 20.


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

Given each Nexmark query potentially has a different output type (and so each query has a different type), I couldn't see any way to iterate the various queries without using macros (and it was a good chance to learn more of Rust's macro support). Let me know if there's a better way.

This PR allows running the Nexmark tests (all by default, but you can select which ones) with whatever configuration you like, and prints out a table similar to the original [Nexmark benchmark results](https://github.com/nexmark/nexmark#benchmark-results).

I've left the defaults as they are for Nexmark itself, but you can run it with the actual config used for the above benchmark results, ie. 100,000,000 events at a rate of 1M per second, with:

```
$ cargo bench --bench nexmark --features with-nexmark -- --first-event-rate=1000000 --max-events=100000000
...
Starting q0 bench of 100000000 events...
Starting q1 bench of 100000000 events...
Starting q2 bench of 100000000 events...
Starting q3 bench of 100000000 events...
Starting q4 bench of 100000000 events...
┌───────────────┬─────────────┬───────┬─────────┬─────────────────┬──────────────────┐
│ Nexmark Query │ Events Num  │ Cores │ Time(s) │ Cores * Time(s) │ Throughput/Cores │
├───────────────┼─────────────┼───────┼─────────┼─────────────────┼──────────────────┤
│ q0            │ 100,000,000 │ 1     │ 99.999  │ 99.999          │ 1000.010 K/s     │
│ q1            │ 100,000,000 │ 1     │ 100.005 │ 100.005         │ 999.949 K/s      │
│ q2            │ 100,000,000 │ 1     │ 100.012 │ 100.012         │ 999.881 K/s      │
│ q3            │ 100,000,000 │ 1     │ 100.000 │ 100.000         │ 1000.004 K/s     │
│ q4            │ 100,000,000 │ 1     │ 116.244 │ 116.244         │ 860.260 K/s      │
└───────────────┴─────────────┴───────┴─────────┴─────────────────┴──────────────────┘
```
Note that it is really only Nexmark q4 that starts to get behind the generated events (by 16%). Early days yet (to put too much value on the results here until I've gone through them some more), but it'll be fun to play with as we optimise queries or internals. You can run particular tests as follows (in this case, q0 and q3, but with only 1,000,000 events:

```
$ cargo bench --bench nexmark --features with-nexmark -- --first-event-rate=1000000 --max-events=1000000 --query q0 --query q3
...
Starting q0 bench of 1000000 events...
Starting q3 bench of 1000000 events...
┌───────────────┬────────────┬───────┬─────────┬─────────────────┬──────────────────┐
│ Nexmark Query │ Events Num │ Cores │ Time(s) │ Cores * Time(s) │ Throughput/Cores │
├───────────────┼────────────┼───────┼─────────┼─────────────────┼──────────────────┤
│ q0            │ 1,000,000  │ 1     │ 1.006   │ 1.006           │ 993.680 K/s      │
│ q3            │ 1,000,000  │ 1     │ 1.000   │ 1.000           │ 1000.478 K/s     │
└───────────────┴────────────┴───────┴─────────┴─────────────────┴──────────────────┘
```

~~There are a couple of remaining issues, in particular, after discovering that I couldn't count the `zset.len()`s to accurately count the number of events processed (since duplicate bids will be merged with an accumulated weight - see inline comment), I've then incorrectly assumed that I can instead just stop iterating when the stream contains empty zsets. This worked for q0 and q1, but doesn't for the other queries (and queries generally) which emit empty zsets initial until (as can be sen above, and is obvious in retrospect :) ).~~ I ended up using channels rather than shared memory, which is (in my mind) much easier to reason about - even for a single-threaded binary.

