### PR TITLE
[nexmark] Adds usr/sys time and max rss memory to the output table.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,6 +553,7 @@ dependencies = [
  "hashbrown",
  "impl-trait-for-tuples",
  "indicatif",
+ "libc",
  "num",
  "num-format",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,8 @@ clap = { version = "3.2.8", features = ["derive", "env"] }
 reqwest = { version = "0.11.11", features = ["blocking"] }
 ascii_table = "4.0.2"
 num-format = "0.4.0"
+
+[target.'cfg(unix)'.dev-dependencies]
 libc = "0.2.127"
 
 [target.'cfg(windows)'.dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ clap = { version = "3.2.8", features = ["derive", "env"] }
 reqwest = { version = "0.11.11", features = ["blocking"] }
 ascii_table = "4.0.2"
 num-format = "0.4.0"
+libc = "0.2.127"
 
 [target.'cfg(windows)'.dev-dependencies]
 winapi = { version = "0.3.9", features = ["psapi"] }

--- a/benches/nexmark/main.rs
+++ b/benches/nexmark/main.rs
@@ -2,8 +2,12 @@
 //!
 //! CLI for running Nexmark benchmarks with DBSP.
 #![feature(is_some_with)]
+use libc::{getrusage, rusage, timeval, RUSAGE_THREAD};
 use std::{
+    io::Error,
+    mem,
     sync::{mpsc, mpsc::TryRecvError},
+    thread,
     time::{Duration, Instant},
 };
 
@@ -75,18 +79,20 @@ macro_rules! nexmark_circuit {
 }
 
 /// Currently just the elapsed time, but later add CPU and Mem.
-#[derive(Debug)]
 struct NexmarkResult {
     name: String,
     num_events: u64,
     elapsed: Duration,
+    usr_cpu: Duration,
+    sys_cpu: Duration,
+    max_rss: u64,
 }
 
 macro_rules! run_query {
-    ( $q_name:expr, $q:expr, $generator_config:expr, $max_events:expr ) => {{
+    ( $q_name:expr, $q:expr, $generator_config:expr, $max_events:expr, $result_tx:expr ) => {{
         // Until we have the I/O API to control the running of circuits,
-        // use an empty channel to signal when the test is finished (all events emitted
-        // by the generator).
+        // use a channel to signal when the test is finished (all events emitted
+        // by the generator), sending back the number of events processed.
         let (fixedpoint_tx, fixedpoint_rx): (mpsc::Sender<u64>, mpsc::Receiver<u64>) =
             mpsc::channel();
 
@@ -106,22 +112,42 @@ macro_rules! run_query {
                 _ => panic!("unexpected result from fixedpoint sync channel"),
             }
         }
-        NexmarkResult {
-            name: $q_name.to_string(),
-            num_events: num_events_generated,
-            elapsed: start.elapsed(),
-        }
+
+        let (usr_cpu, sys_cpu, max_rss) = unsafe { rusage_thread() };
+
+        $result_tx
+            .send(NexmarkResult {
+                name: $q_name.to_string(),
+                num_events: num_events_generated,
+                elapsed: start.elapsed(),
+                sys_cpu,
+                usr_cpu,
+                max_rss,
+            })
+            .unwrap();
     }};
 }
 
 macro_rules! run_queries {
     ( $generator_config:expr, $max_events:expr, $queries_to_run:expr, $( ($q_name:expr, $q:expr) ),+ ) => {{
         let mut results: Vec<NexmarkResult> = Vec::new();
+
+        // Run each query in a separate thread so we can measure the resource
+        // usage of the thread in isolation. We'll communicate the resource usage
+        // for collection via a channel to accumulate here.
+        let (result_tx, result_rx): (mpsc::Sender<NexmarkResult>, mpsc::Receiver<NexmarkResult>) =
+            mpsc::channel();
+
         $(
         if $queries_to_run.len() == 0 || $queries_to_run.contains(&$q_name.to_string()) {
             println!("Starting {} bench of {} events...", $q_name, $max_events);
-
-            results.push(run_query!($q_name, $q, $generator_config.clone(), $max_events));
+            let thread_result_tx = result_tx.clone();
+            let thread_generator_config = $generator_config.clone();
+            thread::spawn(move || {
+                run_query!($q_name, $q, thread_generator_config, $max_events, thread_result_tx);
+            });
+            // Wait for the thread to finish then collect the result.
+            results.push(result_rx.recv().unwrap());
         }
         )+
         results
@@ -130,12 +156,16 @@ macro_rules! run_queries {
 
 fn create_ascii_table() -> AsciiTable {
     let mut ascii_table = AsciiTable::default();
-    ascii_table.column(0).set_header("Nexmark Query");
-    ascii_table.column(1).set_header("Events Num");
+    ascii_table.column(0).set_header("Query");
+    ascii_table.column(1).set_header("#Events");
     ascii_table.column(2).set_header("Cores");
-    ascii_table.column(3).set_header("Time(s)");
-    ascii_table.column(4).set_header("Cores * Time(s)");
-    ascii_table.column(5).set_header("Throughput/Cores");
+    ascii_table.column(3).set_header("Elapsed(s)");
+    // Redundant until we use more than one core.
+    // ascii_table.column(4).set_header("Cores * Time(s)");
+    ascii_table.column(4).set_header("Throughput/Cores");
+    ascii_table.column(5).set_header("User CPU(s)");
+    ascii_table.column(6).set_header("System CPU(s)");
+    ascii_table.column(7).set_header("Max RSS(Kb)");
     ascii_table
 }
 
@@ -173,13 +203,33 @@ fn main() -> Result<()> {
             format!("{}", r.num_events.to_formatted_string(&Locale::en)),
             String::from("1"),
             format!("{0:.3}", r.elapsed.as_secs_f32()),
-            format!("{0:.3}", r.elapsed.as_secs_f32()),
             format!(
                 "{0:.3} K/s",
                 r.num_events as f32 / r.elapsed.as_secs_f32() / 1000.0
             ),
+            format!("{0:.3}", r.usr_cpu.as_secs_f32()),
+            format!("{0:.3}", r.sys_cpu.as_secs_f32()),
+            format!("{}", r.max_rss.to_formatted_string(&Locale::en)),
         ]
     }));
 
     Ok(())
+}
+
+fn duration_for_timeval(tv: timeval) -> Duration {
+    Duration::new(tv.tv_sec as u64, tv.tv_usec as u32 * 1_000)
+}
+
+// Returns the user CPU, system CPU and maxrss (in Kb) for the current thread.
+unsafe fn rusage_thread() -> (Duration, Duration, u64) {
+    let mut ru: rusage = mem::zeroed();
+    let err_code = getrusage(RUSAGE_THREAD, &mut ru);
+    if err_code != 0 {
+        panic!("getrusage returned {}", Error::last_os_error());
+    }
+    (
+        duration_for_timeval(ru.ru_utime),
+        duration_for_timeval(ru.ru_stime),
+        ru.ru_maxrss as u64,
+    )
 }


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

This PR updates to run each query in its own thread so that the [`getrusage` system call](https://man7.org/linux/man-pages/man2/getrusage.2.html) can be used to get the usr cpu, system cpu and max rss each thread after running its query (requires an `unsafe` call to the `libc` function).

## Benchmarks at 1M events / second

Full run with 100M events but emitted at only 1M/s (see further below for 10M/s)
```
$ cargo bench --bench nexmark --features with-nexmark -- --first-event-rate=1000000 --max-events=100000000
...
┌───────┬─────────────┬───────┬────────────┬─────────────┬─────────────┬─────────────┬─────────────┐
│ Query │ #Events     │ Cores │ Elapsed(s) │ Throughput+ │ User CPU(s) │ System CPU+ │ Max RSS(Kb) │
├───────┼─────────────┼───────┼────────────┼─────────────┼─────────────┼─────────────┼─────────────┤
│ q0    │ 100,000,000 │ 1     │ 100.000    │ 1000.004 K+ │ 72.505      │ 0.589       │ 37,180      │
│ q1    │ 100,000,000 │ 1     │ 100.000    │ 1000.001 K+ │ 73.132      │ 0.653       │ 37,180      │
│ q2    │ 100,000,000 │ 1     │ 100.002    │ 999.983 K/s │ 62.708      │ 0.476       │ 37,180      │
│ q3    │ 100,000,000 │ 1     │ 100.000    │ 999.997 K/s │ 69.006      │ 0.610       │ 334,920     │
│ q4    │ 100,000,000 │ 1     │ 109.696    │ 911.607 K/s │ 90.729      │ 18.720      │ 8,320,280   │
└───────┴─────────────┴───────┴────────────┴─────────────┴─────────────┴─────────────┴─────────────┘
```

For comparison, here's with only 10M events (at 1M/s)
```
$ cargo bench --bench nexmark --features with-nexmark -- --first-event-rate=1000000 --max-events=10000000
...
┌───────┬────────────┬───────┬────────────┬──────────────┬─────────────┬─────────────┬─────────────┐
│ Query │ #Events    │ Cores │ Elapsed(s) │ Throughput/+ │ User CPU(s) │ System CPU+ │ Max RSS(Kb) │
├───────┼────────────┼───────┼────────────┼──────────────┼─────────────┼─────────────┼─────────────┤
│ q0    │ 10,000,000 │ 1     │ 10.003     │ 999.677 K/s  │ 7.274       │ 0.112       │ 37,284      │
│ q1    │ 10,000,000 │ 1     │ 10.000     │ 1000.032 K/s │ 6.918       │ 0.081       │ 37,284      │
│ q2    │ 10,000,000 │ 1     │ 10.000     │ 999.985 K/s  │ 5.921       │ 0.054       │ 37,284      │
│ q3    │ 10,000,000 │ 1     │ 10.000     │ 1000.019 K/s │ 6.286       │ 0.087       │ 48,136      │
│ q4    │ 10,000,000 │ 1     │ 10.044     │ 995.573 K/s  │ 9.676       │ 0.262       │ 722,120     │
└───────┴────────────┴───────┴────────────┴──────────────┴─────────────┴─────────────┴─────────────┘
```

or even just 1M events (at 1M/s)

```
$ cargo bench --bench nexmark --features with-nexmark -- --first-event-rate=1000000 --max-events=1000000
...
┌───────┬───────────┬───────┬────────────┬──────────────┬─────────────┬──────────────┬─────────────┐
│ Query │ #Events   │ Cores │ Elapsed(s) │ Throughput/+ │ User CPU(s) │ System CPU(+ │ Max RSS(Kb) │
├───────┼───────────┼───────┼────────────┼──────────────┼─────────────┼──────────────┼─────────────┤
│ q0    │ 1,000,000 │ 1     │ 1.004      │ 995.843 K/s  │ 0.763       │ 0.020        │ 37,332      │
│ q1    │ 1,000,000 │ 1     │ 1.019      │ 981.394 K/s  │ 0.817       │ 0.024        │ 37,936      │
│ q2    │ 1,000,000 │ 1     │ 1.000      │ 1000.209 K/s │ 0.566       │ 0.000        │ 37,936      │
│ q3    │ 1,000,000 │ 1     │ 1.000      │ 999.630 K/s  │ 0.663       │ 0.004        │ 37,936      │
│ q4    │ 1,000,000 │ 1     │ 1.003      │ 997.102 K/s  │ 0.836       │ 0.030        │ 90,500      │
└───────┴───────────┴───────┴────────────┴──────────────┴─────────────┴──────────────┴─────────────┘
```

So queries 0-2 don't grow in memory with large input data sets (as expected - no indexes to manage, data is passed through), but q3 and particularly q4 grows.

This will now be useful for trying things like interning strings (for q3).

## Benchmarks at 10M/s

Again - early days in that I need to check and verify data, but here's two queries running faster (saturating the system, with 5M/s and 10M/s). Looks like 1M/s is around the saturation point from this initial data.

Running 10M events but emitted at 5M/s
```
┌───────┬────────────┬───────┬────────────┬──────────────┬─────────────┬─────────────┬─────────────┐
│ Query │ #Events    │ Cores │ Elapsed(s) │ Throughput/+ │ User CPU(s) │ System CPU+ │ Max RSS(Kb) │
├───────┼────────────┼───────┼────────────┼──────────────┼─────────────┼─────────────┼─────────────┤
│ q0    │ 10,000,000 │ 1     │ 11.298     │ 885.138 K/s  │ 8.752       │ 2.535       │ 7,064,148   │
│ q1    │ 10,000,000 │ 1     │ 13.536     │ 738.774 K/s  │ 10.558      │ 2.967       │ 8,973,856   │
│ q2    │ 10,000,000 │ 1     │ 9.204      │ 1086.494 K/s │ 8.606       │ 1.470       │ 8,973,856   │
│ q3    │ 10,000,000 │ 1     │ 9.255      │ 1080.539 K/s │ 7.786       │ 1.459       │ 8,973,856   │
│ q4    │ 10,000,000 │ 1     │ 11.629     │ 859.937 K/s  │ 9.408       │ 2.211       │ 8,973,856   │
└───────┴────────────┴───────┴────────────┴──────────────┴─────────────┴─────────────┴─────────────┘
```

and then 10M events emitted at 10M/s
```
┌───────┬────────────┬───────┬────────────┬──────────────┬─────────────┬─────────────┬─────────────┐
│ Query │ #Events    │ Cores │ Elapsed(s) │ Throughput/+ │ User CPU(s) │ System CPU+ │ Max RSS(Kb) │
├───────┼────────────┼───────┼────────────┼──────────────┼─────────────┼─────────────┼─────────────┤
│ q0    │ 10,000,000 │ 1     │ 12.025     │ 831.631 K/s  │ 9.249       │ 2.771       │ 7,064,148   │
│ q1    │ 10,000,000 │ 1     │ 13.880     │ 720.461 K/s  │ 10.932      │ 2.938       │ 8,973,568   │
│ q2    │ 10,000,000 │ 1     │ 9.313      │ 1073.818 K/s │ 8.644       │ 1.581       │ 8,973,568   │
│ q3    │ 10,000,000 │ 1     │ 9.239      │ 1082.418 K/s │ 7.724       │ 1.507       │ 8,973,568   │
│ q4    │ 10,000,000 │ 1     │ 12.459     │ 802.655 K/s  │ 9.728       │ 2.823       │ 8,973,568   │
└───────┴────────────┴───────┴────────────┴──────────────┴─────────────┴─────────────┴─────────────┘
```

Unfortunately I can't yet do more than around 10M events at 10M/s as the process gets OOM'd (We'll need to eventually fix the scheduler/source so we don't keep pulling bigger and bigger batches into memory after passing the saturation point). 