### PR TITLE
Input handle and circuit handle APIs.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,9 +59,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91f1f46651137be86f3a2b9a8359f9ab421d04d941c62b5982e1ca21113adf9"
+checksum = "c794e162a5eff65c72ef524dfe393eb923c354e350bb78b9c7383df13f3bc142"
 
 [[package]]
 name = "arrayvec"
@@ -413,6 +413,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +459,16 @@ dependencies = [
  "memoffset",
  "once_cell",
  "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -545,6 +569,7 @@ dependencies = [
  "cached",
  "clap 3.2.16",
  "criterion",
+ "crossbeam",
  "crossbeam-utils",
  "csv",
  "deepsize",
@@ -1799,9 +1824,9 @@ checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
 
 [[package]]
 name = "serde"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e590c437916fb6b221e1d00df6e3294f3fccd70ca7e92541c475d6ed6ef5fee2"
+checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
 
 [[package]]
 name = "serde_cbor"
@@ -1815,9 +1840,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b5b8d809babe02f538c2cfec6f2c1ed10804c0e5a6a041a049a4f5588ccc2e"
+checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ fxhash = "0.2"
 rand = { version = "0.8", optional = true }
 clap = { version = "3.2", optional = true, features = ["derive", "env"] }
 cached = { version = "0.38.0", optional = true }
+crossbeam = "0.8.2"
 
 # TODO: eliminate dependency on timely-dataflow by cloning relevant
 # parts.

--- a/benches/galen.rs
+++ b/benches/galen.rs
@@ -270,7 +270,8 @@ fn main() -> Result<()> {
             outq.gather(0)
                 .inspect(|zs: &OrdZSet<_, _>| println!("outq: {}", zs.len()));
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         let graph = monitor.visualize_circuit();
         fs::write(GALEN_GRAPH, graph.to_dot()).unwrap();

--- a/benches/galen.rs
+++ b/benches/galen.rs
@@ -4,11 +4,11 @@
 use anyhow::{Context, Result};
 use csv::ReaderBuilder;
 use dbsp::{
-    circuit::{Root, Runtime, Stream},
     monitor::TraceMonitor,
     operator::CsvSource,
     time::NestedTimestamp32,
     trace::{ord::OrdZSet, BatchReader},
+    Circuit, Runtime, Stream,
 };
 use std::{
     fs::{self, File},
@@ -75,7 +75,7 @@ fn main() -> Result<()> {
     let hruntime = Runtime::run(8, || {
         let monitor = TraceMonitor::new_panic_on_error();
 
-        let root = Root::build(|circuit| {
+        let circuit = Circuit::build(|circuit| {
             /*
             use dbsp::{
                 circuit::GlobalNodeId,
@@ -275,7 +275,7 @@ fn main() -> Result<()> {
         let graph = monitor.visualize_circuit();
         fs::write(GALEN_GRAPH, graph.to_dot()).unwrap();
 
-        root.step().unwrap();
+        circuit.step().unwrap();
     });
 
     hruntime.join().map_err(|error| {

--- a/benches/ldbc-graphalytics/data.rs
+++ b/benches/ldbc-graphalytics/data.rs
@@ -620,7 +620,7 @@ impl EdgeParser {
         // Directed graphs can use an ordered builder
         if self.directed {
             let mut edges = <EdgeMap as Batch>::Builder::with_capacity((), approx_edges);
-            self.parse(|src, dest| edges.push((src, dest, Weight::one())));
+            self.parse(|src, dest| edges.push(((src, dest), Weight::one())));
             edges.done()
 
         // Undirected graphs must use an unordered builder
@@ -677,7 +677,7 @@ impl VertexParser {
     pub fn load(self, approx_vertices: usize) -> VertexSet {
         // The vertices file is ordered so we can use an ordered builder
         let mut vertices = <VertexSet as Batch>::Builder::with_capacity((), approx_vertices);
-        self.parse(|vertex| vertices.push((vertex, (), Weight::one())));
+        self.parse(|vertex| vertices.push((vertex, Weight::one())));
         vertices.done()
     }
 
@@ -748,7 +748,7 @@ impl ResultParser for BfsResults {
             let vertex = vertex.parse().unwrap();
             let distance = distance.parse().unwrap();
 
-            results.push(((vertex, distance), (), Weight::one()));
+            results.push(((vertex, distance), Weight::one()));
             buffer.clear();
         }
 
@@ -783,7 +783,7 @@ impl ResultParser for PageRankResults {
             let vertex = vertex.parse().unwrap();
             let rank = F64::new(distance.parse::<f64>().unwrap());
 
-            results.push((vertex, rank, Weight::one()));
+            results.push(((vertex, rank), Weight::one()));
             buffer.clear();
         }
 

--- a/benches/ldbc-graphalytics/main.rs
+++ b/benches/ldbc-graphalytics/main.rs
@@ -12,7 +12,7 @@ use crate::{
 use clap::Parser;
 use dbsp::{
     algebra::NegByRef,
-    circuit::{trace::SchedulerEvent, Root, Runtime},
+    circuit::{trace::SchedulerEvent, Runtime},
     monitor::TraceMonitor,
     operator::Generator,
     profile::CPUProfiler,
@@ -124,7 +124,7 @@ fn main() {
         let output = Rc::new(RefCell::new(OutputData::None));
 
         let output_inner = output.clone();
-        let root = Root::build(move |circuit| {
+        let root = Circuit::build(move |circuit| {
             if config.profile && Runtime::worker_index() == 0 {
                 attach_profiling(dataset, circuit);
             }
@@ -186,7 +186,7 @@ fn main() {
                 Args::ListDatasets { .. } | Args::ListDownloaded { .. } => unreachable!(),
             }
         })
-        .unwrap();
+        .unwrap().0;
 
         if Runtime::worker_index() == 0 {
             let elapsed = start.elapsed();

--- a/benches/ldbc-graphalytics/pagerank.rs
+++ b/benches/ldbc-graphalytics/pagerank.rs
@@ -136,7 +136,7 @@ where
         let mut cursor = vertices.cursor();
         while cursor.key_valid() {
             let node = *cursor.key();
-            output.push((((node, initial_weight), ()), 1));
+            output.push(((node, initial_weight), 1));
             cursor.step_key();
         }
 
@@ -149,7 +149,7 @@ where
     let total_vertices = vertices.apply(|vertices| {
         let total_vertices = vertices.layer.keys();
         let mut builder = <OrdIndexedZSet<_, _, _> as Batch>::Builder::with_capacity((), 1);
-        builder.push(((), total_vertices, 1));
+        builder.push((((), total_vertices), 1));
         builder.done()
     });
 
@@ -174,7 +174,7 @@ where
                 cursor.step_val();
             }
 
-            output.push((node, total_outputs, 1));
+            output.push(((node, total_outputs), 1));
             cursor.step_key();
         }
 
@@ -199,7 +199,7 @@ where
             let mut cursor = edges.cursor();
             while cursor.key_valid() {
                 while cursor.val_valid() {
-                    output.push(((*cursor.val(), ()), 1));
+                    output.push((*cursor.val(), 1));
                     cursor.step_val();
                 }
                 cursor.step_key();
@@ -485,7 +485,7 @@ where
         let mut cursor = vertices.cursor();
         while cursor.key_valid() {
             let node = *cursor.key();
-            builder.push((node, (), Rank::one()));
+            builder.push((node, Rank::one()));
             cursor.step_key();
         }
 
@@ -503,7 +503,7 @@ where
         let mut cursor = vertices.cursor();
         while cursor.key_valid() {
             let node = *cursor.key();
-            builder.push(((), node, weight));
+            builder.push((((), node), weight));
             cursor.step_key();
         }
 
@@ -522,7 +522,7 @@ where
         let mut cursor = vertices.cursor();
         while cursor.key_valid() {
             let node = *cursor.key();
-            builder.push((node, (), initial_weight));
+            builder.push((node, initial_weight));
             cursor.step_key();
         }
 
@@ -540,7 +540,7 @@ where
         let mut cursor = vertices.cursor();
         while cursor.key_valid() {
             let node = *cursor.key();
-            builder.push((node, (), teleport));
+            builder.push((node, teleport));
             cursor.step_key();
         }
 
@@ -562,7 +562,7 @@ where
                 cursor.step_val();
             }
 
-            builder.push((node, (), Rank::new(total_outputs as f64)));
+            builder.push((node, Rank::new(total_outputs as f64)));
             cursor.step_key();
         }
 
@@ -587,7 +587,7 @@ where
             while cursor.val_valid() {
                 let dest = *cursor.val();
                 let weight = Rank::new(cursor.weight() as f64);
-                builder.push((src, dest, weight));
+                builder.push(((src, dest), weight));
                 cursor.step_val();
             }
             cursor.step_key();
@@ -676,7 +676,7 @@ where
         let mut batch = Vec::with_capacity(weights.len());
         let mut weights = weights.cursor();
         while weights.key_valid() {
-            batch.push((((*weights.key(), weights.weight()), ()), 1));
+            batch.push(((*weights.key(), weights.weight()), 1));
             weights.step_key();
         }
 
@@ -710,7 +710,7 @@ where
                     debug_assert!(lhs.val_valid() && rhs.val_valid());
 
                     let (lhs_weight, rhs_weight) = (lhs.weight(), rhs.weight());
-                    builder.push((*lhs.key(), (), lhs_weight / rhs_weight));
+                    builder.push((*lhs.key(), lhs_weight / rhs_weight));
 
                     lhs.step_key();
                     rhs.step_key();

--- a/benches/nexmark/main.rs
+++ b/benches/nexmark/main.rs
@@ -15,7 +15,6 @@ use anyhow::Result;
 use ascii_table::AsciiTable;
 use clap::Parser;
 use dbsp::{
-    circuit::{Circuit, Root},
     nexmark::{
         config::Config as NexmarkConfig,
         generator::config::Config as GeneratorConfig,
@@ -24,6 +23,7 @@ use dbsp::{
         NexmarkSource,
     },
     trace::{ord::OrdZSet, BatchReader},
+    Circuit,
 };
 use num_format::{Locale, ToFormattedString};
 use rand::prelude::ThreadRng;

--- a/benches/nexmark/main.rs
+++ b/benches/nexmark/main.rs
@@ -98,7 +98,7 @@ macro_rules! run_query {
 
         let circuit = nexmark_circuit!($q, $generator_config, fixedpoint_tx);
 
-        let root = Root::build(circuit).unwrap();
+        let root = Circuit::build(circuit).unwrap().0;
 
         let num_events_generated;
         let start = Instant::now();

--- a/benches/path.rs
+++ b/benches/path.rs
@@ -67,7 +67,7 @@ fn main() {
                     for from in 0..LAYER {
                         for to in 0..LAYER {
                             tuples.push((
-                                ((from + (LAYER * layer), to + LAYER * (layer + 1)), ()),
+                                (from + (LAYER * layer), to + LAYER * (layer + 1)),
                                 1,
                             ));
                         }

--- a/benches/path.rs
+++ b/benches/path.rs
@@ -66,10 +66,7 @@ fn main() {
                 for layer in 0..5 {
                     for from in 0..LAYER {
                         for to in 0..LAYER {
-                            tuples.push((
-                                (from + (LAYER * layer), to + LAYER * (layer + 1)),
-                                1,
-                            ));
+                            tuples.push(((from + (LAYER * layer), to + LAYER * (layer + 1)), 1));
                         }
                     }
                 }
@@ -120,7 +117,8 @@ fn main() {
                 }
             });
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         //let graph = monitor.visualize_circuit();
         //fs::write("path.dot", graph.to_dot()).unwrap();

--- a/benches/path.rs
+++ b/benches/path.rs
@@ -1,14 +1,13 @@
 use dbsp::{
-    circuit::{Root, Stream},
     operator::{FilterMap, Generator},
     time::NestedTimestamp32,
     trace::{ord::OrdZSet, Batch, BatchReader},
-    Runtime,
+    Circuit, Runtime, Stream,
 };
 
 fn main() {
     let hruntime = Runtime::run(16, || {
-        let root = Root::build(|circuit| {
+        let circuit = Circuit::build(|circuit| {
             /*
             use dbsp::{
                 circuit::{trace::SchedulerEvent, GlobalNodeId},
@@ -126,7 +125,7 @@ fn main() {
         //let graph = monitor.visualize_circuit();
         //fs::write("path.dot", graph.to_dot()).unwrap();
 
-        root.step().unwrap();
+        circuit.step().unwrap();
     });
 
     hruntime.join().unwrap();

--- a/src/algebra/zset/mod.rs
+++ b/src/algebra/zset/mod.rs
@@ -36,10 +36,10 @@ pub trait ZSet: IndexedZSet<Val = ()> {
     fn weighted_count(&self) -> Self::R;
 }
 
-impl<Z> ZSet for Z
+impl<Z, K> ZSet for Z
 where
-    Z: IndexedZSet<Val = ()>,
-    Z::Key: Clone,
+    Z: IndexedZSet<Item = K, Key = K, Val = ()>,
+    K: Clone,
     Z::R: ZRingValue,
 {
     fn distinct(&self) -> Self {
@@ -49,7 +49,7 @@ where
         while cursor.key_valid() {
             let w = cursor.weight();
             if w.ge0() {
-                builder.push((cursor.key().clone(), (), HasOne::one()));
+                builder.push((cursor.key().clone(), HasOne::one()));
             }
             cursor.step_key();
         }

--- a/src/algebra/zset/zset_macro.rs
+++ b/src/algebra/zset/zset_macro.rs
@@ -6,7 +6,7 @@
 #[macro_export]
 macro_rules! indexed_zset {
     ( $($key:expr => { $($value:expr => $weight:expr),* }),* $(,)?) => {{
-        let mut batcher = <<$crate::trace::ord::OrdIndexedZSet<_, _, _> as $crate::trace::Batch>::Batcher as $crate::trace::Batcher<_, _, _, _, _>>::new(());
+        let mut batcher = <<$crate::trace::ord::OrdIndexedZSet<_, _, _> as $crate::trace::Batch>::Batcher as $crate::trace::Batcher<_, _, _, _>>::new(());
         let mut batch = ::std::vec![ $( $( (($key, $value), $weight) ),* ),* ];
         $crate::trace::Batcher::push_batch(&mut batcher, &mut batch);
         $crate::trace::Batcher::seal(batcher)
@@ -20,9 +20,9 @@ macro_rules! indexed_zset {
 #[macro_export]
 macro_rules! zset {
     ( $( $key:expr => $weight:expr ),* $(,)?) => {{
-        let mut batcher = <<$crate::trace::ord::OrdZSet<_, _> as $crate::trace::Batch>::Batcher as $crate::trace::Batcher<_, _, _, _, _>>::new(());
+        let mut batcher = <<$crate::trace::ord::OrdZSet<_, _> as $crate::trace::Batch>::Batcher as $crate::trace::Batcher<_, _, _, _>>::new(());
 
-        let mut batch = ::std::vec![ $( (($key, ()), $weight) ),* ];
+        let mut batch = ::std::vec![ $( ($key, $weight) ),* ];
         $crate::trace::Batcher::push_batch(&mut batcher, &mut batch);
         $crate::trace::Batcher::seal(batcher)
     }};
@@ -35,9 +35,9 @@ macro_rules! zset {
 #[macro_export]
 macro_rules! zset_set {
     ( $( $key:expr ),* $(,)?) => {{
-        let mut batcher = <<$crate::trace::ord::OrdZSet<_, _> as $crate::trace::Batch>::Batcher as $crate::trace::Batcher<_, _, _, _, _>>::new(());
+        let mut batcher = <<$crate::trace::ord::OrdZSet<_, _> as $crate::trace::Batch>::Batcher as $crate::trace::Batcher<_, _, _, _>>::new(());
 
-        let mut batch = ::std::vec![ $( (($key, ()), 1) ),* ];
+        let mut batch = ::std::vec![ $( ($key, 1) ),* ];
         $crate::trace::Batcher::push_batch(&mut batcher, &mut batch);
         $crate::trace::Batcher::seal(batcher)
     }};

--- a/src/circuit/dbsp_handle.rs
+++ b/src/circuit/dbsp_handle.rs
@@ -1,0 +1,324 @@
+use crate::{
+    circuit::runtime::RuntimeHandle, Circuit, Error as DBSPError, Runtime, RuntimeError,
+    SchedulerError,
+};
+use crossbeam::channel::{bounded, Receiver, Sender, TryRecvError};
+use std::thread::Result as ThreadResult;
+
+impl Runtime {
+    /// Instantiate a circuit in a multithreaded runtime.
+    ///
+    /// Creates a multithreaded runtime with `nworkers` worker threads and
+    /// instantiates identical circuits in each worker, using `constructor`
+    /// closure. Returns a [`DBSPHandle`] that can be used to control
+    /// the circuit and a user-defined value returned by the constructor.
+    /// This value typically contains one or more input handles used to
+    /// push data to the circuit at runtime (see
+    /// [`Circuit::add_input_stream`], [`Circuit::add_input_zset`], and related
+    /// methods).
+    ///
+    /// To ensure that the multithreaded runtime has identical input/output
+    /// behavior to a single-threaded circuit, the `constructor` closure
+    /// must satisfy certain constraints.  Most importantly, it must create
+    /// identical circuits in all worker threads, adding and connecting
+    /// operators in the same order.  This ensures that operators that shard
+    /// their inputs across workers, e.g.,
+    /// [`Stream::join`](`crate::Stream::join`), work correctly.
+    ///
+    /// TODO: Document other requirements.  Not all operators are currently
+    /// thread-safe.
+    pub fn init_circuit<F, T>(nworkers: usize, constructor: F) -> Result<(DBSPHandle, T), DBSPError>
+    where
+        F: FnOnce(&mut Circuit<()>) -> T + Clone + Send + 'static,
+        T: Clone + Send + 'static,
+    {
+        // When a worker finishes building the circuit, it sends completion status back
+        // to us via this channel.  The function returns after receiving a
+        // notification from each worker.
+        let (init_senders, init_receivers): (Vec<_>, Vec<_>) =
+            (0..nworkers).map(|_| bounded(0)).unzip();
+
+        // Channels used to send commands to workers.
+        let (command_senders, command_receivers): (Vec<_>, Vec<_>) =
+            (0..nworkers).map(|_| bounded(1)).unzip();
+
+        // Channels used to signal command completion to the client.
+        let (status_senders, status_receivers): (Vec<_>, Vec<_>) =
+            (0..nworkers).map(|_| bounded(1)).unzip();
+
+        let runtime = Self::run(nworkers, move || {
+            let worker_index = Runtime::worker_index();
+
+            // Drop all but one channels.  This makes sure that if one of the worker panics
+            // or exits, its channel will become disonnected.
+            let init_sender = init_senders.into_iter().nth(worker_index).unwrap();
+            let status_sender = status_senders.into_iter().nth(worker_index).unwrap();
+            let command_receiver = command_receivers.into_iter().nth(worker_index).unwrap();
+
+            let circuit = match Circuit::build(constructor) {
+                Ok((circuit, res)) => {
+                    if init_sender.send(Ok(res)).is_err() {
+                        return;
+                    }
+                    circuit
+                }
+                Err(e) => {
+                    let _ = init_sender.send(Err(e));
+                    return;
+                }
+            };
+
+            // TODO: uncomment this when we have support for background compaction.
+            // let mut moregc = true;
+
+            while !Runtime::kill_in_progress() {
+                // Wait for command.
+                match command_receiver.try_recv() {
+                    Ok(()) => {
+                        //moregc = true;
+                        let status = circuit.step();
+                        // Send response.
+                        if status_sender.send(status).is_err() {
+                            return;
+                        };
+                    }
+                    // Nothing to do: do some housekeeping and relinquish the CPU if there's none
+                    // left.
+                    Err(TryRecvError::Empty) => {
+                        // GC
+                        /*if moregc {
+                            moregc = circuit.gc();
+                        } else {*/
+                        Runtime::parker().with(|parker| parker.park());
+                        //}
+                    }
+                    Err(_) => {
+                        break;
+                    }
+                }
+            }
+        });
+
+        // Receive initialization status from all workers.
+
+        let mut init_status = Vec::with_capacity(nworkers);
+
+        for (worker, receiver) in init_receivers.iter().enumerate() {
+            match receiver.recv() {
+                Ok(Err(scheduler_error)) => {
+                    init_status.push(Err(DBSPError::Scheduler(scheduler_error)))
+                }
+                Ok(Ok(ret)) => init_status.push(Ok(ret)),
+                Err(_) => {
+                    init_status.push(Err(DBSPError::Runtime(RuntimeError::WorkerPanic(worker))))
+                }
+            }
+        }
+
+        // On error, kill the runtime.
+        if let Some(Err(e)) = init_status.iter().find(|status| status.is_err()) {
+            let _ = runtime.kill();
+            return Err(e.clone());
+        }
+
+        let dbsp = DBSPHandle::new(runtime, command_senders, status_receivers);
+
+        // `constructor` should return identical results in all workers.  Use
+        // worker 0 output.
+        Ok((dbsp, init_status[0].as_ref().unwrap().clone()))
+    }
+}
+
+/// A handle to control the execution of a circuit in a multithreaded runtime.
+#[derive(Debug)]
+pub struct DBSPHandle {
+    runtime: Option<RuntimeHandle>,
+    // Channels used to send commands to workers.  Currently the only supported
+    // command is 'step', so we can use `()` to represent commands.
+    command_senders: Vec<Sender<()>>,
+    // Channels used to receive command completion status from
+    // workers.
+    status_receivers: Vec<Receiver<Result<(), SchedulerError>>>,
+}
+
+impl DBSPHandle {
+    fn new(
+        runtime: RuntimeHandle,
+        command_senders: Vec<Sender<()>>,
+        status_receivers: Vec<Receiver<Result<(), SchedulerError>>>,
+    ) -> Self {
+        Self {
+            runtime: Some(runtime),
+            command_senders,
+            status_receivers,
+        }
+    }
+
+    fn kill_inner(&mut self) -> ThreadResult<()> {
+        self.command_senders.clear();
+        self.status_receivers.clear();
+        self.runtime.take().unwrap().kill()
+    }
+
+    /// Evaluate the circuit for one clock cycle.
+    pub fn step(&mut self) -> Result<(), DBSPError> {
+        if self.runtime.is_none() {
+            return Err(DBSPError::Runtime(RuntimeError::Killed));
+        }
+
+        // Send command.
+        for (worker, sender) in self.command_senders.iter().enumerate() {
+            if matches!(sender.send(()), Err(_)) {
+                let _ = self.kill_inner();
+                return Err(DBSPError::Runtime(RuntimeError::WorkerPanic(worker)));
+            }
+            self.runtime.as_ref().unwrap().unpark_worker(worker);
+        }
+
+        // Receive responses.
+        for (worker, receiver) in self.status_receivers.iter().enumerate() {
+            match receiver.recv() {
+                Err(_) => {
+                    let _ = self.kill_inner();
+                    return Err(DBSPError::Runtime(RuntimeError::WorkerPanic(worker)));
+                }
+                Ok(Err(e)) => {
+                    let _ = self.kill_inner();
+                    return Err(DBSPError::Scheduler(e));
+                }
+                Ok(Ok(_)) => {}
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Terminate the execution of the circuit, exiting all worker threads.
+    ///
+    /// If one or more of the worker threads panics, returns the argument the
+    /// `panic!` macro was called with (see `std::thread::Result`).
+    ///
+    /// This is the preferred way of killing a circuit.  Simply dropping the
+    /// handle will have the same effect, but without reporting the error
+    /// status.
+    pub fn kill(mut self) -> ThreadResult<()> {
+        if self.runtime.is_none() {
+            return Ok(());
+        }
+
+        self.kill_inner()
+    }
+}
+
+impl Drop for DBSPHandle {
+    fn drop(&mut self) {
+        if self.runtime.is_some() {
+            let _ = self.kill_inner();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{operator::Generator, Error as DBSPError, Runtime, RuntimeError};
+
+    // Panic during initialization in worker thread.
+    #[test]
+    fn test_panic_in_worker1() {
+        test_panic_in_worker(1);
+    }
+
+    #[test]
+    fn test_panic_in_worker4() {
+        test_panic_in_worker(4);
+    }
+
+    fn test_panic_in_worker(nworkers: usize) {
+        let res = Runtime::init_circuit(nworkers, |circuit| {
+            if Runtime::worker_index() == 0 {
+                panic!();
+            }
+
+            circuit.add_source(Generator::new(|| 5usize));
+        });
+
+        assert_eq!(
+            res.unwrap_err(),
+            DBSPError::Runtime(RuntimeError::WorkerPanic(0))
+        );
+    }
+
+    // TODO: initialization error in worker thread (the `constructor` closure
+    // currently does not return an error).
+    // TODO: panic/error during GC.
+
+    // Panic in `Circuit::step`.
+    #[test]
+    fn test_step_panic1() {
+        test_step_panic(1);
+    }
+
+    #[test]
+    fn test_step_panic4() {
+        test_step_panic(4);
+    }
+
+    fn test_step_panic(nworkers: usize) {
+        let (mut handle, _) = Runtime::init_circuit(nworkers, |circuit| {
+            circuit.add_source(Generator::new(|| {
+                if Runtime::worker_index() == 0 {
+                    panic!()
+                } else {
+                    5usize
+                }
+            }));
+        })
+        .unwrap();
+
+        assert_eq!(
+            handle.step().unwrap_err(),
+            DBSPError::Runtime(RuntimeError::WorkerPanic(0))
+        );
+    }
+
+    // Kill the runtime.
+    #[test]
+    fn test_kill1() {
+        test_kill(1);
+    }
+
+    #[test]
+    fn test_kill4() {
+        test_kill(4);
+    }
+
+    fn test_kill(nworkers: usize) {
+        let (mut handle, _) = Runtime::init_circuit(nworkers, |circuit| {
+            circuit.add_source(Generator::new(|| 5usize));
+        })
+        .unwrap();
+
+        handle.step().unwrap();
+        handle.kill().unwrap();
+    }
+
+    // Drop the runtime.
+    #[test]
+    fn test_drop1() {
+        test_drop(1);
+    }
+
+    #[test]
+    fn test_drop4() {
+        test_drop(4);
+    }
+
+    fn test_drop(nworkers: usize) {
+        let (mut handle, _) = Runtime::init_circuit(nworkers, |circuit| {
+            circuit.add_source(Generator::new(|| 5usize));
+        })
+        .unwrap();
+
+        handle.step().unwrap();
+    }
+}

--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -21,7 +21,7 @@ pub mod schedule;
 pub mod trace;
 
 pub use circuit_builder::{
-    Circuit, ExportId, ExportStream, FeedbackConnector, GlobalNodeId, NodeId, OwnershipPreference,
-    Root, Scope, Stream,
+    Circuit, CircuitHandle, ExportId, ExportStream, FeedbackConnector, GlobalNodeId, NodeId,
+    OwnershipPreference, Scope, Stream,
 };
 pub use runtime::{LocalStore, LocalStoreMarker, Runtime, RuntimeHandle};

--- a/src/circuit/mod.rs
+++ b/src/circuit/mod.rs
@@ -13,6 +13,7 @@ Copyright (c) $CURRENT_YEAR VMware, Inc
 //! streams and emitting a single value to the output stream.
 
 pub mod circuit_builder;
+mod dbsp_handle;
 mod runtime;
 
 pub mod cache;
@@ -24,4 +25,7 @@ pub use circuit_builder::{
     Circuit, CircuitHandle, ExportId, ExportStream, FeedbackConnector, GlobalNodeId, NodeId,
     OwnershipPreference, Scope, Stream,
 };
-pub use runtime::{LocalStore, LocalStoreMarker, Runtime, RuntimeHandle};
+pub use dbsp_handle::DBSPHandle;
+pub use runtime::{Error as RuntimeError, LocalStore, LocalStoreMarker, Runtime, RuntimeHandle};
+
+pub use schedule::Error as SchedulerError;

--- a/src/circuit/runtime.rs
+++ b/src/circuit/runtime.rs
@@ -85,13 +85,13 @@ impl Runtime {
     ///
     /// # #[cfg(not(all(windows, miri)))]
     /// # fn main() {
-    /// use dbsp::circuit::{Root, Runtime};
+    /// use dbsp::circuit::{Circuit, Runtime};
     ///
     /// // Create a runtime with 4 worker threads.
     /// let hruntime = Runtime::run(4, || {
     ///     // This closure runs within each worker thread.
     ///
-    ///     let root = Root::build(move |circuit| {
+    ///     let root = Circuit::build(move |circuit| {
     ///         // Populate `circuit` with operators.
     ///     })
     ///     .unwrap();
@@ -295,11 +295,9 @@ impl TypedMapKey<LocalStoreMarker> for WorkerId {
 mod tests {
     use super::Runtime;
     use crate::{
-        circuit::{
-            schedule::{DynamicScheduler, Scheduler, StaticScheduler},
-            Root,
-        },
+        circuit::schedule::{DynamicScheduler, Scheduler, StaticScheduler},
         operator::Generator,
+        Circuit,
     };
     use std::{cell::RefCell, rc::Rc, thread::sleep, time::Duration};
 
@@ -322,7 +320,7 @@ mod tests {
         let hruntime = Runtime::run(4, || {
             let data = Rc::new(RefCell::new(vec![]));
             let data_clone = data.clone();
-            let root = Root::build_with_scheduler::<_, S>(move |circuit| {
+            let root = Circuit::build_with_scheduler::<_, S>(move |circuit| {
                 let runtime = Runtime::runtime().unwrap();
                 // Generator that produces values using `sequence_next`.
                 circuit
@@ -362,7 +360,7 @@ mod tests {
     {
         let hruntime = Runtime::run(16, || {
             // Create a nested circuit that iterates forever.
-            let root = Root::build_with_scheduler::<_, S>(move |circuit| {
+            let root = Circuit::build_with_scheduler::<_, S>(move |circuit| {
                 circuit
                     .iterate_with_scheduler::<_, _, _, S>(|child| {
                         let mut n: usize = 0;

--- a/src/circuit/schedule/mod.rs
+++ b/src/circuit/schedule/mod.rs
@@ -9,7 +9,7 @@ mod dynamic_scheduler;
 pub use dynamic_scheduler::DynamicScheduler;
 
 /// Scheduler errors.
-#[derive(Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Error {
     /// `origin` node has more than one strong successors who insist on
     /// consuming its output by value (`OwnershipPreference::

--- a/src/circuit/trace.rs
+++ b/src/circuit/trace.rs
@@ -9,8 +9,8 @@
 //! behavior.
 //!
 //! See [`super::Circuit::register_circuit_event_handler`] and
-//! [`super::Root::register_scheduler_event_handler`] APIs for attaching
-//! event handlers to a circuit.
+//! [`super::CircuitHandle::register_scheduler_event_handler`] APIs for
+//! attaching event handlers to a circuit.
 //!
 //! Event handlers are invoked synchronously and therefore must complete
 //! quickly, with any expensive processing completed asynchronously.
@@ -362,7 +362,7 @@ impl Display for CircuitEvent {
 ///                ClockEnd               StepEnd       EvalEnd(id)
 /// ```
 ///
-/// The root circuit automaton is instantiated by the [`super::Root::build`]
+/// The root circuit automaton is instantiated by the [`super::Circuit::build`]
 /// function.  A subcircuit automaton is instantiated when its parent scheduler
 /// evaluates the node that contains this subcircuit (see below).
 ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,8 @@
+use crate::{RuntimeError, SchedulerError};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Error {
+    Scheduler(SchedulerError),
+    Runtime(RuntimeError),
+    Custom(String),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,5 +23,5 @@ pub use ref_pair::RefPair;
 pub use shared_ref::SharedRef;
 pub use time::Timestamp;
 
-pub use circuit::{Circuit, Runtime, Stream};
+pub use circuit::{Circuit, CircuitHandle, Runtime, Stream};
 pub use trace::ord::{OrdIndexedZSet, OrdZSet};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![feature(generic_associated_types)]
 #![cfg_attr(feature = "with-nexmark", feature(is_some_with))]
 
+mod error;
 mod num_entries;
 mod ref_pair;
 mod shared_ref;
@@ -18,10 +19,14 @@ pub mod trace;
 #[cfg(feature = "with-nexmark")]
 pub mod nexmark;
 
+pub use error::Error;
 pub use num_entries::NumEntries;
 pub use ref_pair::RefPair;
 pub use shared_ref::SharedRef;
 pub use time::Timestamp;
 
-pub use circuit::{Circuit, CircuitHandle, Runtime, Stream};
+pub use circuit::{
+    Circuit, CircuitHandle, DBSPHandle, Runtime, RuntimeError, SchedulerError, Stream,
+};
+pub use operator::{CollectionHandle, InputHandle};
 pub use trace::ord::{OrdIndexedZSet, OrdZSet};

--- a/src/monitor/mod.rs
+++ b/src/monitor/mod.rs
@@ -196,9 +196,9 @@ impl TraceMonitorInternal {
             });
         });
         circuit.register_scheduler_event_handler(handler_name, move |event| {
-            // The `ClockEnd` event can be triggered by `Root::drop()` while the thread
-            // is being terminated, at which point the lock may be poisoned.  Just ignore
-            // the event in that case.
+            // The `ClockEnd` event can be triggered by `CircuitHandle::drop()` while the
+            // thread is being terminated, at which point the lock may be
+            // poisoned.  Just ignore the event in that case.
             if let Ok(mut this) = this_clone.lock() {
                 let _ = this.scheduler_event(event).map_err(|e| {
                     (this.scheduler_error_handler)(event, &e);

--- a/src/nexmark/mod.rs
+++ b/src/nexmark/mod.rs
@@ -267,7 +267,8 @@ pub mod tests {
                     assert_eq!(data, &expected_zset);
                 });
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         root.step().unwrap();
     }

--- a/src/nexmark/mod.rs
+++ b/src/nexmark/mod.rs
@@ -146,11 +146,11 @@ where
         // next call.
         self.next_event = next_event;
 
-        C::from_tuples(
+        C::from_keys(
             (),
             next_events
                 .into_iter()
-                .map(|next_event| ((next_event.event, ()), W::one()))
+                .map(|next_event| (next_event.event, W::one()))
                 .collect(),
         )
     }
@@ -160,8 +160,8 @@ where
 pub mod tests {
     use self::generator::tests::{generate_expected_next_events, RangedTimeGenerator};
     use super::*;
+    use crate::{trace::Batch, Circuit, OrdZSet};
     use core::ops::Range;
-    use crate::{OrdZSet, trace::Batch, Circuit};
     use rand::rngs::mock::StepRng;
     use std::sync::{mpsc, mpsc::Receiver};
 
@@ -184,13 +184,13 @@ pub mod tests {
     pub fn generate_expected_zset_tuples(
         wallclock_base_time: u64,
         num_events: usize,
-    ) -> Vec<((Event, ()), isize)> {
+    ) -> Vec<(Event, isize)> {
         let expected_events = generate_expected_next_events(wallclock_base_time, num_events);
 
         expected_events
             .into_iter()
             .filter(|event| event.is_some())
-            .map(|event| ((event.unwrap().event, ()), 1))
+            .map(|event| (event.unwrap().event, 1))
             .collect()
     }
 
@@ -199,7 +199,7 @@ pub mod tests {
         wallclock_base_time: u64,
         num_events: usize,
     ) -> OrdZSet<Event, isize> {
-        OrdZSet::<Event, isize>::from_tuples(
+        OrdZSet::<Event, isize>::from_keys(
             (),
             generate_expected_zset_tuples(wallclock_base_time, num_events),
         )

--- a/src/nexmark/mod.rs
+++ b/src/nexmark/mod.rs
@@ -160,8 +160,8 @@ where
 pub mod tests {
     use self::generator::tests::{generate_expected_next_events, RangedTimeGenerator};
     use super::*;
-    use crate::{circuit::Root, trace::ord::OrdZSet, trace::Batch};
     use core::ops::Range;
+    use crate::{OrdZSet, trace::Batch, Circuit};
     use rand::rngs::mock::StepRng;
     use std::sync::{mpsc, mpsc::Receiver};
 
@@ -257,9 +257,8 @@ pub mod tests {
 
     #[test]
     fn test_nexmark_dbsp_source_full_batch() {
-        let root = Root::build(move |circuit| {
+        let root = Circuit::build(move |circuit| {
             let (source, _) = make_source_with_wallclock_times(0..9, 10);
-
             let expected_zset = generate_expected_zset(0, 10);
 
             circuit

--- a/src/nexmark/queries/q0.rs
+++ b/src/nexmark/queries/q0.rs
@@ -12,13 +12,13 @@ pub fn q0(input: NexmarkStream) -> NexmarkStream {
 mod tests {
     use super::*;
     use crate::nexmark::tests::{generate_expected_zset_tuples, make_source_with_wallclock_times};
-    use crate::{circuit::Root, trace::ord::OrdZSet, trace::Batch};
+    use crate::{Circuit, OrdZSet, trace::Batch};
 
     #[test]
     fn test_q0() {
         let (source, _) = make_source_with_wallclock_times(1..3, 10);
 
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             let input = circuit.add_source(source);
 
             let output = q0(input);
@@ -32,6 +32,6 @@ mod tests {
         })
         .unwrap();
 
-        root.step().unwrap();
+        circuit.step().unwrap();
     }
 }

--- a/src/nexmark/queries/q0.rs
+++ b/src/nexmark/queries/q0.rs
@@ -30,7 +30,8 @@ mod tests {
                 )
             });
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         circuit.step().unwrap();
     }

--- a/src/nexmark/queries/q0.rs
+++ b/src/nexmark/queries/q0.rs
@@ -12,7 +12,7 @@ pub fn q0(input: NexmarkStream) -> NexmarkStream {
 mod tests {
     use super::*;
     use crate::nexmark::tests::{generate_expected_zset_tuples, make_source_with_wallclock_times};
-    use crate::{Circuit, OrdZSet, trace::Batch};
+    use crate::{trace::Batch, Circuit, OrdZSet};
 
     #[test]
     fn test_q0() {

--- a/src/nexmark/queries/q1.rs
+++ b/src/nexmark/queries/q1.rs
@@ -57,16 +57,16 @@ mod tests {
             output.inspect(move |e| {
                 assert_eq!(
                     e,
-                    &OrdZSet::from_tuples(
+                    &OrdZSet::from_keys(
                         (),
                         generate_expected_zset_tuples(0, 10)
                             .into_iter()
-                            .map(|((event, _), w)| {
+                            .map(|(event, w)| {
                                 let event = match event {
                                     Event::Bid(b) => Event::Bid(Bid { price: 89, ..b }),
                                     _ => event,
                                 };
-                                ((event, ()), w)
+                                (event, w)
                             })
                             .collect()
                     )

--- a/src/nexmark/queries/q1.rs
+++ b/src/nexmark/queries/q1.rs
@@ -73,7 +73,8 @@ mod tests {
                 )
             });
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         circuit.step().unwrap();
     }

--- a/src/nexmark/queries/q1.rs
+++ b/src/nexmark/queries/q1.rs
@@ -41,13 +41,13 @@ pub fn q1(input: NexmarkStream) -> NexmarkStream {
 mod tests {
     use super::*;
     use crate::nexmark::tests::{generate_expected_zset_tuples, make_source_with_wallclock_times};
-    use crate::{circuit::Root, trace::ord::OrdZSet, trace::Batch};
+    use crate::{trace::Batch, Circuit, OrdZSet};
 
     #[test]
     fn test_q1() {
         let (source, _) = make_source_with_wallclock_times(0..2, 10);
 
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             let input = circuit.add_source(source);
 
             let output = q1(input);
@@ -75,6 +75,6 @@ mod tests {
         })
         .unwrap();
 
-        root.step().unwrap();
+        circuit.step().unwrap();
     }
 }

--- a/src/nexmark/queries/q2.rs
+++ b/src/nexmark/queries/q2.rs
@@ -100,7 +100,8 @@ mod tests {
                 )
             });
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         root.step().unwrap();
     }

--- a/src/nexmark/queries/q2.rs
+++ b/src/nexmark/queries/q2.rs
@@ -39,7 +39,7 @@ mod tests {
         model::Bid,
         NexmarkSource,
     };
-    use crate::{OrdZSet, trace::Batch};
+    use crate::{trace::Batch, OrdZSet};
     use rand::rngs::mock::StepRng;
     use std::sync::mpsc;
 
@@ -90,11 +90,11 @@ mod tests {
                 // id and price.
                 assert_eq!(
                     e,
-                    &OrdZSet::from_tuples(
+                    &OrdZSet::from_keys(
                         (),
                         vec![
-                            (((AUCTION_ID_MODULO, 99), ()), 1),
-                            (((5 * AUCTION_ID_MODULO, 125), ()), 1),
+                            ((AUCTION_ID_MODULO, 99), 1),
+                            ((5 * AUCTION_ID_MODULO, 125), 1),
                         ]
                     )
                 )

--- a/src/nexmark/queries/q2.rs
+++ b/src/nexmark/queries/q2.rs
@@ -39,7 +39,7 @@ mod tests {
         model::Bid,
         NexmarkSource,
     };
-    use crate::{circuit::Root, trace::ord::OrdZSet, trace::Batch};
+    use crate::{OrdZSet, trace::Batch};
     use rand::rngs::mock::StepRng;
     use std::sync::mpsc;
 
@@ -79,7 +79,7 @@ mod tests {
         let source: NexmarkSource<StepRng, isize, OrdZSet<Event, isize>> =
             NexmarkSource::from_generator(CannedEventGenerator::new(canned_events), tx);
 
-        let root = Root::build(move |circuit| {
+        let root = Circuit::build(move |circuit| {
             let input = circuit.add_source(source);
 
             let output = q2(input);

--- a/src/nexmark/queries/q3.rs
+++ b/src/nexmark/queries/q3.rs
@@ -72,7 +72,7 @@ mod tests {
         model::{Auction, Person},
         NexmarkSource,
     };
-    use crate::{circuit::Root, trace::ord::OrdZSet, trace::Batch};
+    use crate::{Circuit, OrdZSet, trace::Batch};
     use rand::rngs::mock::StepRng;
     use std::sync::mpsc;
 
@@ -130,7 +130,7 @@ mod tests {
         let source: NexmarkSource<StepRng, isize, OrdZSet<Event, isize>> =
             NexmarkSource::from_generator(CannedEventGenerator::new(canned_events), tx);
 
-        let root = Root::build(move |circuit| {
+        let root = Circuit::build(move |circuit| {
             let input = circuit.add_source(source);
 
             let output = q3(input);

--- a/src/nexmark/queries/q3.rs
+++ b/src/nexmark/queries/q3.rs
@@ -164,7 +164,8 @@ mod tests {
                 )
             });
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         root.step().unwrap();
     }

--- a/src/nexmark/queries/q3.rs
+++ b/src/nexmark/queries/q3.rs
@@ -72,7 +72,7 @@ mod tests {
         model::{Auction, Person},
         NexmarkSource,
     };
-    use crate::{Circuit, OrdZSet, trace::Batch};
+    use crate::{trace::Batch, Circuit, OrdZSet};
     use rand::rngs::mock::StepRng;
     use std::sync::mpsc;
 
@@ -138,30 +138,24 @@ mod tests {
             output.inspect(move |e| {
                 assert_eq!(
                     e,
-                    &OrdZSet::from_tuples(
+                    &OrdZSet::from_keys(
                         (),
                         vec![
                             (
                                 (
-                                    (
-                                        String::from("CA Seller"),
-                                        String::from("Phoenix"),
-                                        String::from("CA"),
-                                        999,
-                                    ),
-                                    ()
+                                    String::from("CA Seller"),
+                                    String::from("Phoenix"),
+                                    String::from("CA"),
+                                    999,
                                 ),
                                 1
                             ),
                             (
                                 (
-                                    (
-                                        String::from("ID Seller"),
-                                        String::from("Phoenix"),
-                                        String::from("ID"),
-                                        452,
-                                    ),
-                                    ()
+                                    String::from("ID Seller"),
+                                    String::from("Phoenix"),
+                                    String::from("ID"),
+                                    452,
                                 ),
                                 1
                             ),

--- a/src/nexmark/queries/q4.rs
+++ b/src/nexmark/queries/q4.rs
@@ -109,7 +109,7 @@ mod tests {
         model::{Auction, Bid, Event},
         NexmarkSource,
     };
-    use crate::{Circuit, OrdZSet, trace::Batch};
+    use crate::{trace::Batch, Circuit, OrdZSet};
     use rand::rngs::mock::StepRng;
     use std::sync::mpsc;
 
@@ -218,7 +218,8 @@ mod tests {
                 )
             });
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         root.step().unwrap();
     }

--- a/src/nexmark/queries/q4.rs
+++ b/src/nexmark/queries/q4.rs
@@ -214,7 +214,7 @@ mod tests {
             output.inspect(move |e| {
                 assert_eq!(
                     e,
-                    &OrdZSet::from_tuples((), vec![(((1, 200), ()), 1), (((2, 20), ()), 1),])
+                    &OrdZSet::from_tuples((), vec![((1, 200), 1), ((2, 20), 1),])
                 )
             });
         })

--- a/src/nexmark/queries/q4.rs
+++ b/src/nexmark/queries/q4.rs
@@ -109,7 +109,7 @@ mod tests {
         model::{Auction, Bid, Event},
         NexmarkSource,
     };
-    use crate::{circuit::Root, trace::ord::OrdZSet, trace::Batch};
+    use crate::{Circuit, OrdZSet, trace::Batch};
     use rand::rngs::mock::StepRng;
     use std::sync::mpsc;
 
@@ -206,7 +206,7 @@ mod tests {
 
         // Winning bids for auctions in category 1 are 100 and 300 - ie. AVG of 200
         // Winning (only) bid for auction in category 2 is 20.
-        let root = Root::build(move |circuit| {
+        let root = Circuit::build(move |circuit| {
             let input = circuit.add_source(source);
 
             let output = q4(input);

--- a/src/operator/aggregate.rs
+++ b/src/operator/aggregate.rs
@@ -458,7 +458,8 @@ mod test {
                 })
                 .unwrap();
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         for _ in 0..3 {
             root.step().unwrap();

--- a/src/operator/aggregate.rs
+++ b/src/operator/aggregate.rs
@@ -215,12 +215,12 @@ where
             cursor.values(&mut vals);
             // Skip keys that only contain values with weight zero.
             if !vals.is_empty() {
-                elements.push((((self.agg_func)(cursor.key(), &mut vals), ()), Z::R::one()));
+                elements.push(((self.agg_func)(cursor.key(), &mut vals), Z::R::one()));
             }
             vals.clear();
             cursor.step_key();
         }
-        O::from_tuples((), elements)
+        O::from_keys((), elements)
     }
 }
 
@@ -293,14 +293,14 @@ where
                 integral_cursor.values(&mut vals);
                 // Skip keys that only contain values with weight 0.
                 if !vals.is_empty() {
-                    result.push((((self.agg_func)(key, &mut vals), ()), weight.clone()));
+                    result.push(((self.agg_func)(key, &mut vals), weight.clone()));
                 }
                 vals.clear();
             }
             delta_cursor.step_key();
         }
 
-        O::from_tuples((), result)
+        O::from_keys((), result)
     }
 }
 

--- a/src/operator/aggregate.rs
+++ b/src/operator/aggregate.rs
@@ -308,7 +308,7 @@ where
 mod test {
     use std::{cell::RefCell, rc::Rc};
 
-    use crate::{circuit::Root, operator::GeneratorNested, zset, zset_set, OrdZSet, Runtime};
+    use crate::{operator::GeneratorNested, zset, zset_set, Circuit, OrdZSet, Runtime};
 
     fn do_aggregate_test_mt(workers: usize) {
         let hruntime = Runtime::run(workers, || {
@@ -328,7 +328,7 @@ mod test {
 
     #[test]
     fn aggregate_test() {
-        let root = Root::build(move |circuit| {
+        let root = Circuit::build(move |circuit| {
             let mut inputs = vec![
                 vec![
                     zset_set! { (1, 10), (1, 20), (5, 1) },

--- a/src/operator/apply2.rs
+++ b/src/operator/apply2.rs
@@ -83,7 +83,8 @@ mod test {
                 .apply2(&source2, |x, y| *x + *y)
                 .inspect(|z| assert_eq!(*z, 0));
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         for _ in 0..3 {
             circuit.step().unwrap();

--- a/src/operator/apply2.rs
+++ b/src/operator/apply2.rs
@@ -67,12 +67,12 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::{circuit::Root, operator::Generator};
+    use crate::{operator::Generator, Circuit};
     use std::vec;
 
     #[test]
     fn apply2_test() {
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             let mut inputs1 = vec![1, 2, 3].into_iter();
             let mut inputs2 = vec![-1, -2, -3].into_iter();
 
@@ -86,7 +86,7 @@ mod test {
         .unwrap();
 
         for _ in 0..3 {
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
     }
 }

--- a/src/operator/communication/exchange.rs
+++ b/src/operator/communication/exchange.rs
@@ -354,10 +354,7 @@ where
 ///
 /// # #[cfg(not(miri))]
 /// # fn main() {
-/// use dbsp::{
-///     operator::Generator,
-///     Circuit, Runtime,
-/// };
+/// use dbsp::{operator::Generator, Circuit, Runtime};
 ///
 /// const WORKERS: usize = 16;
 /// const ROUNDS: usize = 10;
@@ -400,7 +397,8 @@ where
 ///             round += 1;
 ///         });
 ///     })
-///     .unwrap();
+///     .unwrap()
+///     .0;
 ///
 ///     for _ in 1..ROUNDS {
 ///         circuit.step();
@@ -706,7 +704,7 @@ mod tests {
             S: Scheduler + 'static,
         {
             let hruntime = Runtime::run(workers, move || {
-                let circuit = Circuit::build_with_scheduler::<_, S>(move |circuit| {
+                let circuit = Circuit::build_with_scheduler::<_, _, S>(move |circuit| {
                     let mut n: usize = 0;
                     let source = circuit.add_source(Generator::new(move || {
                         let result = n;
@@ -733,7 +731,8 @@ mod tests {
                             round += 1;
                         });
                 })
-                .unwrap();
+                .unwrap()
+                .0;
 
                 for _ in 1..ROUNDS {
                     circuit.step().unwrap();

--- a/src/operator/communication/exchange.rs
+++ b/src/operator/communication/exchange.rs
@@ -355,15 +355,15 @@ where
 /// # #[cfg(not(miri))]
 /// # fn main() {
 /// use dbsp::{
-///     circuit::{Root, Runtime},
 ///     operator::Generator,
+///     Circuit, Runtime,
 /// };
 ///
 /// const WORKERS: usize = 16;
 /// const ROUNDS: usize = 10;
 ///
 /// let hruntime = Runtime::run(WORKERS, || {
-///     let root = Root::build(|circuit| {
+///     let circuit = Circuit::build(|circuit| {
 ///         // Create a data source that generates numbers 0, 1, 2, ...
 ///         let mut n: usize = 0;
 ///         let source = circuit.add_source(Generator::new(move || {
@@ -403,7 +403,7 @@ where
 ///     .unwrap();
 ///
 ///     for _ in 1..ROUNDS {
-///         root.step();
+///         circuit.step();
 ///     }
 /// });
 ///
@@ -628,9 +628,10 @@ mod tests {
     use crate::{
         circuit::{
             schedule::{DynamicScheduler, Scheduler, StaticScheduler},
-            Root, Runtime,
+            Runtime,
         },
         operator::Generator,
+        Circuit,
     };
     use std::thread::yield_now;
 
@@ -705,7 +706,7 @@ mod tests {
             S: Scheduler + 'static,
         {
             let hruntime = Runtime::run(workers, move || {
-                let root = Root::build_with_scheduler::<_, S>(move |circuit| {
+                let circuit = Circuit::build_with_scheduler::<_, S>(move |circuit| {
                     let mut n: usize = 0;
                     let source = circuit.add_source(Generator::new(move || {
                         let result = n;
@@ -735,7 +736,7 @@ mod tests {
                 .unwrap();
 
                 for _ in 1..ROUNDS {
-                    root.step().unwrap();
+                    circuit.step().unwrap();
                 }
             });
 

--- a/src/operator/communication/shard.rs
+++ b/src/operator/communication/shard.rs
@@ -270,7 +270,8 @@ mod tests {
                         }
                     });
             })
-            .unwrap();
+            .unwrap()
+            .0;
 
             for _ in 0..3 {
                 circuit.step().unwrap();

--- a/src/operator/communication/shard.rs
+++ b/src/operator/communication/shard.rs
@@ -214,8 +214,7 @@ where
             let batch_index = (hash32(cursor.key()) as usize) % nshards;
             while cursor.val_valid() {
                 builders[batch_index].push((
-                    cursor.key().clone(),
-                    cursor.val().clone(),
+                    OB::item_from(cursor.key().clone(), cursor.val().clone()),
                     cursor.weight(),
                 ));
                 cursor.step_val();

--- a/src/operator/communication/shard.rs
+++ b/src/operator/communication/shard.rs
@@ -232,10 +232,9 @@ where
 #[cfg(test)]
 mod tests {
     use crate::{
-        circuit::Root,
         operator::Generator,
         trace::{Batch, BatchReader},
-        OrdIndexedZSet, Runtime,
+        Circuit, OrdIndexedZSet, Runtime,
     };
 
     #[test]
@@ -255,7 +254,7 @@ mod tests {
 
     fn do_test_shard(workers: usize) {
         let hruntime = Runtime::run(workers, || {
-            let root = Root::build(move |circuit| {
+            let circuit = Circuit::build(move |circuit| {
                 let input = circuit.add_source(Generator::new(|| {
                     let worker_index = Runtime::worker_index();
                     let num_workers = Runtime::runtime().unwrap().num_workers();
@@ -275,7 +274,7 @@ mod tests {
             .unwrap();
 
             for _ in 0..3 {
-                root.step().unwrap();
+                circuit.step().unwrap();
             }
         });
 

--- a/src/operator/condition.rs
+++ b/src/operator/condition.rs
@@ -155,7 +155,7 @@ mod test {
     where
         S: Scheduler + 'static,
     {
-        let circuit = Circuit::build_with_scheduler::<_, S>(|circuit| {
+        let circuit = Circuit::build_with_scheduler::<_, _, S>(|circuit| {
             TraceMonitor::new_panic_on_error().attach(circuit, "monitor");
 
             // Graph edges
@@ -232,7 +232,8 @@ mod test {
             });
             reachable2.inspect(|r| assert_eq!(r, &zset! { 1 => 1, 2 => 1, 4 => 1, 5 => 1, 6 => 1}));
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         for _ in 0..3 {
             circuit.step().unwrap();

--- a/src/operator/condition.rs
+++ b/src/operator/condition.rs
@@ -131,17 +131,14 @@ impl<C> Condition<C> {
 #[cfg(test)]
 mod test {
     use crate::{
-        circuit::{
-            schedule::{DynamicScheduler, Scheduler, StaticScheduler},
-            Circuit, Root, Stream,
-        },
+        circuit::schedule::{DynamicScheduler, Scheduler, StaticScheduler},
         monitor::TraceMonitor,
         operator::{DelayedFeedback, FilterMap, Generator},
         trace::{
             ord::{OrdIndexedZSet, OrdZSet},
             BatchReader,
         },
-        zset,
+        zset, Circuit, Stream,
     };
 
     #[test]
@@ -158,7 +155,7 @@ mod test {
     where
         S: Scheduler + 'static,
     {
-        let root = Root::build_with_scheduler::<_, S>(|circuit| {
+        let circuit = Circuit::build_with_scheduler::<_, S>(|circuit| {
             TraceMonitor::new_panic_on_error().attach(circuit, "monitor");
 
             // Graph edges
@@ -238,7 +235,7 @@ mod test {
         .unwrap();
 
         for _ in 0..3 {
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
     }
 }

--- a/src/operator/csv.rs
+++ b/src/operator/csv.rs
@@ -81,10 +81,10 @@ where
             let data: Vec<_> = self
                 .reader
                 .deserialize()
-                .map(|x| ((x.unwrap(), ()), W::one()))
+                .map(|x| (x.unwrap(), W::one()))
                 .collect();
 
-            C::from_tuples((), data)
+            C::from_keys((), data)
         } else {
             C::zero()
         };

--- a/src/operator/csv.rs
+++ b/src/operator/csv.rs
@@ -96,12 +96,12 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::{circuit::Root, operator::CsvSource, trace::ord::OrdZSet, zset};
+    use crate::{operator::CsvSource, zset, Circuit, OrdZSet};
     use csv::ReaderBuilder;
 
     #[test]
     fn test_csv_reader() {
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             let expected = zset! {
                 (18, 3, 237641) => 1,
                 (237641, 4, 18) => 1,
@@ -132,6 +132,6 @@ mod test {
         })
         .unwrap();
 
-        root.step().unwrap();
+        circuit.step().unwrap();
     }
 }

--- a/src/operator/csv.rs
+++ b/src/operator/csv.rs
@@ -130,7 +130,8 @@ mod test {
                     assert_eq!(data, &expected)
                 });
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         circuit.step().unwrap();
     }

--- a/src/operator/distinct.rs
+++ b/src/operator/distinct.rs
@@ -656,7 +656,8 @@ mod test {
                 })
                 .unwrap();
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         for _ in 0..3 {
             circuit.step().unwrap();
@@ -737,7 +738,8 @@ mod test {
                 })
                 .unwrap();
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         for _ in 0..3 {
             circuit.step().unwrap();

--- a/src/operator/distinct.rs
+++ b/src/operator/distinct.rs
@@ -580,7 +580,7 @@ where
 mod test {
     use std::{cell::RefCell, rc::Rc};
 
-    use crate::{circuit::Root, operator::GeneratorNested, zset, OrdZSet, Runtime};
+    use crate::{operator::GeneratorNested, zset, Circuit, OrdZSet, Runtime};
 
     fn do_distinct_incremental_nested_test_mt(workers: usize) {
         let hruntime = Runtime::run(workers, || {
@@ -600,7 +600,7 @@ mod test {
 
     #[test]
     fn distinct_incremental_nested_test() {
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             let mut inputs = vec![
                 vec![zset! { 1 => 1, 2 => 1 }, zset! { 2 => -1, 3 => 2, 4 => 2 }],
                 vec![zset! { 2 => 1, 3 => 1 }, zset! { 3 => -2, 4 => -1 }],
@@ -659,7 +659,7 @@ mod test {
         .unwrap();
 
         for _ in 0..3 {
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
     }
 
@@ -681,7 +681,7 @@ mod test {
 
     #[test]
     fn distinct_trace_test() {
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             let mut inputs = vec![
                 vec![zset! { 1 => 1, 2 => 1 }, zset! { 2 => -1, 3 => 2, 4 => 2 }],
                 vec![zset! { 2 => 1, 3 => 1 }, zset! { 3 => -2, 4 => -1 }],
@@ -740,7 +740,7 @@ mod test {
         .unwrap();
 
         for _ in 0..3 {
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
     }
 }

--- a/src/operator/distinct.rs
+++ b/src/operator/distinct.rs
@@ -231,11 +231,11 @@ where
             if old_weight.le0() {
                 // Weight changes from non-positive to positive.
                 if new_weight.ge0() && !new_weight.is_zero() {
-                    builder.push((v.clone(), (), HasOne::one()));
+                    builder.push((Z::item_from(v.clone(), ()), HasOne::one()));
                 }
             } else if new_weight.le0() {
                 // Weight changes from positive to non-positive.
-                builder.push((v.clone(), (), Z::R::one().neg()));
+                builder.push((Z::item_from(v.clone(), ()), Z::R::one().neg()));
             }
             delta_cursor.step_key();
         }
@@ -347,7 +347,7 @@ where
         _trace: &'s T,
         value: &Z::Key,
         weight: Z::R,
-        output: &mut Vec<((Z::Key, ()), Z::R)>,
+        output: &mut Vec<(Z::Item, Z::R)>,
     ) {
         //eprintln!("value: {:?}, weight: {:?}", value, weight);
         trace_cursor.seek_key(value);
@@ -397,7 +397,7 @@ where
 
             // Update output.
             if delta_old != delta_new {
-                output.push(((value.clone(), ()), delta_new + delta_old.neg()));
+                output.push((Z::item_from(value.clone(), ()), delta_new + delta_old.neg()));
             }
 
             // Record next_ts in `self.future_updates`.
@@ -406,7 +406,7 @@ where
                 self.future_updates[idx].insert(value.clone());
             }
         } else if weight.ge0() && !weight.is_zero() {
-            output.push(((value.clone(), ()), HasOne::one()));
+            output.push((Z::item_from(value.clone(), ()), HasOne::one()));
         }
     }
 }

--- a/src/operator/filter_map.rs
+++ b/src/operator/filter_map.rs
@@ -767,7 +767,7 @@ mod test {
                 assert_eq!(*n, i_sqr_pos_indexed_output.next().unwrap());
             });
         })
-        .unwrap();
+        .unwrap().0;
 
         for _ in 0..1 {
             circuit.step().unwrap();

--- a/src/operator/filter_map.rs
+++ b/src/operator/filter_map.rs
@@ -339,7 +339,7 @@ where
                 while cursor.val_valid() {
                     let val = cursor.val().clone();
                     let w = cursor.weight();
-                    builder.push((cursor.key().clone(), val, w.clone()));
+                    builder.push((CO::item_from(cursor.key().clone(), val), w.clone()));
                     cursor.step_val();
                 }
             }
@@ -410,7 +410,7 @@ where
                 if (self.filter)((cursor.key(), cursor.val())) {
                     let val = cursor.val().clone();
                     let w = cursor.weight();
-                    builder.push((cursor.key().clone(), val, w.clone()));
+                    builder.push((CO::item_from(cursor.key().clone(), val), w.clone()));
                 }
                 cursor.step_val();
             }
@@ -467,7 +467,7 @@ where
         while cursor.key_valid() {
             while cursor.val_valid() {
                 let (k, v) = (self.map)((cursor.key(), cursor.val()));
-                batch.push(((k, v), cursor.weight()));
+                batch.push((CO::item_from(k, v), cursor.weight()));
                 cursor.step_val();
             }
             cursor.step_key();
@@ -533,7 +533,7 @@ where
                 let w = cursor.weight();
                 let v = cursor.val();
                 let k = cursor.key();
-                batch.push((((self.map_borrowed)(k), v.clone()), w.clone()));
+                batch.push((CO::item_from((self.map_borrowed)(k), v.clone()), w.clone()));
                 cursor.step_val();
             }
             cursor.step_key();
@@ -599,7 +599,7 @@ where
             while cursor.val_valid() {
                 let w = cursor.weight();
                 for (x, y) in (self.map_func)((cursor.key(), cursor.val())).into_iter() {
-                    batch.push(((x, y), w.clone()));
+                    batch.push((CO::item_from(x, y), w.clone()));
                 }
                 cursor.step_val();
             }

--- a/src/operator/filter_map.rs
+++ b/src/operator/filter_map.rs
@@ -613,17 +613,16 @@ where
 #[cfg(test)]
 mod test {
     use crate::{
-        circuit::Root,
         indexed_zset,
         operator::{FilterMap, Generator},
         trace::ord::OrdZSet,
-        zset,
+        zset, Circuit,
     };
     use std::vec;
 
     #[test]
     fn filter_map_test() {
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             let mut input: vec::IntoIter<OrdZSet<(isize, &'static str), isize>> =
                 vec![zset! { (1, "1") => 1, (-1, "-1") => 1, (5, "5 foo") => 1, (-2, "-2") => 1 }].into_iter();
 
@@ -771,7 +770,7 @@ mod test {
         .unwrap();
 
         for _ in 0..1 {
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
     }
 }

--- a/src/operator/index.rs
+++ b/src/operator/index.rs
@@ -251,7 +251,7 @@ mod test {
                    .integrate()
                    .inspect(move |fm: &OrdIndexedZSet<_, _, _>| assert_eq!(fm, &outputs.next().unwrap()));
         })
-        .unwrap();
+        .unwrap().0;
 
         for _ in 0..2 {
             circuit.step().unwrap();
@@ -284,7 +284,7 @@ mod test {
                    .integrate()
                    .inspect(move |fm: &OrdIndexedZSet<_, _, _>| assert_eq!(fm, &outputs.next().unwrap()));
         })
-        .unwrap();
+        .unwrap().0;
 
         for _ in 0..2 {
             circuit.step().unwrap();

--- a/src/operator/index.rs
+++ b/src/operator/index.rs
@@ -139,7 +139,7 @@ where
             let (k, v) = cursor.key().clone();
             // TODO: pass key (and value?) by reference
             let w = cursor.weight();
-            builder.push((k, v, w));
+            builder.push((CO::item_from(k, v), w));
             cursor.step_key();
         }
         builder.done()
@@ -209,7 +209,7 @@ where
             let (k, v) = (self.index_func)(cursor.key());
             // TODO: pass key (and value?) by reference
             let w = cursor.weight();
-            tuples.push(((k, v), w));
+            tuples.push((CO::item_from(k, v), w));
             cursor.step_key();
         }
 

--- a/src/operator/index.rs
+++ b/src/operator/index.rs
@@ -223,13 +223,11 @@ where
 }
 #[cfg(test)]
 mod test {
-    use crate::{
-        circuit::Root, indexed_zset, operator::Generator, trace::ord::OrdIndexedZSet, zset,
-    };
+    use crate::{indexed_zset, operator::Generator, trace::ord::OrdIndexedZSet, zset, Circuit};
 
     #[test]
     fn index_test() {
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             let mut inputs = vec![
                 zset!{ (1, "a") => 1
                      , (1, "b") => 1
@@ -256,13 +254,13 @@ mod test {
         .unwrap();
 
         for _ in 0..2 {
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
     }
 
     #[test]
     fn index_with_test() {
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             let mut inputs = vec![
                 zset!{ (1, "a") => 1
                      , (1, "b") => 1
@@ -289,7 +287,7 @@ mod test {
         .unwrap();
 
         for _ in 0..2 {
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
     }
 }

--- a/src/operator/input.rs
+++ b/src/operator/input.rs
@@ -1,0 +1,1229 @@
+use crate::{
+    algebra::{HasOne, MonoidValue},
+    circuit::{
+        operator_traits::{Operator, SourceOperator},
+        LocalStoreMarker, OwnershipPreference, Scope,
+    },
+    operator::{
+        trace::{DelayedTraceId, IntegrateTraceId, UntimedTraceAppend, Z1Trace},
+        upsert::Upsert,
+    },
+    trace::{spine_fueled::Spine, Batch},
+    Circuit, OrdIndexedZSet, OrdZSet, Runtime, Stream,
+};
+use deepsize::DeepSizeOf;
+use fxhash::hash32;
+use std::{
+    borrow::Cow,
+    hash::{Hash, Hasher},
+    marker::PhantomData,
+    mem::take,
+    ops::{DerefMut, Neg},
+    sync::{Arc, Mutex},
+};
+use typedmap::TypedMapKey;
+
+pub type IndexedZSetStream<K, V, R> = Stream<Circuit<()>, OrdIndexedZSet<K, V, R>>;
+pub type ZSetStream<K, R> = Stream<Circuit<()>, OrdZSet<K, R>>;
+
+impl Circuit<()> {
+    /// Create an input stream that carries values of type `T`.
+    ///
+    /// Input streams are used to push data to the circuit from the outside
+    /// world via the [`InputHandle`] object returned by this method:
+    ///
+    /// ```text
+    ///                   ┌──────────────────────┐
+    ///                   │Circuit               │
+    ///                   │                      │
+    /// ┌───────────┐     │   stream             │
+    /// │InputHandle├──────────────────►         │
+    /// └───────────┘     │                      │
+    ///                   │                      │
+    ///                   └──────────────────────┘
+    /// ```
+    ///
+    /// At each clock cycle, the stream consumes the last value placed in it via
+    /// the `InputHandle` (or `<T as Default>::default()` if no value was
+    /// placed in the stream since the last clock cycle) and yields this
+    /// value to all downstream operators connected to it.
+    ///
+    /// See [`InputHandle`] for more details.
+    pub fn add_input_stream<T>(&self) -> (Stream<Self, T>, InputHandle<T>)
+    where
+        T: Default + Clone + Send + 'static,
+    {
+        let (input, input_handle) = Input::new(|x| x);
+        let stream = self.add_source(input);
+        (stream, input_handle)
+    }
+
+    /// Create an input stream that carries values of type [`OrdZSet<K,
+    /// R>`](`OrdZSet`).
+    ///
+    /// Creates an input stream that carries values of type `OrdZSet<K, R>` and
+    /// an input handle of type [`CollectionHandle<K, R>`](`CollectionHandle`)
+    /// used to construct input Z-sets out of individual elements.  The
+    /// client invokes `[CollectionHandle::push]` and
+    /// [`CollectionHandle::append`] any number of times to add values to
+    /// the input Z-set. These values are distributed across all worker
+    /// threads (when running in a multithreaded [`Runtime`]) based on the
+    /// hash of the value and buffered until the start of the next clock
+    /// cycle.  At the start of a clock cycle (triggered by
+    /// [`DBSPHandle::step`](`crate::DBSPHandle::step`) or
+    /// [`CircuitHandle::step`](`crate::CircuitHandle::step`)), the circuit
+    /// reads all buffered values and assembles them into an `OrdZSet`.
+    ///
+    /// See [`CollectionHandle`] for more details.
+    // TODO: Add a version that takes a custom hash function.
+    pub fn add_input_zset<K, R>(&self) -> (Stream<Self, OrdZSet<K, R>>, CollectionHandle<K, R>)
+    where
+        K: Clone + Send + Ord + Hash + 'static,
+        R: MonoidValue + Send,
+    {
+        let (input, input_handle) = Input::new(|tuples| OrdZSet::from_keys((), tuples));
+        let stream = self.add_source(input);
+
+        let zset_handle = <CollectionHandle<K, R>>::new(input_handle);
+
+        (stream, zset_handle)
+    }
+
+    /// Create an input stream that carries values of type [`OrdIndexedZSet<K,
+    /// V, R>`](`OrdIndexedZSet`).
+    ///
+    /// Creates an input stream that carries values of type `OrdIndexedZSet<K,
+    /// V, R>` and an input handle of type [`CollectionHandle<K, (V,
+    /// R)>`](`CollectionHandle`) used to construct input Z-sets out of
+    /// individual elements.  The client invokes `[CollectionHandle::push]`
+    /// and [`CollectionHandle::append`] any number of times to add
+    /// `key/value/weight` triples the indexed Z-set. These triples are
+    /// distributed across all worker threads (when running in a
+    /// multithreaded [`Runtime`]) based on the hash of the key, and
+    /// buffered until the start of the next clock cycle.  At the start of a
+    /// clock cycle (triggered by
+    /// [`DBSPHandle::step`](`crate::DBSPHandle::step`) or
+    /// [`CircuitHandle::step`](`crate::CircuitHandle::step`)), the circuit
+    /// reads all buffered values and assembles them into an `OrdIndexedZSet`.
+    ///
+    /// See [`CollectionHandle`] for more details.
+    // TODO: Add a version that takes a custom hash function.
+    #[allow(clippy::type_complexity)]
+    pub fn add_input_indexed_zset<K, V, R>(
+        &self,
+    ) -> (IndexedZSetStream<K, V, R>, CollectionHandle<K, (V, R)>)
+    where
+        K: Ord + Clone + Hash + Send + 'static,
+        V: Ord + Clone + Send + 'static,
+        R: MonoidValue + Clone + Send,
+    {
+        let (input, input_handle) = Input::new(|tuples: Vec<(K, (V, R))>| {
+            OrdIndexedZSet::from_tuples(
+                (),
+                tuples.into_iter().map(|(k, (v, w))| ((k, v), w)).collect(),
+            )
+        });
+        let stream = self.add_source(input);
+
+        let zset_handle = <CollectionHandle<K, (V, R)>>::new(input_handle);
+
+        (stream, zset_handle)
+    }
+
+    fn add_upsert<K, VI, V, F, B>(
+        &self,
+        input_stream: Stream<Self, Vec<(K, VI)>>,
+        upsert_func: F,
+    ) -> Stream<Self, B>
+    where
+        K: Clone + Ord + Hash + Send + DeepSizeOf + 'static,
+        F: Fn(VI) -> Option<V> + 'static,
+        B: Batch<Key = K, Val = V, Time = ()> + DeepSizeOf + 'static,
+        B::R: MonoidValue + HasOne + Neg<Output = B::R> + DeepSizeOf,
+        V: Eq + Clone + Ord + 'static,
+        VI: Eq + Clone + 'static,
+    {
+        // ```text
+        // We build the following circuit to implement the upsert semantics.
+        // The collection is accumulated into a trace using integrator
+        // (UntimedTraceAppend + Z1Trace = integrator).  The `Upsert` operator
+        // evaluates each upsert command in the input stream against the trace
+        // and computes a batch of updates to be added to the trace.
+        //
+        //                          ┌─────────────────────────────────────────►
+        //                          │
+        //                          │
+        // input_stream ┌──────┐    │        ┌──────────────────┐  trace
+        // ────────────►│Upsert├────┴───────►│UntimedTraceAppend├────┐
+        //              └──────┘   upsert    └──────────────────┘    │
+        //                 ▲                  ▲                      │
+        //                 │                  │                      │
+        //                 │                  │   ┌───────┐          │
+        //                 └──────────────────┴───┤Z1Trace│◄─────────┘
+        //                    z1trace             └───────┘
+        // ```
+        let (z1trace, z1feedback) = self.add_feedback(Z1Trace::new(true, self.root_scope()));
+        let upsert = self.add_binary_operator_with_preference(
+            Upsert::new(upsert_func),
+            &z1trace,
+            &input_stream,
+            OwnershipPreference::PREFER_OWNED,
+            OwnershipPreference::PREFER_OWNED,
+        );
+        let trace = self.add_binary_operator_with_preference(
+            <UntimedTraceAppend<Spine<_>>>::new(),
+            &z1trace,
+            &upsert,
+            OwnershipPreference::STRONGLY_PREFER_OWNED,
+            OwnershipPreference::PREFER_OWNED,
+        );
+
+        z1feedback.connect_with_preference(&trace, OwnershipPreference::STRONGLY_PREFER_OWNED);
+        self.cache_insert(
+            DelayedTraceId::new(upsert.origin_node_id().clone()),
+            z1trace,
+        );
+        self.cache_insert(
+            IntegrateTraceId::new(upsert.origin_node_id().clone()),
+            trace,
+        );
+
+        upsert
+    }
+
+    /// Create an input table with set semantics.
+    ///
+    /// # Motivation
+    ///
+    /// DBSP represents relational data using Z-sets, i.e., tables where each
+    /// record has a weight, which denotes the number of times the record occurs
+    /// in the table.  Updates to Z-sets are also Z-sets, with
+    /// positive weights representing insertions and negative weights
+    /// representing deletions.  The contents of the Z-set after an update
+    /// is computed by summing up the weights associated with each record.
+    /// Z-set updates are commutative, e.g., insert->insert->delete and
+    /// insert->delete->insert sequences are both equivalent to a single
+    /// insert.  This internal representation enables efficient incremental
+    /// computation, but it does not always match the data model used by the
+    /// outside world, and may require a translation layer to eliminate this
+    /// mismatch when ingesting data into DBSP.
+    ///
+    /// In particular, input tables often behave as sets.  A set is a special
+    /// case of a Z-set where all weights are equal to 1.  Duplicate
+    /// insertions and deletions to sets are ignored, i.e., inserting an
+    /// existing element or deleting an element not in the set are both
+    /// no-ops.  Set updates are not commutative, e.g., the
+    /// insert->delete->insert sequence is equivalent to a single insert,
+    /// while insert->insert->delete is equivalent to a delete.
+    ///
+    /// # Details
+    ///
+    /// The `add_input_set` operator creates an input table that internally
+    /// appears as a Z-set with unit weights, but that ingests input data
+    /// using set semantics. It returns a stream that carries values of type
+    /// `OrdZSet<K, R>` and an input handle of type
+    /// [`CollectionHandle<K,bool>`](`CollectionHandle`).  The client uses
+    /// `[CollectionHandle::push]` and [`CollectionHandle::append`] to submit
+    /// commands of the form `(val, true)` to insert an element to the set
+    /// and `(val, false) ` to delete `val` from the set.  These commands
+    /// are buffered until the start of the next clock cycle.
+    ///
+    /// At the start of a clock cycle (triggered by
+    /// [`DBSPHandle::step`](`crate::DBSPHandle::step`) or
+    /// [`CircuitHandle::step`](`crate::CircuitHandle::step`)), DBSP applies
+    /// buffered commands in order and computes an update to the input set as
+    /// an `OrdZSet` with weights `+1` and `-1` representing set insertions and
+    /// deletions respectively. The following table illustrates the
+    /// relationship between input commands, the contents of the set and the
+    /// contents of the stream produced by this operator:
+    ///
+    /// ```text
+    /// time │      input commands          │content of the   │ stream returned by     │  comment
+    ///      │                              │input set        │ `add_input_set`        │
+    /// ─────┼──────────────────────────────┼─────────────────┼────────────────────────┼───────────────────────────────────────────────────────
+    ///    1 │{("foo",true),("bar",true)}   │  {"foo","bar"}  │ {("foo",+1),("bar",+1)}│
+    ///    2 │{("foo",true),("bar",false)}  │  {"foo"}        │ {("bar",-1)}           │ignore duplicate insert of "foo"
+    ///    3 │{("foo",false),("foo",true)}  │  {"foo"}        │ {}                     │deleting and re-inserting "foo" is a no-op
+    ///    4 │{("foo",false),("bar",false)} │  {}             │ {("foo",-1)}           │deleting value "bar" that is not in the set is a no-op
+    /// ─────┴──────────────────────────────┴─────────────────┴────────────────────────┴────────────────────────────────────────────────────────
+    /// ```
+    ///
+    /// Internally, this operator maintains the contents of the input set
+    /// partitioned across all worker threads based on the hash of the
+    /// value.  Insert/delete commands are routed to the worker in charge of
+    /// the given value.
+    // TODO: Add a version that takes a custom hash function.
+    pub fn add_input_set<K, R>(&self) -> (ZSetStream<K, R>, CollectionHandle<K, bool>)
+    where
+        K: Clone + Ord + Hash + Send + DeepSizeOf + 'static,
+        R: MonoidValue + HasOne + Neg<Output = R> + DeepSizeOf,
+    {
+        self.region("input_set", || {
+            let (input, input_handle) = Input::new(|tuples: Vec<(K, bool)>| tuples);
+            let input_stream = self.add_source(input);
+            let zset_handle = <CollectionHandle<K, bool>>::new(input_handle);
+
+            let upsert =
+                self.add_upsert(input_stream, |insert| if insert { Some(()) } else { None });
+
+            (upsert, zset_handle)
+        })
+    }
+
+    /// Create an input table as a key-value map with upsert update semantics.
+    ///
+    /// # Motivation
+    ///
+    /// DBSP represents indexed data using indexed Z-sets, i.e., sets
+    /// of `(key, value, weight)` tuples, where `weight`
+    /// denotes the number of times the key-value pair occurs in
+    /// the table.  Updates to indexed Z-sets are also indexed Z-sets, with
+    /// positive weights representing insertions and negative weights
+    /// representing deletions.  The contents of the indexed Z-set after an
+    /// update is computed by summing up weights associated with each
+    /// key-value pair. This representation enables efficient incremental
+    /// computation, but it does not always match the data model used by the
+    /// outside world, and may require a translation layer to eliminate this
+    /// mismatch when ingesting indexed data into DBSP.
+    ///
+    /// In particular, input tables often behave as key-value maps.  
+    /// A map is a special case of an indexed Z-set where each key has
+    /// a unique value associated with it and where all weights are 1.
+    /// Map updates follow the update-or-insert (*upsert*) semantics,
+    /// where inserting a new key-value pair overwrites the old value
+    /// associated with the key, if any.
+    ///
+    /// # Details
+    ///
+    /// The `add_input_map` operator creates an input table that internally
+    /// appears as an indexed Z-set with all unit weights, but that ingests
+    /// input data using upsert semantics. It returns a stream that carries
+    /// values of type `OrdIndexedZSet<K, V, R>` and an input handle of type
+    /// [`CollectionHandle<K,Option<V>>`](`CollectionHandle`).  The client uses
+    /// `[CollectionHandle::push]` and [`CollectionHandle::append`] to submit
+    /// commands of the form `(key, Some(val))` to insert a new key-value
+    /// pair and `(key, None) ` to delete the value associated with `key` is
+    /// any. These commands are buffered until the start of the next clock
+    /// cycle.
+    ///
+    /// At the start of a clock cycle (triggered by
+    /// [`DBSPHandle::step`](`crate::DBSPHandle::step`) or
+    /// [`CircuitHandle::step`](`crate::CircuitHandle::step`)),
+    /// DBSP applies buffered commands in order and
+    /// computes an update to the input set as an `OrdIndexedZSet` with weights
+    /// `+1` and `-1` representing insertions and deletions respectively.
+    /// The following table illustrates the relationship between input commands,
+    /// the contents of the map and the contents of the stream produced by this
+    /// operator:
+    ///
+    /// ```text
+    /// time │      input commands               │content of the        │ stream returned by         │  comment
+    ///      │                                   │input map             │ `add_input_map`            │
+    /// ─────┼───────────────────────────────────┼──────────────────────┼────────────────────────────┼───────────────────────────────────────────────────────
+    ///    1 │{(1,Some("foo"), (2,Some("bar"))}  │{(1,"foo"),(2,"bar")} │ {(1,"foo",+1),(2,"bar",+1)}│
+    ///    2 │{(1,Some("foo"), (2,Some("baz"))}  │{(1,"foo"),(2,"baz")} │ {(2,"bar",-1),(2,"baz",+1)}│ Ignore duplicate insert of (1,"foo"). New value
+    ///      |                                   |                      |                            | "baz" for key 2 overwrites the old value "bar".
+    ///    3 │{(1,None),(2,Some("bar")),(2,None)}│{}                    │ {(1,"foo",-1),(2,"baz",-1)}│ Delete both keys. Upsert (2,"bar") is overridden
+    ///      |                                   |                      |                            | by subsequent delete command.
+    /// ─────┴───────────────────────────────────┴──────────────────────┴────────────────────────────┴────────────────────────────────────────────────────────
+    /// ```
+    ///
+    /// Note that upsert commands cannot fail.  Duplicate inserts and deletes
+    /// are simply ignored.
+    ///
+    /// Internally, this operator maintains the contents of the map
+    /// partitioned across all worker threads based on the hash of the
+    /// key.  Upsert/delete commands are routed to the worker in charge of
+    /// the given key.
+    // TODO: Add a version that takes a custom hash function.
+    pub fn add_input_map<K, V, R>(
+        &self,
+    ) -> (IndexedZSetStream<K, V, R>, CollectionHandle<K, Option<V>>)
+    where
+        K: Clone + Ord + Hash + Send + DeepSizeOf + 'static,
+        V: Ord + Clone + Send + DeepSizeOf + 'static,
+        R: MonoidValue + HasOne + Neg<Output = R> + DeepSizeOf,
+    {
+        self.region("input_map", || {
+            let (input, input_handle) = Input::new(|tuples: Vec<(K, Option<V>)>| tuples);
+            let input_stream = self.add_source(input);
+            let zset_handle = <CollectionHandle<K, Option<V>>>::new(input_handle);
+
+            let upsert = self.add_upsert(input_stream, |val| val);
+
+            (upsert, zset_handle)
+        })
+    }
+}
+
+/// `TypedMapKey` entry used to share InputHandle objects across workers in a
+/// runtime. The first worker to create the handle will store it in the map,
+/// subsequent workers will get a clone of the same handle.
+struct InputId<T> {
+    id: usize,
+    _marker: PhantomData<T>,
+}
+
+unsafe impl<T> Sync for InputId<T> {}
+
+// Implement `Hash`, `Eq` manually to avoid `T: Hash` type bound.
+impl<T> Hash for InputId<T> {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.id.hash(state);
+    }
+}
+
+impl<T> PartialEq for InputId<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl<T> Eq for InputId<T> {}
+
+impl<T> InputId<T> {
+    fn new(id: usize) -> Self {
+        Self {
+            id,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<T> TypedMapKey<LocalStoreMarker> for InputId<T>
+where
+    T: 'static,
+{
+    type Value = InputHandle<T>;
+}
+
+/// Mailbox used to buffer data sent via an `InputHandle` to a worker thread.
+#[derive(Clone)]
+struct Mailbox<T> {
+    value: Arc<Mutex<T>>,
+}
+
+impl<T> Mailbox<T>
+where
+    T: Default,
+{
+    fn new() -> Self {
+        Self {
+            value: Arc::new(Mutex::new(Default::default())),
+        }
+    }
+
+    fn take(&self) -> T {
+        take(self.value.lock().unwrap().deref_mut())
+    }
+
+    fn update<F>(&self, f: F)
+    where
+        F: FnOnce(&mut T),
+    {
+        f(self.value.lock().unwrap().deref_mut());
+    }
+
+    fn set(&self, v: T) {
+        *self.value.lock().unwrap() = v;
+    }
+}
+
+struct InputHandleInternal<T> {
+    mailbox: Vec<Mailbox<T>>,
+}
+
+impl<T> InputHandleInternal<T>
+where
+    T: Default + Clone,
+{
+    fn new(num_workers: usize) -> Self {
+        assert_ne!(num_workers, 0);
+
+        let mut mailbox = Vec::with_capacity(num_workers);
+        for _ in 0..num_workers {
+            mailbox.push(Mailbox::new());
+        }
+
+        Self { mailbox }
+    }
+
+    fn set_for_worker(&self, worker: usize, v: T) {
+        self.mailbox[worker].set(v);
+    }
+
+    fn update_for_worker<F>(&self, worker: usize, f: F)
+    where
+        F: FnOnce(&mut T),
+    {
+        self.mailbox[worker].update(f);
+    }
+
+    /// Send the same value to all workers.
+    fn set_for_all(&self, v: T) {
+        for i in 0..self.mailbox.len() - 1 {
+            self.mailbox[i].set(v.clone());
+        }
+        self.mailbox[self.mailbox.len() - 1].set(v);
+    }
+
+    fn clear_for_all(&self) {
+        for mailbox in self.mailbox.iter() {
+            mailbox.set(Default::default());
+        }
+    }
+
+    fn mailbox(&self, worker: usize) -> &Mailbox<T> {
+        &self.mailbox[worker]
+    }
+}
+
+/// A handle used to write data to an input stream created by
+/// the [`Circuit::add_input_stream`] method.
+///
+/// Internally, the handle manages an array of mailboxes, one for
+/// each worker thread.  At the start of each clock cycle, the
+/// circuit reads the current value from each mailbox and writes
+/// it to the input stream associated with the handle, leaving
+/// the mailbox empty (more precisely, the mailbox will contain
+/// `T::default()`).  The handle is then used to write new values
+/// to the mailboxes, which will be consumed at the next
+/// logical clock tick.
+#[derive(Clone)]
+pub struct InputHandle<T>(Arc<InputHandleInternal<T>>);
+
+impl<T> InputHandle<T>
+where
+    T: Default + Send + Clone + 'static,
+{
+    fn new() -> Self {
+        match Runtime::runtime() {
+            None => Self(Arc::new(InputHandleInternal::new(1))),
+            Some(runtime) => {
+                let input_id = runtime.sequence_next(Runtime::worker_index());
+
+                runtime
+                    .local_store()
+                    .entry(InputId::new(input_id))
+                    .or_insert_with(|| {
+                        Self(Arc::new(InputHandleInternal::new(runtime.num_workers())))
+                    })
+                    .value()
+                    .clone()
+            }
+        }
+    }
+
+    fn mailbox(&self, worker: usize) -> &Mailbox<T> {
+        self.0.mailbox(worker)
+    }
+
+    /// Write value `v` to the specified worker's mailbox,
+    /// overwriting any previous value in the mailbox.
+    pub fn set_for_worker(&self, worker: usize, v: T) {
+        self.0.set_for_worker(worker, v);
+    }
+
+    /// Mutate the contents of the specified worker's mailbox
+    /// using closure `f`.
+    pub fn update_for_worker<F>(&self, worker: usize, f: F)
+    where
+        F: FnOnce(&mut T),
+    {
+        self.0.update_for_worker(worker, f);
+    }
+
+    /// Write value `v` to all worker mailboxes.
+    pub fn set_for_all(&self, v: T) {
+        self.0.set_for_all(v);
+    }
+
+    pub fn clear_for_all(&self) {
+        self.0.clear_for_all();
+    }
+}
+
+pub trait HashFunc<K>: Fn(&K) -> u32 + Send + Sync {}
+
+impl<K, F> HashFunc<K> for F where F: Fn(&K) -> u32 + Send + Sync {}
+
+/// A handle used to write data to an input stream created by
+/// [`add_input_zset`](`Circuit::add_input_zset`),
+/// [`add_input_indexed_zset`](`Circuit::add_input_indexed_zset`),
+/// [`add_input_set`](`Circuit::add_input_set`), and
+/// [`add_input_map`](`Circuit::add_input_map`)
+/// methods.
+///
+/// The handle provides an API to push updates to the stream in
+/// the form of `(key, value)` tuples.  See
+/// [`add_input_zset`](`Circuit::add_input_zset`),
+/// [`add_input_indexed_zset`](`Circuit::add_input_indexed_zset`),
+/// [`add_input_set`](`Circuit::add_input_set`), and
+/// [`add_input_map`](`Circuit::add_input_map`)
+/// documentation for the exact semantics of these updates.
+///
+/// Internally, the handle manages an array of mailboxes, one for
+/// each worker thread. It automatically partitions updates across
+/// mailboxes based on the hash of the key.
+/// At the start of each clock cycle, the
+/// circuit consumed updates buffered in each mailbox, leaving
+/// the mailbox empty.
+pub struct CollectionHandle<K, V> {
+    buffers: Vec<Vec<(K, V)>>,
+    input_handle: InputHandle<Vec<(K, V)>>,
+    hash_func: Arc<dyn HashFunc<K>>,
+}
+
+impl<K, V> Clone for CollectionHandle<K, V>
+where
+    K: Clone + Send + 'static,
+    V: Clone + Send + 'static,
+{
+    fn clone(&self) -> Self {
+        // Don't clone buffers.
+        Self::with_hasher(self.input_handle.clone(), self.hash_func.clone())
+    }
+}
+
+impl<K, V> CollectionHandle<K, V>
+where
+    K: Clone + Send + 'static,
+    V: Clone + Send + 'static,
+{
+    fn new(input_handle: InputHandle<Vec<(K, V)>>) -> Self
+    where
+        K: Hash,
+    {
+        Self::with_hasher(
+            input_handle,
+            Arc::new(|k: &K| hash32(k)) as Arc<dyn HashFunc<K>>,
+        )
+    }
+
+    fn with_hasher(
+        input_handle: InputHandle<Vec<(K, V)>>,
+        hash_func: Arc<dyn HashFunc<K>>,
+    ) -> Self {
+        Self {
+            buffers: vec![Vec::new(); input_handle.0.mailbox.len()],
+            input_handle,
+            hash_func,
+        }
+    }
+
+    #[inline]
+    fn num_partitions(&self) -> usize {
+        self.buffers.len()
+    }
+
+    /// Push a single `(key,value)` pair to the input stream.
+    pub fn push(&self, k: K, v: V) {
+        let num_partitions = self.num_partitions();
+
+        if num_partitions > 1 {
+            self.input_handle.update_for_worker(
+                (((self.hash_func)(&k) as usize) % num_partitions) as usize,
+                |tuples| tuples.push((k, v)),
+            );
+        } else {
+            self.input_handle
+                .update_for_worker(0, |tuples| tuples.push((k, v)));
+        }
+    }
+
+    /// Push multiple `(key,value)` pairs to the input stream.
+    ///
+    /// This is more efficient than pushing values one-by-one using
+    /// [`Self::push`].
+    ///
+    /// # Concurrency
+    ///
+    /// This method partitions updates across workers and then buffers them
+    /// atomically with respect to each worker, i.e., each worker observes
+    /// all updates in an `append` at the same logical time.  However the
+    /// operation is not atomic as a whole: concurrent `append` and
+    /// `clear_input` calls (performed via clones of the
+    /// same `CollectionHandle`) may apply in different orders in different
+    /// worker threads.  This method is also not atomic with respect to
+    /// [`DBSPHandle::step`](`crate::DBSPHandle::step`) and
+    /// [`CircuitHandle::step`](`crate::CircuitHandle::step`)) methods: a
+    /// `DBSPHandle::step` call performed concurrently with `append` may
+    /// result in only a subset of the workers observing updates from this
+    /// `append` operation.  The remaining updates will appear
+    /// during subsequent logical clock cycles.
+    pub fn append(&mut self, vals: &mut Vec<(K, V)>) {
+        let num_partitions = self.num_partitions();
+
+        if num_partitions > 1 {
+            for (k, v) in vals.drain(..) {
+                self.buffers[((self.hash_func)(&k) as usize) % num_partitions].push((k, v));
+            }
+            for worker in 0..num_partitions {
+                self.input_handle.update_for_worker(worker, |tuples| {
+                    if tuples.is_empty() {
+                        *tuples = take(&mut self.buffers[worker]);
+                    } else {
+                        tuples.append(&mut self.buffers[worker]);
+                    }
+                })
+            }
+        } else {
+            self.input_handle.update_for_worker(0, |tuples| {
+                if tuples.is_empty() {
+                    *tuples = take(vals);
+                } else {
+                    tuples.append(vals);
+                }
+            });
+        }
+    }
+
+    /// Clear all inputs buffered since the start of the last clock cycle.
+    ///
+    /// # Concurrency
+    ///
+    /// Similar to [`Self::append`], this method atomically clears updates
+    /// buffered for each worker thread, i.e., the worker observes all or none
+    /// of the updates buffered before the call to `clear_input`; however the
+    /// operation is not atomic as a whole: concurrent `append` and
+    /// `clear_input` calls (performed via clones of the
+    /// same `CollectionHandle`) may apply in different orders in different
+    /// worker threads.  This method is also not atomic with respect to
+    /// [`DBSPHandle::step`](`crate::DBSPHandle::step`) and
+    /// [`CircuitHandle::step`](`crate::CircuitHandle::step`)) methods: a
+    /// `DBSPHandle::step` call performed concurrently with `clear_input` may
+    /// result in only a subset of the workers observing empty inputs, while
+    /// other workers observe updates buffered prior to the `clear_input` call.
+    pub fn clear_input(&self) {
+        self.input_handle.set_for_all(Vec::new());
+    }
+}
+
+/// Source operator that injects data received via `InputHandle` to the circuit.
+///
+/// ```text
+///                   ┌───────────────────┐
+///                   │Circuit            │
+///                   │                   │
+/// ┌───────────┐     │    ┌─────┐        │
+/// │InputHandle├─────────►│Input├─────►  │
+/// └───────────┘     │    └─────┘        │
+///                   │                   │
+///                   └───────────────────┘
+/// ```
+struct Input<IT, OT, F> {
+    mailbox: Mailbox<IT>,
+    input_func: F,
+    phantom: PhantomData<OT>,
+}
+
+impl<IT, OT, F> Input<IT, OT, F>
+where
+    IT: Default + Clone + Send + 'static,
+{
+    fn new(input_func: F) -> (Self, InputHandle<IT>) {
+        let handle = InputHandle::new();
+        let mailbox = handle.mailbox(Runtime::worker_index()).clone();
+
+        let input = Self {
+            mailbox,
+            input_func,
+            phantom: PhantomData,
+        };
+
+        (input, handle)
+    }
+}
+
+impl<IT, OT, F> Operator for Input<IT, OT, F>
+where
+    IT: 'static,
+    OT: 'static,
+    F: 'static,
+{
+    fn name(&self) -> Cow<'static, str> {
+        Cow::from("Input")
+    }
+
+    fn fixedpoint(&self, _scope: Scope) -> bool {
+        false
+    }
+}
+
+impl<IT, OT, F> SourceOperator<OT> for Input<IT, OT, F>
+where
+    IT: Default + 'static,
+    OT: 'static,
+    F: Fn(IT) -> OT + 'static,
+{
+    fn eval(&mut self) -> OT {
+        let v = self.mailbox.take();
+        (self.input_func)(v)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        indexed_zset,
+        trace::{cursor::Cursor, BatchReader},
+        zset, Circuit, CollectionHandle, InputHandle, OrdIndexedZSet, OrdZSet, Runtime,
+    };
+    use std::iter::once;
+
+    fn input_batches() -> Vec<OrdZSet<usize, isize>> {
+        vec![
+            zset! { 1 => 1, 2 => 1, 3 => 1 },
+            zset! { 5 => -1, 10 => 2, 11 => 11 },
+            zset! {},
+        ]
+    }
+
+    fn input_vecs() -> Vec<Vec<(usize, isize)>> {
+        input_batches()
+            .into_iter()
+            .map(|batch| {
+                let mut cursor = batch.cursor();
+                let mut result = Vec::new();
+
+                while cursor.key_valid() {
+                    result.push((*cursor.key(), cursor.weight()));
+                    cursor.step_key();
+                }
+                result
+            })
+            .collect()
+    }
+
+    fn input_test_circuit(
+        circuit: &Circuit<()>,
+        nworkers: usize,
+    ) -> InputHandle<OrdZSet<usize, isize>> {
+        let (stream, handle) = circuit.add_input_stream::<OrdZSet<usize, isize>>();
+
+        let mut expected_batches = input_batches()
+            .into_iter()
+            .chain(input_batches().into_iter())
+            .chain(input_batches().into_iter().map(move |batch| {
+                let mut result = batch.clone();
+                for _ in 1..nworkers {
+                    result += batch.clone();
+                }
+                result
+            }));
+        stream.gather(0).inspect(move |batch| {
+            if Runtime::worker_index() == 0 {
+                assert_eq!(batch, &expected_batches.next().unwrap())
+            }
+        });
+
+        handle
+    }
+
+    #[test]
+    fn input_test_st() {
+        let (circuit, input_handle) =
+            Circuit::build(move |circuit| input_test_circuit(circuit, 1)).unwrap();
+
+        for batch in input_batches().into_iter() {
+            input_handle.set_for_worker(0, batch);
+            circuit.step().unwrap();
+        }
+
+        for batch in input_batches().into_iter() {
+            input_handle.update_for_worker(0, |b| *b = batch);
+            circuit.step().unwrap();
+        }
+
+        for batch in input_batches().into_iter() {
+            input_handle.set_for_all(batch);
+            circuit.step().unwrap();
+        }
+    }
+
+    fn input_test_mt(workers: usize) {
+        let (mut dbsp, input_handle) =
+            Runtime::init_circuit(workers, move |circuit| input_test_circuit(circuit, workers))
+                .unwrap();
+
+        for (round, batch) in input_batches().into_iter().enumerate() {
+            input_handle.set_for_worker(round % workers, batch);
+            dbsp.step().unwrap();
+        }
+
+        for (round, batch) in input_batches().into_iter().enumerate() {
+            input_handle.update_for_worker(round % workers, |b| *b = batch);
+            dbsp.step().unwrap();
+        }
+
+        for batch in input_batches().into_iter() {
+            input_handle.set_for_all(batch);
+            dbsp.step().unwrap();
+        }
+
+        dbsp.kill().unwrap();
+    }
+
+    #[test]
+    fn input_test_mt1() {
+        input_test_mt(1);
+    }
+
+    #[test]
+    fn input_test_mt4() {
+        input_test_mt(4);
+    }
+
+    fn zset_test_circuit(circuit: &Circuit<()>) -> CollectionHandle<usize, isize> {
+        let (stream, handle) = circuit.add_input_zset::<usize, isize>();
+
+        let mut expected_batches = input_batches()
+            .into_iter()
+            .chain(input_batches().into_iter())
+            .chain(once(zset! {}));
+        stream.gather(0).inspect(move |batch| {
+            if Runtime::worker_index() == 0 {
+                assert_eq!(batch, &expected_batches.next().unwrap())
+            }
+        });
+
+        handle
+    }
+
+    #[test]
+    fn zset_test_st() {
+        let (circuit, mut input_handle) =
+            Circuit::build(move |circuit| zset_test_circuit(circuit)).unwrap();
+
+        for mut vec in input_vecs().into_iter() {
+            input_handle.append(&mut vec);
+            circuit.step().unwrap();
+        }
+
+        for vec in input_vecs().into_iter() {
+            for (k, w) in vec.into_iter() {
+                input_handle.push(k, w);
+            }
+            input_handle.push(5, 1);
+            input_handle.push(5, -1);
+            circuit.step().unwrap();
+        }
+
+        for mut vec in input_vecs().into_iter() {
+            input_handle.append(&mut vec);
+        }
+        input_handle.clear_input();
+        circuit.step().unwrap();
+    }
+
+    fn zset_test_mt(workers: usize) {
+        let (mut dbsp, mut input_handle) =
+            Runtime::init_circuit(workers, |circuit| zset_test_circuit(circuit)).unwrap();
+
+        for mut vec in input_vecs().into_iter() {
+            input_handle.append(&mut vec);
+            dbsp.step().unwrap();
+        }
+
+        for vec in input_vecs().into_iter() {
+            for (k, w) in vec.into_iter() {
+                input_handle.push(k, w);
+            }
+            input_handle.push(5, 1);
+            input_handle.push(5, -1);
+            dbsp.step().unwrap();
+        }
+
+        for mut vec in input_vecs().into_iter() {
+            input_handle.append(&mut vec);
+        }
+        input_handle.clear_input();
+        dbsp.step().unwrap();
+
+        dbsp.kill().unwrap();
+    }
+
+    #[test]
+    fn zset_test_mt1() {
+        zset_test_mt(1);
+    }
+
+    #[test]
+    fn zset_test_mt4() {
+        zset_test_mt(4);
+    }
+
+    fn input_indexed_batches() -> Vec<OrdIndexedZSet<usize, usize, isize>> {
+        vec![
+            indexed_zset! { 1 => {1 => 1, 2 => 1}, 2 => { 3 => 1 }, 3 => {4 => -1, 5 => 5} },
+            indexed_zset! { 5 => {10 => -1}, 10 => {2 => 1, 3 => -1}, 11 => {11 => 11} },
+            indexed_zset! {},
+        ]
+    }
+
+    fn input_indexed_vecs() -> Vec<Vec<(usize, (usize, isize))>> {
+        input_indexed_batches()
+            .into_iter()
+            .map(|batch| {
+                let mut cursor = batch.cursor();
+                let mut result = Vec::new();
+
+                while cursor.key_valid() {
+                    while cursor.val_valid() {
+                        result.push((*cursor.key(), (*cursor.val(), cursor.weight())));
+                        cursor.step_val();
+                    }
+                    cursor.step_key();
+                }
+                result
+            })
+            .collect()
+    }
+
+    fn indexed_zset_test_circuit(circuit: &Circuit<()>) -> CollectionHandle<usize, (usize, isize)> {
+        let (stream, handle) = circuit.add_input_indexed_zset::<usize, usize, isize>();
+
+        let mut expected_batches = input_indexed_batches()
+            .into_iter()
+            .chain(input_indexed_batches().into_iter());
+        stream.gather(0).inspect(move |batch| {
+            if Runtime::worker_index() == 0 {
+                assert_eq!(batch, &expected_batches.next().unwrap())
+            }
+        });
+
+        handle
+    }
+
+    #[test]
+    fn indexed_zset_test_st() {
+        let (circuit, mut input_handle) =
+            Circuit::build(move |circuit| indexed_zset_test_circuit(circuit)).unwrap();
+
+        for mut vec in input_indexed_vecs().into_iter() {
+            input_handle.append(&mut vec);
+            circuit.step().unwrap();
+        }
+
+        for vec in input_indexed_vecs().into_iter() {
+            for (k, v) in vec.into_iter() {
+                input_handle.push(k, v);
+            }
+            input_handle.push(5, (7, 1));
+            input_handle.push(5, (7, -1));
+            circuit.step().unwrap();
+        }
+    }
+
+    fn indexed_zset_test_mt(workers: usize) {
+        let (mut dbsp, mut input_handle) =
+            Runtime::init_circuit(workers, |circuit| indexed_zset_test_circuit(circuit)).unwrap();
+
+        for mut vec in input_indexed_vecs().into_iter() {
+            input_handle.append(&mut vec);
+            dbsp.step().unwrap();
+        }
+
+        for vec in input_indexed_vecs().into_iter() {
+            for (k, v) in vec.into_iter() {
+                input_handle.push(k, v);
+            }
+            dbsp.step().unwrap();
+        }
+
+        dbsp.kill().unwrap();
+    }
+
+    #[test]
+    fn indexed_zset_test_mt1() {
+        indexed_zset_test_mt(1);
+    }
+
+    #[test]
+    fn indexed_zset_test_mt4() {
+        indexed_zset_test_mt(4);
+    }
+
+    fn input_set_updates() -> Vec<Vec<(usize, bool)>> {
+        vec![
+            vec![(1, true), (2, true), (3, false)],
+            vec![(1, false), (2, true), (3, true), (4, true)],
+            vec![(2, false), (2, true), (3, true), (4, false)],
+            vec![(2, true), (2, false)],
+        ]
+    }
+
+    fn output_set_updates() -> Vec<OrdZSet<usize, isize>> {
+        vec![
+            zset! { 1 => 1,  2 => 1},
+            zset! { 1 => -1, 3 => 1,  4 => 1 },
+            zset! { 4 => -1 },
+            zset! { 2 => -1 },
+        ]
+    }
+
+    fn set_test_circuit(circuit: &Circuit<()>) -> CollectionHandle<usize, bool> {
+        let (stream, handle) = circuit.add_input_set::<usize, isize>();
+
+        let mut expected_batches = output_set_updates().into_iter();
+
+        stream.gather(0).inspect(move |batch| {
+            if Runtime::worker_index() == 0 {
+                assert_eq!(batch, &expected_batches.next().unwrap())
+            }
+        });
+
+        handle
+    }
+
+    #[test]
+    fn set_test_st() {
+        let (circuit, mut input_handle) =
+            Circuit::build(move |circuit| set_test_circuit(circuit)).unwrap();
+
+        for mut vec in input_set_updates().into_iter() {
+            input_handle.append(&mut vec);
+            circuit.step().unwrap();
+        }
+
+        let (circuit, input_handle) =
+            Circuit::build(move |circuit| set_test_circuit(circuit)).unwrap();
+
+        for vec in input_set_updates().into_iter() {
+            for (k, b) in vec.into_iter() {
+                input_handle.push(k, b);
+            }
+            circuit.step().unwrap();
+        }
+    }
+
+    fn set_test_mt(workers: usize) {
+        let (mut dbsp, mut input_handle) =
+            Runtime::init_circuit(workers, |circuit| set_test_circuit(circuit)).unwrap();
+
+        for mut vec in input_set_updates().into_iter() {
+            input_handle.append(&mut vec);
+            dbsp.step().unwrap();
+        }
+
+        dbsp.kill().unwrap();
+
+        let (mut dbsp, input_handle) =
+            Runtime::init_circuit(workers, |circuit| set_test_circuit(circuit)).unwrap();
+
+        for vec in input_set_updates().into_iter() {
+            for (k, b) in vec.into_iter() {
+                input_handle.push(k, b);
+            }
+            dbsp.step().unwrap();
+        }
+
+        dbsp.kill().unwrap();
+    }
+
+    #[test]
+    fn set_test_mt1() {
+        set_test_mt(1);
+    }
+
+    #[test]
+    fn set_test_mt4() {
+        set_test_mt(4);
+    }
+
+    fn input_map_updates() -> Vec<Vec<(usize, Option<usize>)>> {
+        vec![
+            vec![(1, Some(1)), (1, Some(2)), (2, None), (3, Some(3))],
+            vec![
+                (1, Some(1)),
+                (1, None),
+                (2, Some(2)),
+                (3, Some(4)),
+                (4, Some(4)),
+                (4, None),
+                (4, Some(5)),
+            ],
+            vec![(1, Some(5)), (1, Some(6)), (3, None), (4, Some(6))],
+        ]
+    }
+
+    fn output_map_updates() -> Vec<OrdIndexedZSet<usize, usize, isize>> {
+        vec![
+            indexed_zset! { 1 => {2 => 1},  3 => {3 => 1}},
+            indexed_zset! { 1 => {2 => -1}, 2 => {2 => 1}, 3 => {3 => -1, 4 => 1}, 4 => {5 => 1}},
+            indexed_zset! { 1 => {6 => 1},  3 => {4 => -1}, 4 => {5 => -1, 6 => 1}},
+        ]
+    }
+
+    fn map_test_circuit(circuit: &Circuit<()>) -> CollectionHandle<usize, Option<usize>> {
+        let (stream, handle) = circuit.add_input_map::<usize, usize, isize>();
+
+        let mut expected_batches = output_map_updates().into_iter();
+
+        stream.gather(0).inspect(move |batch| {
+            if Runtime::worker_index() == 0 {
+                assert_eq!(batch, &expected_batches.next().unwrap())
+            }
+        });
+
+        handle
+    }
+
+    #[test]
+    fn map_test_st() {
+        let (circuit, mut input_handle) =
+            Circuit::build(move |circuit| map_test_circuit(circuit)).unwrap();
+
+        for mut vec in input_map_updates().into_iter() {
+            input_handle.append(&mut vec);
+            circuit.step().unwrap();
+        }
+
+        let (circuit, input_handle) =
+            Circuit::build(move |circuit| map_test_circuit(circuit)).unwrap();
+
+        for vec in input_map_updates().into_iter() {
+            for (k, v) in vec.into_iter() {
+                input_handle.push(k, v);
+            }
+            circuit.step().unwrap();
+        }
+    }
+
+    fn map_test_mt(workers: usize) {
+        let (mut dbsp, mut input_handle) =
+            Runtime::init_circuit(workers, |circuit| map_test_circuit(circuit)).unwrap();
+
+        for mut vec in input_map_updates().into_iter() {
+            input_handle.append(&mut vec);
+            dbsp.step().unwrap();
+        }
+
+        dbsp.kill().unwrap();
+
+        let (mut dbsp, input_handle) =
+            Runtime::init_circuit(workers, |circuit| map_test_circuit(circuit)).unwrap();
+
+        for vec in input_map_updates().into_iter() {
+            for (k, v) in vec.into_iter() {
+                input_handle.push(k, v);
+            }
+            dbsp.step().unwrap();
+        }
+
+        dbsp.kill().unwrap();
+    }
+
+    #[test]
+    fn map_test_mt1() {
+        map_test_mt(1);
+    }
+
+    #[test]
+    fn map_test_mt4() {
+        map_test_mt(4);
+    }
+}

--- a/src/operator/inspect.rs
+++ b/src/operator/inspect.rs
@@ -18,10 +18,10 @@ where
     ///
     /// ```
     /// # use dbsp::{
-    /// #     circuit::Root,
     /// #     operator::Generator,
+    /// #     Circuit,
     /// # };
-    /// let root = Root::build(move |circuit| {
+    /// let circuit = Circuit::build(move |circuit| {
     ///     let mut n = 1;
     ///     let stream = circuit.add_source(Generator::new(move || {
     ///         let res = n;

--- a/src/operator/integrate.rs
+++ b/src/operator/integrate.rs
@@ -50,7 +50,8 @@ where
     /// #   let mut counter2 = 0;
     /// #   integral.delay().inspect(move |n| { assert_eq!(*n, counter2); counter2 += 1; });
     /// })
-    /// .unwrap();
+    /// .unwrap()
+    /// .0;
     ///
     /// # for _ in 0..5 {
     /// #     circuit.step().unwrap();
@@ -171,7 +172,8 @@ mod test {
                 assert_eq!(*n, counter);
             });
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         for _ in 0..100 {
             circuit.step().unwrap();
@@ -210,7 +212,8 @@ mod test {
                 counter3 += 1;
             });
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         for _ in 0..100 {
             circuit.step().unwrap();
@@ -265,7 +268,8 @@ mod test {
                 .unwrap();
             integral.inspect(move |n| assert_eq!(*n, expected_outer_integrals.next().unwrap()));
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         for _ in 0..4 {
             circuit.step().unwrap();

--- a/src/operator/integrate.rs
+++ b/src/operator/integrate.rs
@@ -37,10 +37,10 @@ where
     ///
     /// ```
     /// # use dbsp::{
-    /// #     circuit::Root,
     /// #     operator::Generator,
+    /// #     Circuit,
     /// # };
-    /// let root = Root::build(move |circuit| {
+    /// let circuit = Circuit::build(move |circuit| {
     ///     // Generate a stream of 1's.
     ///     let stream = circuit.add_source(Generator::new(|| 1));
     ///     // Integrate the stream.
@@ -53,7 +53,7 @@ where
     /// .unwrap();
     ///
     /// # for _ in 0..5 {
-    /// #     root.step().unwrap();
+    /// #     circuit.step().unwrap();
     /// # }
     /// ```
     ///
@@ -155,16 +155,15 @@ where
 mod test {
     use crate::{
         algebra::HasZero,
-        circuit::Root,
         monitor::TraceMonitor,
         operator::{DelayedFeedback, Generator},
         trace::{ord::OrdZSet, Batch},
-        zset,
+        zset, Circuit,
     };
 
     #[test]
     fn scalar_integrate() {
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             let source = circuit.add_source(Generator::new(|| 1));
             let mut counter = 0;
             source.integrate().inspect(move |n| {
@@ -175,13 +174,13 @@ mod test {
         .unwrap();
 
         for _ in 0..100 {
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
     }
 
     #[test]
     fn zset_integrate() {
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             let mut counter1 = 0;
             let mut s = <OrdZSet<usize, isize>>::zero();
             let source = circuit.add_source(Generator::new(move || {
@@ -214,7 +213,7 @@ mod test {
         .unwrap();
 
         for _ in 0..100 {
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
     }
 
@@ -236,7 +235,7 @@ mod test {
     /// ```
     #[test]
     fn scalar_integrate_nested() {
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             TraceMonitor::new_panic_on_error().attach(circuit, "monitor");
 
             let mut input = vec![3, 4, 2, 5].into_iter();
@@ -269,7 +268,7 @@ mod test {
         .unwrap();
 
         for _ in 0..4 {
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
     }
 }

--- a/src/operator/integrate.rs
+++ b/src/operator/integrate.rs
@@ -195,18 +195,18 @@ mod test {
             integral.inspect(move |s| {
                 let mut batch = Vec::with_capacity(counter2);
                 for i in 0..counter2 {
-                    batch.push(((i, ()), (counter2 - i) as isize));
+                    batch.push((i, (counter2 - i) as isize));
                 }
-                assert_eq!(s, &<OrdZSet<_, _>>::from_tuples((), batch));
+                assert_eq!(s, &<OrdZSet<_, _>>::from_keys((), batch));
                 counter2 += 1;
             });
             let mut counter3 = 0;
             integral.delay().inspect(move |s| {
                 let mut batch = Vec::with_capacity(counter2);
                 for i in 1..counter3 {
-                    batch.push((((i - 1), ()), (counter3 - i) as isize));
+                    batch.push(((i - 1), (counter3 - i) as isize));
                 }
-                assert_eq!(s, &<OrdZSet<_, _>>::from_tuples((), batch));
+                assert_eq!(s, &<OrdZSet<_, _>>::from_keys((), batch));
                 counter3 += 1;
             });
         })

--- a/src/operator/join.rs
+++ b/src/operator/join.rs
@@ -740,7 +740,8 @@ mod test {
                     }
                 });
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         for _ in 0..5 {
             circuit.step().unwrap();
@@ -835,7 +836,7 @@ mod test {
                 assert_eq!(*ps, outputs.next().unwrap());
             });
         })
-        .unwrap();
+        .unwrap().0;
 
         for _ in 0..8 {
             //eprintln!("{}", i);
@@ -948,7 +949,7 @@ mod test {
                 assert_eq!(*labeled, outputs.next().unwrap());
             });
         })
-        .unwrap();
+        .unwrap().0;
 
         for _ in 0..8 {
             //eprintln!("{}", i);
@@ -1034,7 +1035,7 @@ mod test {
                 assert_eq!(*res, outputs.next().unwrap());
             });
         })
-        .unwrap();
+        .unwrap().0;
 
         for _ in 0..8 {
             //eprintln!("{}", i);

--- a/src/operator/join.rs
+++ b/src/operator/join.rs
@@ -599,14 +599,13 @@ where
 #[cfg(test)]
 mod test {
     use crate::{
-        circuit::{Circuit, Root, Runtime, Stream},
         operator::{DelayedFeedback, FilterMap, Generator},
         time::{NestedTimestamp32, Product, Timestamp},
         trace::{
             ord::{OrdIndexedZSet, OrdZSet},
             Batch,
         },
-        zset,
+        zset, Circuit, Runtime, Stream,
     };
     use deepsize::DeepSizeOf;
     use std::{
@@ -616,7 +615,7 @@ mod test {
 
     #[test]
     fn join_test() {
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             let mut input1 = vec![
                 zset! {
                     (1, "a") => 1,
@@ -742,7 +741,7 @@ mod test {
         .unwrap();
 
         for _ in 0..5 {
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
     }
 
@@ -766,7 +765,7 @@ mod test {
     // transitive closure of the edge relation.
     #[test]
     fn join_trace_test() {
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             // Changes to the edges relation.
             let mut edges: vec::IntoIter<OrdZSet<(usize, usize), isize>> = vec![
                 zset! { (1, 2) => 1 },
@@ -838,7 +837,7 @@ mod test {
 
         for _ in 0..8 {
             //eprintln!("{}", i);
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
     }
 
@@ -898,7 +897,7 @@ mod test {
 
     #[test]
     fn propagate_test() {
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             let mut edges: vec::IntoIter<OrdZSet<Edge, isize>> = vec![
                 zset! { Edge(1, 2) => 1, Edge(1, 3) => 1, Edge(2, 4) => 1, Edge(3, 4) => 1 },
                 zset! { Edge(5, 7) => 1, Edge(6, 7) => 1 },
@@ -951,13 +950,13 @@ mod test {
 
         for _ in 0..8 {
             //eprintln!("{}", i);
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
     }
 
     #[test]
     fn propagate_nested_test() {
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             let mut edges: vec::IntoIter<OrdZSet<Edge, isize>> = vec![
                 zset! { Edge(1, 2) => 1, Edge(1, 3) => 1, Edge(2, 4) => 1, Edge(3, 4) => 1 },
                 zset! { Edge(5, 7) => 1, Edge(6, 7) => 1 },
@@ -1037,7 +1036,7 @@ mod test {
 
         for _ in 0..8 {
             //eprintln!("{}", i);
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
     }
 }

--- a/src/operator/join.rs
+++ b/src/operator/join.rs
@@ -178,6 +178,7 @@ where
         Z::Batcher: DeepSizeOf,
         Z::Key: Clone + Default,
         Z::R: MulByRef + Default,
+        Z::Item: Default,
         F: Fn(&I1::Key, &I1::Val, &I2::Val) -> Z::Key + Clone + 'static,
     {
         // TODO: I think this is correct, but we need a proper proof.
@@ -304,7 +305,7 @@ where
                             let v2 = cursor2.val();
 
                             batch.push((
-                                ((self.join_func)(cursor1.key(), v1, v2), ()),
+                                (self.join_func)(cursor1.key(), v1, v2),
                                 w1.mul_by_ref(&w2),
                             ));
                             cursor2.step_val();
@@ -320,7 +321,7 @@ where
             }
         }
 
-        Z::from_tuples((), batch)
+        Z::from_keys((), batch)
     }
 }
 
@@ -383,7 +384,7 @@ where
                             let v2 = cursor2.val();
 
                             batch.push((
-                                ((self.join_func)(cursor1.key(), v1, v2), ()),
+                                Z::item_from((self.join_func)(cursor1.key(), v1, v2), ()),
                                 w1.mul_by_ref(&w2),
                             ));
                             cursor2.step_val();
@@ -507,6 +508,7 @@ where
     Z::Key: Clone + Default,
     Z::Batcher: DeepSizeOf,
     Z::R: MulByRef + Default,
+    Z::Item: Default,
 {
     fn eval(&mut self, index: &I, trace: &T) -> Z {
         /*println!("JoinTrace::eval@{}:\n  index:\n{}\n  trace:\n{}",
@@ -547,7 +549,7 @@ where
                             trace_cursor.map_times(|ts, w2| {
                                 output_tuples.push((
                                     ts.join(&self.time),
-                                    ((output.clone(), ()), w1.mul_by_ref(w2)),
+                                    (Z::item_from(output.clone(), ()), w1.mul_by_ref(w2)),
                                 ));
                                 //println!("  tuple@{}: ({:?}, {})", off,
                                 // output, w1.clone() * w2.clone());

--- a/src/operator/join_range.rs
+++ b/src/operator/join_range.rs
@@ -185,7 +185,7 @@ where
 
                         // Add all `(k,v)` tuples output by `join_func` to the output batch.
                         for (k, v) in (self.join_func)(k1, v1, i2_cursor.key(), i2_cursor.val()) {
-                            tuples.push(((k, v), w.clone()));
+                            tuples.push((O::item_from(k, v), w.clone()));
                         }
                         i2_cursor.step_val();
                     }
@@ -295,7 +295,7 @@ mod test {
                 .apply2(&output2, |o1, o2| assert_eq!(o1, o2));
         })
         .unwrap();
-
+        
         for _ in 0..5 {
             circuit.step().unwrap();
         }

--- a/src/operator/join_range.rs
+++ b/src/operator/join_range.rs
@@ -294,8 +294,9 @@ mod test {
                 .index()
                 .apply2(&output2, |o1, o2| assert_eq!(o1, o2));
         })
-        .unwrap();
-        
+        .unwrap()
+        .0;
+
         for _ in 0..5 {
             circuit.step().unwrap();
         }

--- a/src/operator/join_range.rs
+++ b/src/operator/join_range.rs
@@ -202,11 +202,11 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::{circuit::Root, operator::Generator, zset};
+    use crate::{operator::Generator, zset, Circuit};
 
     #[test]
     fn stream_join_range_test() {
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             let mut input1 = vec![
                 zset! {
                     (1, "a") => 1,
@@ -297,7 +297,7 @@ mod test {
         .unwrap();
 
         for _ in 0..5 {
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
     }
 }

--- a/src/operator/mod.rs
+++ b/src/operator/mod.rs
@@ -6,7 +6,9 @@ pub mod communication;
 pub mod recursive;
 
 pub(crate) mod apply;
+mod input;
 pub(crate) mod inspect;
+pub(crate) mod upsert;
 
 mod aggregate;
 mod condition;
@@ -41,6 +43,7 @@ pub use distinct::Distinct;
 pub use filter_map::{FilterKeys, FilterMap, FilterVals, FlatMap, Map, MapKeys};
 pub use generator::{Generator, GeneratorNested};
 pub use index::Index;
+pub use input::{CollectionHandle, InputHandle};
 pub use inspect::Inspect;
 pub use join::Join;
 pub use join_range::StreamJoinRange;

--- a/src/operator/neg.rs
+++ b/src/operator/neg.rs
@@ -68,10 +68,9 @@ where
 mod test {
     use crate::{
         algebra::HasZero,
-        circuit::{Circuit, Root},
         operator::Generator,
         trace::{ord::OrdZSet, Batch},
-        zset,
+        zset, Circuit,
     };
 
     #[test]
@@ -90,13 +89,13 @@ mod test {
             source
         };
 
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             build_circuit(circuit);
         })
         .unwrap();
 
         for _ in 0..100 {
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
     }
 }

--- a/src/operator/neg.rs
+++ b/src/operator/neg.rs
@@ -92,7 +92,8 @@ mod test {
         let circuit = Circuit::build(move |circuit| {
             build_circuit(circuit);
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         for _ in 0..100 {
             circuit.step().unwrap();

--- a/src/operator/plus.rs
+++ b/src/operator/plus.rs
@@ -24,10 +24,10 @@ where
     ///
     /// ```
     /// # use dbsp::{
-    /// #   circuit::Root,
     /// #   operator::Generator,
+    /// #   Circuit,
     /// # };
-    /// let root = Root::build(move |circuit| {
+    /// let circuit = Circuit::build(move |circuit| {
     ///     // Stream of non-negative values: 0, 1, 2, ...
     ///     let mut n = 0;
     ///     let source1 = circuit.add_source(Generator::new(move || {
@@ -48,7 +48,7 @@ where
     /// .unwrap();
     ///
     /// # for _ in 0..5 {
-    /// #     root.step().unwrap();
+    /// #     circuit.step().unwrap();
     /// # }
     /// ```
     pub fn plus(&self, other: &Stream<Circuit<P>, D>) -> Stream<Circuit<P>, D> {
@@ -188,15 +188,15 @@ where
 mod test {
     use crate::{
         algebra::HasZero,
-        circuit::{Circuit, OwnershipPreference, Root},
+        circuit::OwnershipPreference,
         operator::{Generator, Inspect},
         trace::{ord::OrdZSet, Batch},
-        zset,
+        zset, Circuit,
     };
 
     #[test]
     fn scalar_plus() {
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             let mut n = 0;
             let source1 = circuit.add_source(Generator::new(move || {
                 let res = n;
@@ -214,7 +214,7 @@ mod test {
         .unwrap();
 
         for _ in 0..100 {
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
     }
 
@@ -259,18 +259,18 @@ mod test {
             (source1, source2)
         };
         // Allow `Plus` to consume both streams by value.
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             build_plus_circuit(circuit);
             build_minus_circuit(circuit);
         })
         .unwrap();
 
         for _ in 0..100 {
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
 
         // Only consume source2 by value.
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             let (source1, _source2) = build_plus_circuit(circuit);
             circuit.add_unary_operator_with_preference(
                 Inspect::new(|_| {}),
@@ -287,11 +287,11 @@ mod test {
         .unwrap();
 
         for _ in 0..100 {
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
 
         // Only consume source1 by value.
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             let (_source1, source2) = build_plus_circuit(circuit);
             circuit.add_unary_operator_with_preference(
                 Inspect::new(|_| {}),
@@ -309,11 +309,11 @@ mod test {
         .unwrap();
 
         for _ in 0..100 {
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
 
         // Consume both streams by reference.
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             let (source1, source2) = build_plus_circuit(circuit);
             circuit.add_unary_operator_with_preference(
                 Inspect::new(|_| {}),
@@ -341,7 +341,7 @@ mod test {
         .unwrap();
 
         for _ in 0..100 {
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
     }
 }

--- a/src/operator/plus.rs
+++ b/src/operator/plus.rs
@@ -45,7 +45,8 @@ where
     ///     // Compute pairwise sums of values in the stream; the output stream will contain zeros.
     ///     source1.plus(&source2).inspect(|n| assert_eq!(*n, 0));
     /// })
-    /// .unwrap();
+    /// .unwrap()
+    /// .0;
     ///
     /// # for _ in 0..5 {
     /// #     circuit.step().unwrap();
@@ -211,7 +212,8 @@ mod test {
             }));
             source1.plus(&source2).inspect(|n| assert_eq!(*n, 100));
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         for _ in 0..100 {
             circuit.step().unwrap();
@@ -263,7 +265,8 @@ mod test {
             build_plus_circuit(circuit);
             build_minus_circuit(circuit);
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         for _ in 0..100 {
             circuit.step().unwrap();
@@ -284,7 +287,8 @@ mod test {
                 OwnershipPreference::STRONGLY_PREFER_OWNED,
             );
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         for _ in 0..100 {
             circuit.step().unwrap();
@@ -306,7 +310,8 @@ mod test {
                 OwnershipPreference::STRONGLY_PREFER_OWNED,
             );
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         for _ in 0..100 {
             circuit.step().unwrap();
@@ -338,7 +343,8 @@ mod test {
                 OwnershipPreference::STRONGLY_PREFER_OWNED,
             );
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         for _ in 0..100 {
             circuit.step().unwrap();

--- a/src/operator/recursive.rs
+++ b/src/operator/recursive.rs
@@ -175,16 +175,15 @@ impl<P: Clone + 'static> Circuit<P> {
     ///
     /// ```
     /// use dbsp::{
-    ///     circuit::{Root, Stream},
     ///     operator::Generator,
     ///     time::NestedTimestamp32,
     ///     trace::ord::OrdZSet,
-    ///     zset, zset_set,
+    ///     Circuit, Stream, zset, zset_set,
     /// };
     /// use std::vec;
     ///
     /// // Propagate labels along graph edges.
-    /// let root = Root::build(move |circuit| {
+    /// let root = Circuit::build(move |circuit| {
     ///     // Graph topology.
     ///     let mut edges = vec![
     ///         // Start with four nodes connected in a cycle.
@@ -291,17 +290,16 @@ impl<P: Clone + 'static> Circuit<P> {
 #[cfg(test)]
 mod test {
     use crate::{
-        circuit::{Root, Stream},
         operator::{FilterMap, Generator},
         time::NestedTimestamp32,
         trace::ord::OrdZSet,
-        zset,
+        zset, Circuit, Stream,
     };
     use std::vec;
 
     #[test]
     fn reachability() {
-        let root = Root::build(move |circuit| {
+        let root = Circuit::build(move |circuit| {
             // Changes to the edges relation.
             let mut edges = vec![
                 zset! { (1, 2) => 1 },
@@ -362,7 +360,7 @@ mod test {
     fn reachability2() {
         type Edges<S> = Stream<S, OrdZSet<(usize, usize), isize>>;
 
-        let root = Root::build(move |circuit| {
+        let root = Circuit::build(move |circuit| {
             // Changes to the edges relation.
             let mut edges = vec![
                 zset! { (1, 2) => 1 },

--- a/src/operator/recursive.rs
+++ b/src/operator/recursive.rs
@@ -240,7 +240,7 @@ impl<P: Clone + 'static> Circuit<P> {
     ///         assert_eq!(*ls, expected_outputs.next().unwrap());
     ///     });
     /// })
-    /// .unwrap();
+    /// .unwrap().0;
     ///
     /// for _ in 0..3 {
     ///     root.step().unwrap();
@@ -347,7 +347,7 @@ mod test {
                 assert_eq!(*ps, outputs.next().unwrap());
             });
         })
-        .unwrap();
+        .unwrap().0;
 
         for _ in 0..8 {
             root.step().unwrap();
@@ -419,7 +419,7 @@ mod test {
                 assert_eq!(*ps, outputs2.next().unwrap());
             });
         })
-        .unwrap();
+        .unwrap().0;
 
         for _ in 0..8 {
             root.step().unwrap();

--- a/src/operator/semijoin.rs
+++ b/src/operator/semijoin.rs
@@ -131,7 +131,10 @@ where
 
                         // Add to our output batch
                         builder.push((
-                            Out::item_from((pair_cursor.key().clone(), pair_cursor.val().clone()), ()),
+                            Out::item_from(
+                                (pair_cursor.key().clone(), pair_cursor.val().clone()),
+                                (),
+                            ),
                             kv_weight,
                         ));
                         pair_cursor.step_val();

--- a/src/operator/semijoin.rs
+++ b/src/operator/semijoin.rs
@@ -131,8 +131,7 @@ where
 
                         // Add to our output batch
                         builder.push((
-                            (pair_cursor.key().clone(), pair_cursor.val().clone()),
-                            (),
+                            Out::item_from((pair_cursor.key().clone(), pair_cursor.val().clone()), ()),
                             kv_weight,
                         ));
                         pair_cursor.step_val();

--- a/src/operator/sum.rs
+++ b/src/operator/sum.rs
@@ -168,7 +168,8 @@ mod test {
         let circuit = Circuit::build(move |circuit| {
             build_circuit(circuit);
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         for _ in 0..100 {
             circuit.step().unwrap();
@@ -183,7 +184,8 @@ mod test {
                 OwnershipPreference::STRONGLY_PREFER_OWNED,
             );
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         for _ in 0..100 {
             circuit.step().unwrap();
@@ -208,7 +210,8 @@ mod test {
                 OwnershipPreference::STRONGLY_PREFER_OWNED,
             );
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         for _ in 0..100 {
             circuit.step().unwrap();

--- a/src/operator/sum.rs
+++ b/src/operator/sum.rs
@@ -129,10 +129,10 @@ where
 mod test {
     use crate::{
         algebra::HasZero,
-        circuit::{Circuit, OwnershipPreference, Root},
+        circuit::OwnershipPreference,
         operator::{Generator, Inspect},
         trace::{ord::OrdZSet, Batch},
-        zset,
+        zset, Circuit,
     };
 
     #[test]
@@ -165,17 +165,17 @@ mod test {
         };
 
         // Allow `Sum` to consume all streams by value.
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             build_circuit(circuit);
         })
         .unwrap();
 
         for _ in 0..100 {
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
 
         // Only consume source2, source3 by value.
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             let (source1, _source2, _source3) = build_circuit(circuit);
             circuit.add_unary_operator_with_preference(
                 Inspect::new(|_| {}),
@@ -186,11 +186,11 @@ mod test {
         .unwrap();
 
         for _ in 0..100 {
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
 
         // Consume all streams by reference.
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             let (source1, source2, source3) = build_circuit(circuit);
             circuit.add_unary_operator_with_preference(
                 Inspect::new(|_| {}),
@@ -211,7 +211,7 @@ mod test {
         .unwrap();
 
         for _ in 0..100 {
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
     }
 }

--- a/src/operator/trace.rs
+++ b/src/operator/trace.rs
@@ -44,7 +44,7 @@ where
         while cursor.val_valid() {
             let val = cursor.val().clone();
             let w = cursor.weight();
-            builder.push((cursor.key().clone(), val, w.clone()));
+            builder.push((BO::item_from(cursor.key().clone(), val), w.clone()));
             cursor.step_val();
         }
         cursor.step_key();

--- a/src/operator/upsert.rs
+++ b/src/operator/upsert.rs
@@ -1,0 +1,140 @@
+use crate::{
+    algebra::{HasOne, HasZero},
+    circuit::{
+        operator_traits::{BinaryOperator, Operator},
+        OwnershipPreference, Scope,
+    },
+    trace::{cursor::Cursor, Batch, Trace},
+};
+use std::{borrow::Cow, marker::PhantomData, mem::swap, ops::Neg};
+
+pub struct Upsert<K, VI, F, V, T, B> {
+    val_func: F,
+    phantom: PhantomData<(K, VI, V, T, B)>,
+}
+
+impl<K, VI, F, V, T, B> Upsert<K, VI, F, V, T, B> {
+    pub fn new(val_func: F) -> Self {
+        Self {
+            val_func,
+            phantom: PhantomData,
+        }
+    }
+}
+
+/// Internal implementation of `Circuit::add_set` and `Circuit::add_map`.
+///
+/// Applies a vector of upsert commands to a trace (an upsert inserts a
+/// key/value pair, replacing existing value for the given key, or deletes
+/// a key/value pair if it exists).  Outputs a batch of changes to the
+/// trace.
+impl<K, VI, F, V, T, B> Operator for Upsert<K, VI, F, V, T, B>
+where
+    B: 'static,
+    T: 'static,
+    V: 'static,
+    F: 'static,
+    VI: 'static,
+    K: 'static,
+{
+    fn name(&self) -> Cow<'static, str> {
+        Cow::from("Upsert")
+    }
+
+    fn fixedpoint(&self, _scope: Scope) -> bool {
+        true
+    }
+}
+
+fn skip_zero_weights<'s, K, V, R, C>(cursor: &mut C) -> bool
+where
+    C: Cursor<'s, K, V, (), R>,
+    R: HasZero,
+{
+    while cursor.val_valid() && cursor.weight().is_zero() {
+        cursor.step_val();
+    }
+    cursor.val_valid()
+}
+
+impl<K, VI, F, V, T, B> BinaryOperator<T, Vec<(K, VI)>, B> for Upsert<K, VI, F, V, T, B>
+where
+    T: Trace<Key = K, Val = V, Batch = B, Time = (), R = B::R> + 'static,
+    B: Batch<Key = K, Val = V, Time = ()> + 'static,
+    F: Fn(VI) -> Option<V> + 'static,
+    K: Ord + Clone + 'static,
+    VI: Eq + 'static,
+    B::R: HasOne + Neg<Output = B::R> + 'static,
+    V: Eq + Clone + 'static,
+{
+    fn eval(&mut self, _trace: &T, _upserts: &Vec<(K, VI)>) -> B {
+        panic!("Upsert::eval(): cannot accept upserts by reference")
+    }
+
+    fn eval_owned_and_ref(&mut self, mut _trace: T, _upserts: &Vec<(K, VI)>) -> B {
+        panic!("Upsert::eval_owned_and_ref(): cannot accept upserts by reference")
+    }
+
+    fn eval_ref_and_owned(&mut self, trace: &T, mut upserts: Vec<(K, VI)>) -> B {
+        let mut updates = Vec::with_capacity(upserts.len());
+        let mut cursor = trace.cursor();
+
+        // Sort the vector by key, preserving the history of updates for each key.
+        // Upserts cannot be merged or reordered, therefore we cannot use unstable sort.
+        upserts.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
+
+        // Find the last upsert for each key, that's the only one that matters.
+        upserts.dedup_by(|(k1, v1), (k2, v2)| {
+            if k1 == k2 {
+                swap(v1, v2);
+                true
+            } else {
+                false
+            }
+        });
+
+        for (k, val) in upserts.into_iter() {
+            cursor.seek_key(&k);
+            let val = (self.val_func)(val);
+
+            if cursor.key_valid() && cursor.key() == &k && skip_zero_weights(&mut cursor) {
+                // Key already present in the trace.
+                match val {
+                    // New value for existing key - delete old value, insert the new one.
+                    Some(val) if &val != cursor.val() => {
+                        updates.push((
+                            B::item_from(cursor.key().clone(), cursor.val().clone()),
+                            B::R::one().neg(),
+                        ));
+                        updates.push((B::item_from(k, val), B::R::one()));
+                    }
+                    // New value is `None` - remove existing key/value pair.
+                    None => {
+                        updates.push((B::item_from(k, cursor.val().clone()), B::R::one().neg()));
+                    }
+                    // Otherwise, the new value is the same as the old value - do nothing.
+                    _ => {}
+                }
+            } else {
+                // Key not in the trace.
+
+                if let Some(val) = val {
+                    updates.push((B::item_from(k, val), HasOne::one()));
+                }
+            }
+        }
+
+        B::from_tuples((), updates)
+    }
+
+    fn eval_owned(&mut self, trace: T, upserts: Vec<(K, VI)>) -> B {
+        self.eval_ref_and_owned(&trace, upserts)
+    }
+
+    fn input_preference(&self) -> (OwnershipPreference, OwnershipPreference) {
+        (
+            OwnershipPreference::PREFER_OWNED,
+            OwnershipPreference::STRONGLY_PREFER_OWNED,
+        )
+    }
+}

--- a/src/operator/window.rs
+++ b/src/operator/window.rs
@@ -220,17 +220,12 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        circuit::{Root, Stream},
-        operator::Generator,
-        trace::ord::OrdIndexedZSet,
-        zset,
-    };
+    use crate::{operator::Generator, trace::ord::OrdIndexedZSet, zset, Circuit, Stream};
     use std::vec;
 
     #[test]
     fn sliding() {
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             type Time = usize;
 
             let mut input = vec![
@@ -286,13 +281,13 @@ mod test {
         .unwrap();
 
         for _ in 0..6 {
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
     }
 
     #[test]
     fn tumbling() {
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             type Time = usize;
 
             let mut input = vec![
@@ -348,13 +343,13 @@ mod test {
         .unwrap();
 
         for _ in 0..11 {
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
     }
 
     #[test]
     fn shrinking() {
-        let root = Root::build(move |circuit| {
+        let circuit = Circuit::build(move |circuit| {
             type Time = usize;
 
             let mut input = vec![
@@ -427,7 +422,7 @@ mod test {
         .unwrap();
 
         for _ in 0..6 {
-            root.step().unwrap();
+            circuit.step().unwrap();
         }
     }
 }

--- a/src/operator/window.rs
+++ b/src/operator/window.rs
@@ -275,7 +275,8 @@ mod test {
                 .window(&bounds)
                 .inspect(move |batch| assert_eq!(batch, &output.next().unwrap()));
         })
-        .unwrap();
+        .unwrap()
+        .0;
 
         for _ in 0..6 {
             circuit.step().unwrap();
@@ -337,7 +338,7 @@ mod test {
                 .window(&bounds)
                 .inspect(move |batch| assert_eq!(batch, &output.next().unwrap()));
         })
-        .unwrap();
+        .unwrap().0;
 
         for _ in 0..11 {
             circuit.step().unwrap();
@@ -416,7 +417,7 @@ mod test {
                 .window(&bounds)
                 .inspect(move |batch| assert_eq!(batch, &output.next().unwrap()));
         })
-        .unwrap();
+        .unwrap().0;
 
         for _ in 0..6 {
             circuit.step().unwrap();

--- a/src/operator/window.rs
+++ b/src/operator/window.rs
@@ -165,9 +165,8 @@ where
                 && trace_cursor.key() < &start1
                 && trace_cursor.key() < end0
             {
-                trace_cursor.map_values(|val, weight| {
-                    tuples.push(((val.clone(), ()), weight.neg_by_ref()))
-                });
+                trace_cursor
+                    .map_values(|val, weight| tuples.push((val.clone(), weight.neg_by_ref())));
                 trace_cursor.step_key();
             }
 
@@ -176,9 +175,8 @@ where
             if &end1 < end0 {
                 trace_cursor.seek_key(&end1);
                 while trace_cursor.key_valid() && trace_cursor.key() < end0 {
-                    trace_cursor.map_values(|val, weight| {
-                        tuples.push(((val.clone(), ()), weight.neg_by_ref()))
-                    });
+                    trace_cursor
+                        .map_values(|val, weight| tuples.push((val.clone(), weight.neg_by_ref())));
                     trace_cursor.step_key();
                 }
             }
@@ -186,8 +184,7 @@ where
             // Add tuples in `trace` that slid into the window (region 3).
             trace_cursor.seek_key(max(end0, &start1));
             while trace_cursor.key_valid() && trace_cursor.key() < &end1 {
-                trace_cursor
-                    .map_values(|val, weight| tuples.push(((val.clone(), ()), weight.clone())));
+                trace_cursor.map_values(|val, weight| tuples.push((val.clone(), weight.clone())));
                 trace_cursor.step_key();
             }
         };
@@ -195,12 +192,12 @@ where
         // Insert tuples in `batch` that fall within the new window.
         batch_cursor.seek_key(&start1);
         while batch_cursor.key_valid() && batch_cursor.key() < &end1 {
-            batch_cursor.map_values(|val, weight| tuples.push(((val.clone(), ()), weight.clone())));
+            batch_cursor.map_values(|val, weight| tuples.push((val.clone(), weight.clone())));
             batch_cursor.step_key();
         }
 
         self.window = Some((start1, end1));
-        OrdZSet::from_tuples((), tuples)
+        OrdZSet::from_keys((), tuples)
     }
 
     fn input_preference(

--- a/src/trace/ord/key_batch.rs
+++ b/src/trace/ord/key_batch.rs
@@ -94,9 +94,18 @@ where
     <O as TryFrom<usize>>::Error: Debug,
     <O as TryInto<usize>>::Error: Debug,
 {
-    type Batcher = MergeBatcher<K, (), T, R, Self>;
+    type Item = K;
+    type Batcher = MergeBatcher<K, T, R, Self>;
     type Builder = OrdKeyBuilder<K, T, R, O>;
     type Merger = OrdKeyMerger<K, T, R, O>;
+
+    fn item_from(key: K, _val: ()) -> Self::Item {
+        key
+    }
+
+    fn from_keys(time: Self::Time, keys: Vec<(Self::Key, Self::R)>) -> Self {
+        Self::from_tuples(time, keys)
+    }
 
     fn begin_merge(&self, other: &Self) -> Self::Merger {
         OrdKeyMerger::new(self, other)
@@ -393,7 +402,7 @@ where
     builder: OrderedBuilder<K, OrderedLeafBuilder<T, R>, O>,
 }
 
-impl<K, T, R, O> Builder<K, (), T, R, OrdKeyBatch<K, T, R, O>> for OrdKeyBuilder<K, T, R, O>
+impl<K, T, R, O> Builder<K, T, R, OrdKeyBatch<K, T, R, O>> for OrdKeyBuilder<K, T, R, O>
 where
     K: Ord + Clone + 'static,
     T: Lattice + Timestamp + Ord + Clone + 'static,
@@ -425,7 +434,7 @@ where
     }
 
     #[inline]
-    fn push(&mut self, (key, _, diff): (K, (), R)) {
+    fn push(&mut self, (key, diff): (K, R)) {
         self.builder.push_tuple((key, (self.time.clone(), diff)));
     }
 

--- a/src/trace/ord/merge_batcher/tests.rs
+++ b/src/trace/ord/merge_batcher/tests.rs
@@ -147,8 +147,7 @@ fn count_tuples() {
 
     #[allow(clippy::type_complexity)]
     let batcher: MergeBatcher<
-        usize,
-        usize,
+        (usize, usize),
         u32,
         isize,
         OrdValBatch<usize, usize, u32, isize, usize>,

--- a/src/trace/ord/zset_batch.rs
+++ b/src/trace/ord/zset_batch.rs
@@ -245,9 +245,18 @@ where
     K: Ord + Clone + 'static,
     R: MonoidValue,
 {
-    type Batcher = MergeBatcher<K, (), (), R, Self>;
+    type Item = K;
+    type Batcher = MergeBatcher<K, (), R, Self>;
     type Builder = OrdZSetBuilder<K, R>;
     type Merger = OrdZSetMerger<K, R>;
+
+    fn item_from(key: K, _val: ()) -> Self::Item {
+        key
+    }
+
+    fn from_keys(time: Self::Time, keys: Vec<(Self::Key, Self::R)>) -> Self {
+        Self::from_tuples(time, keys)
+    }
 
     fn begin_merge(&self, other: &Self) -> Self::Merger {
         OrdZSetMerger::new(self, other)
@@ -398,7 +407,7 @@ where
     builder: OrderedColumnLeafBuilder<K, R>,
 }
 
-impl<K, R> Builder<K, (), (), R, OrdZSet<K, R>> for OrdZSetBuilder<K, R>
+impl<K, R> Builder<K, (), R, OrdZSet<K, R>> for OrdZSetBuilder<K, R>
 where
     K: Ord + Clone + 'static,
     R: MonoidValue,
@@ -423,7 +432,7 @@ where
     }
 
     #[inline]
-    fn push(&mut self, (key, (), diff): (K, (), R)) {
+    fn push(&mut self, (key, diff): (K, R)) {
         self.builder.push_tuple((key, diff));
     }
 


### PR DESCRIPTION
    We add an API to feed external data to a circuit in both single-threaded
    and multi-threaded modes.  The API allows the user to create an input
    stream and a handle that can be used outside the circuit to feed data to
    this stream.  The handle is used to buffer data asynchnously with the
    execution of the circuit.  Buffered data is consumed by the circuit at
    the beginning of each clock cycle.  We support two kinds of input
    handlesstreams with different semantics:
    
    - `InputHandle<T>` - the most basic kind of input handle that buffers a
      single value of any type, created using the following API:
    
      `fn add_input_stream<T>(&self) -> (Stream<Self, T>, InputHandle<T>)`
    
    - `CollectionHandle<K, V>` - buffers updates to relational tables in the
      form of key/value pairs, automatically sharding them among multiple
      workers. The exact semantics of updates varies depending on the method
      used to create the handle:
    
      - `fn add_input_zset<K, R>(&self) -> (Stream<Self, OrdZSet<K, R>>, CollectionHandle<K, R>)`
        the handle accumulates `(key, weight)` pairs, assembled into Z-sets pushed
        to the stream at each clock cycle.
    
      - `fn add_input_indexed_zset<K, V, R>(&self) -> (IndexedZSetStream<K, V, R>, CollectionHandle<K, (V, R)>)`
        the handle accumulates `(key, value, weight)` tuples assembed into
        indexed Z-sets at each clock cycle.
    
      - `fn add_input_set<K, R>(&self) -> (ZSetStream<K, R>, CollectionHandle<K, bool>)`
        accumulates updates to a Z-set with unit weights, where updates are
        applied with set semantics (duplicate deletes and inserts are
        ignored)
    
      - `fn add_input_map<K, V, R>(&self) -> (IndexedZSetStream<K, V, R>, CollectionHandle<K, Option<V>>)`
        accumulates updates to an indexed Z-set with unit weights, where updates are
        applied with upsert semantics (new value replaces existing value associated
        with each the same key if any).
    
    We also introduce a new handle type `DBSPHandle` used to control the
    execution of a circuit in a multithreaded runtime:
    
    - Create a runtime with N worker threads, instantiate the same circuit
      in each worker.
    - Run the N circuits in parallel, driving their logical clocks in lockstep.
    - Terminate the runtime.

@absoludity 