### PR TITLE
[nexmark] Add Query 6 for nexmark

### DIFF
--- a/src/nexmark/generator/mod.rs
+++ b/src/nexmark/generator/mod.rs
@@ -88,7 +88,7 @@ impl<R: Rng> EventGenerator<R> for NexmarkGenerator<R> {
         if !self.has_next() {
             return Ok(None);
         }
-        if self.wallclock_base_time == None {
+        if self.wallclock_base_time.is_none() {
             self.wallclock_base_time = Some(self.wallclock_time());
         }
 

--- a/src/nexmark/queries/mod.rs
+++ b/src/nexmark/queries/mod.rs
@@ -7,6 +7,8 @@ pub use q2::q2;
 pub use q3::q3;
 pub use q4::q4;
 
+pub use q6::q6;
+
 type NexmarkStream = Stream<Circuit<()>, OrdZSet<Event, isize>>;
 
 mod q0;
@@ -14,3 +16,5 @@ mod q1;
 mod q2;
 mod q3;
 mod q4;
+
+mod q6;

--- a/src/nexmark/queries/q6.rs
+++ b/src/nexmark/queries/q6.rs
@@ -1,0 +1,179 @@
+use super::NexmarkStream;
+use crate::{nexmark::model::Event, operator::FilterMap, Circuit, OrdZSet, Stream};
+
+/// Query 6:
+/// Query 6: Average Selling Price by Seller
+///
+/// What is the average selling price per seller for their last 10 closed
+/// auctions. Shares the same ‘winning bids’ core as for Query4, and illustrates
+/// a specialized combiner.
+///
+/// From [Nexmark q6.sql](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/resources/queries/q6.sql)
+///
+/// ```
+/// CREATE TABLE discard_sink (
+///   seller VARCHAR,
+///   avg_price  BIGINT
+/// ) WITH (
+///   'connector' = 'blackhole'
+/// );
+///
+/// -- TODO: this query is not supported yet in Flink SQL, because the OVER WINDOW operator doesn't
+/// --  support to consume retractions.
+/// INSERT INTO discard_sink
+/// SELECT
+///     Q.seller,
+///     AVG(Q.final) OVER
+///         (PARTITION BY Q.seller ORDER BY Q.dateTime ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)
+/// FROM (
+///     SELECT MAX(B.price) AS final, A.seller, B.dateTime
+///     FROM auction AS A, bid AS B
+///     WHERE A.id = B.auction and B.dateTime between A.dateTime and A.expires
+///     GROUP BY A.id, A.seller
+/// ) AS Q;
+/// ```
+
+type Q6Stream = Stream<Circuit<()>, OrdZSet<(u64, usize), isize>>;
+
+pub fn q6(input: NexmarkStream) -> Q6Stream {
+    // Select auctions sellers and index by auction id.
+    let auctions_by_id = input.flat_map_index(|event| match event {
+        Event::Auction(a) => Some((a.id, (a.seller, a.date_time, a.expires))),
+        _ => None,
+    });
+
+    // Select bids and index by auction id.
+    let bids_by_auction = input.flat_map_index(|event| match event {
+        Event::Bid(b) => Some((b.auction, (b.price, b.date_time))),
+        _ => None,
+    });
+
+    type BidsAuctionsJoin =
+        Stream<Circuit<()>, OrdZSet<((u64, u64, u64, u64), (usize, u64)), isize>>;
+
+    // Join to get bids for each auction.
+    let bids_for_auctions: BidsAuctionsJoin = auctions_by_id.join::<(), _, _, _>(
+        &bids_by_auction,
+        |&auction_id, &(seller, a_date_time, a_expires), &(bid_price, bid_date_time)| {
+            (
+                (auction_id, seller, a_date_time, a_expires),
+                (bid_price, bid_date_time),
+            )
+        },
+    );
+
+    // Filter out the invalid bids while indexing.
+    // TODO: update to use incremental version of `join_range` once implemented
+    // (#137).
+    let bids_for_auctions_indexed = bids_for_auctions.flat_map_index(
+        |&((auction_id, seller, a_date_time, a_expires), (bid_price, bid_date_time))| {
+            if bid_date_time >= a_date_time && bid_date_time <= a_expires {
+                Some(((auction_id, seller), bid_price))
+            } else {
+                None
+            }
+        },
+    );
+
+    // winning_bids_by_seller: once we have the winning bids, we don't
+    // need the auction ids anymore.
+    // TODO: We can optimize this given that there are no deletions, as DBSP
+    // doesn't need to keep records of the bids for future max calculations.
+    let winning_bids_by_seller: Stream<Circuit<()>, OrdZSet<(u64, usize), isize>> =
+        bids_for_auctions_indexed.aggregate_incremental(|&key, vals| -> (u64, usize) {
+            // `vals` is sorted in ascending order for each key, so we can
+            // just grab the last one.
+            let (&max, _) = vals.last().unwrap();
+            (key.1, max)
+        });
+    let winning_bids_by_seller_indexed = winning_bids_by_seller.index();
+
+    // Finally, calculate the average winning bid per seller, using the last
+    // 10 closed auctions.
+    // TODO: use linear aggregation when ready (#138).
+    winning_bids_by_seller_indexed.aggregate_incremental(|&key, vals| -> (u64, usize) {
+        let num_items = vals.len();
+        // TODO: Once initial test issue solved, add test to ensure only last
+        // 10 auctions are considered then update here to get it passing.
+        let sum = vals.drain(..).map(|(bid, _)| bid).sum::<usize>();
+        (key, sum / num_items)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        circuit::{Root, Stream},
+        nexmark::{
+            generator::tests::{make_auction, make_bid},
+            model::{Auction, Bid, Event},
+        },
+        operator::Generator,
+        zset,
+    };
+
+    #[test]
+    fn test_q6_average_bids_per_seller_one_auction() {
+        let root = Root::build(move |circuit| {
+            let mut source = vec![
+                zset! {
+                    Event::Auction(Auction {
+                        id: 1,
+                        seller: 99,
+                        expires: 10_000,
+                        ..make_auction()
+                    }) => 1,
+                    Event::Bid(Bid {
+                        auction: 1,
+                        date_time: 1_000,
+                        price: 80,
+                        ..make_bid()
+                    }) => 1,
+                    Event::Bid(Bid {
+                        auction: 1,
+                        date_time: 2_000,
+                        price: 100,
+                        ..make_bid()
+                    }) => 1,
+                },
+                zset! {
+                    // Should not be repeating the auction here - but the
+                    // current query requires it apparently - because the join
+                    // is on the zset diff representations, and so there is
+                    // nothing to join on if there's not a (new) auction here...
+                    // find out how to join when we have new bids but no change
+                    // on the auction.
+                    // Event::Auction(Auction {
+                    //     id: 1,
+                    //     seller: 99,
+                    //     expires: 10_000,
+                    //     ..make_auction()
+                    // }) => 1,
+                    Event::Bid(Bid {
+                        auction: 1,
+                        date_time: 9_000,
+                        price: 200,
+                        ..make_bid()
+                    }) => 1,
+                },
+            ]
+            .into_iter();
+
+            let mut expected_output =
+                vec![zset! { (99, 100) => 1 }, zset! {(99, 150) => 1 }].into_iter();
+
+            let input: Stream<_, OrdZSet<Event, isize>> =
+                circuit.add_source(Generator::new(move || source.next().unwrap()));
+
+            let output = q6(input);
+
+            output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
+        })
+        .unwrap();
+
+        for _ in 0..2 {
+            root.step().unwrap();
+        }
+    }
+}

--- a/src/nexmark/queries/q6.rs
+++ b/src/nexmark/queries/q6.rs
@@ -80,8 +80,9 @@ pub fn q6(input: NexmarkStream) -> Q6Stream {
     // need the auction ids anymore.
     // TODO: We can optimize this given that there are no deletions, as DBSP
     // doesn't need to keep records of the bids for future max calculations.
-    let winning_bids_by_seller: Stream<Circuit<()>, OrdZSet<(u64, (u64, usize)), isize>> =
-        bids_for_auctions_indexed.aggregate_incremental(|&key, vals| -> (u64, (u64, usize)) {
+    type WinningBidsBySeller = Stream<Circuit<()>, OrdZSet<(u64, (u64, usize)), isize>>;
+    let winning_bids_by_seller: WinningBidsBySeller = bids_for_auctions_indexed
+        .aggregate_incremental(|&key, vals| -> (u64, (u64, usize)) {
             // `vals` is sorted in ascending order for each key, so we can
             // just grab the last one.
             let (&max, _) = vals.last().unwrap();


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

This query is windowed not by time, but rather by latest data, so should be achievable (unlike the event-time-windowed q5), and shares a lot with q4.

~~While testing my initial q6 (sans the limit of 10 latest) with multiple batches, I realised that for previous queries (q4) I've been `join`ing on the incremental batch data, which works fine when all the data is in a single batch, does not handle things like a bid in a second batch which is for an auction in the first batch. The test `test_q6_average_bids_per_seller_single_seller_single_auction` verifies that this works here for q6 after adding the `.integrate()` on the join operands. Let me know if this is incorrect (seems odd to be moving away from incremental calculations, but don't see how the join for a bid in a different batch to the auction can work otherwise). If it is correct, I'll go back to test and fix q4 for multiple batches.~~ (It was a bug which was already fixed in main).

The given q6 tests now pass as expected.