### PR TITLE
[nexmark] Improve tests for q0-q2 for multiple batches and using new input API

### DIFF
--- a/benches/nexmark/main.rs
+++ b/benches/nexmark/main.rs
@@ -21,7 +21,7 @@ use dbsp::{
         config::Config as NexmarkConfig,
         generator::config::Config as GeneratorConfig,
         model::Event,
-        queries::{q0, q1, q2, q3, q4},
+        queries::{q0, q1, q2, q3, q4, q6},
         NexmarkSource,
     },
     trace::{ord::OrdZSet, BatchReader},
@@ -202,7 +202,8 @@ fn main() -> Result<()> {
         ("q1", q1),
         ("q2", q2),
         ("q3", q3),
-        ("q4", q4)
+        ("q4", q4),
+        ("q6", q6)
     );
 
     let ascii_table = create_ascii_table();


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

Rather than jumping right in and updating the benchmarking macros to use the new API, I instead learned the new API by updating the q0-q2 tests while also improving them to test multiple batches.

Tomorrow I'll update the remaining tests for q3, q4 and q6 and the nexmark bench macros, additionally enabling the number of works to be entered on the CLI.