### PR TITLE
[nexmark] Update q2, q3, q4 and q6 to use new input API in tests.

### DIFF
--- a/src/nexmark/generator/mod.rs
+++ b/src/nexmark/generator/mod.rs
@@ -242,48 +242,6 @@ pub mod tests {
         }
     }
 
-    /// Returned canned events for tests.
-    pub struct CannedEventGenerator {
-        // The canned next events to be returned.
-        next_events: Vec<NextEvent>,
-
-        current_event_index: usize,
-    }
-
-    impl<R: Rng> EventGenerator<R> for CannedEventGenerator {
-        fn reset(&mut self) {
-            self.current_event_index = 0;
-        }
-
-        fn has_next(&self) -> bool {
-            self.current_event_index < self.next_events.len()
-        }
-
-        fn event_count(&self) -> u64 {
-            self.current_event_index as u64
-        }
-
-        fn next_event(&mut self) -> Result<Option<NextEvent>> {
-            Ok(match self.current_event_index < self.next_events.len() {
-                true => {
-                    let next_event = Some(self.next_events[self.current_event_index].clone());
-                    self.current_event_index += 1;
-                    next_event
-                }
-                _ => None,
-            })
-        }
-    }
-
-    impl CannedEventGenerator {
-        pub fn new(next_events: Vec<NextEvent>) -> Self {
-            CannedEventGenerator {
-                next_events,
-                current_event_index: 0,
-            }
-        }
-    }
-
     pub fn make_test_generator() -> NexmarkGenerator<StepRng> {
         NexmarkGenerator::new(Config::default(), StepRng::new(0, 1))
     }

--- a/src/nexmark/queries/q2.rs
+++ b/src/nexmark/queries/q2.rs
@@ -39,54 +39,52 @@ mod tests {
 
     #[test]
     fn test_q2() {
-        fn input_vecs() -> Vec<Vec<(Event, isize)>> {
+        let input_vecs: Vec<Vec<(Event, isize)>> = vec![
             vec![
-                vec![
-                    (
-                        Event::Bid(Bid {
-                            auction: 1,
-                            price: 80,
-                            ..make_bid()
-                        }),
-                        1,
-                    ),
-                    (
-                        Event::Bid(Bid {
-                            auction: AUCTION_ID_MODULO,
-                            price: 111,
-                            ..make_bid()
-                        }),
-                        1,
-                    ),
-                    (
-                        Event::Bid(Bid {
-                            auction: AUCTION_ID_MODULO + 1,
-                            price: 100,
-                            ..make_bid()
-                        }),
-                        1,
-                    ),
-                ],
-                vec![
-                    (
-                        Event::Bid(Bid {
-                            auction: 3 * AUCTION_ID_MODULO + 25,
-                            price: 80,
-                            ..make_bid()
-                        }),
-                        1,
-                    ),
-                    (
-                        Event::Bid(Bid {
-                            auction: 4 * AUCTION_ID_MODULO,
-                            price: 222,
-                            ..make_bid()
-                        }),
-                        1,
-                    ),
-                ],
-            ]
-        }
+                (
+                    Event::Bid(Bid {
+                        auction: 1,
+                        price: 80,
+                        ..make_bid()
+                    }),
+                    1,
+                ),
+                (
+                    Event::Bid(Bid {
+                        auction: AUCTION_ID_MODULO,
+                        price: 111,
+                        ..make_bid()
+                    }),
+                    1,
+                ),
+                (
+                    Event::Bid(Bid {
+                        auction: AUCTION_ID_MODULO + 1,
+                        price: 100,
+                        ..make_bid()
+                    }),
+                    1,
+                ),
+            ],
+            vec![
+                (
+                    Event::Bid(Bid {
+                        auction: 3 * AUCTION_ID_MODULO + 25,
+                        price: 80,
+                        ..make_bid()
+                    }),
+                    1,
+                ),
+                (
+                    Event::Bid(Bid {
+                        auction: 4 * AUCTION_ID_MODULO,
+                        price: 222,
+                        ..make_bid()
+                    }),
+                    1,
+                ),
+            ],
+        ];
 
         let (circuit, mut input_handle) = Circuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
@@ -105,7 +103,7 @@ mod tests {
         })
         .unwrap();
 
-        for mut vec in input_vecs().into_iter() {
+        for mut vec in input_vecs.into_iter() {
             input_handle.append(&mut vec);
             circuit.step().unwrap();
         }

--- a/src/nexmark/queries/q6.rs
+++ b/src/nexmark/queries/q6.rs
@@ -111,61 +111,72 @@ pub fn q6(input: NexmarkStream) -> Q6Stream {
 mod tests {
     use super::*;
     use crate::{
-        circuit::Stream,
         nexmark::{
             generator::tests::{make_auction, make_bid},
             model::{Auction, Bid, Event},
         },
-        operator::Generator,
         zset, Circuit,
     };
 
     #[test]
     fn test_q6_single_seller_single_auction() {
-        let circuit = Circuit::build(move |circuit| {
-            let mut source = vec![
-                // The first batch has a single auction for seller 99 with a highest bid of 100
-                // (currently).
-                zset! {
+        let input_vecs = vec![
+            // The first batch has a single auction for seller 99 with a highest bid of 100
+            // (currently).
+            vec![
+                (
                     Event::Auction(Auction {
                         id: 1,
                         seller: 99,
                         expires: 10_000,
                         ..make_auction()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Bid(Bid {
                         auction: 1,
                         date_time: 1_000,
                         price: 80,
                         ..make_bid()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Bid(Bid {
                         auction: 1,
                         date_time: 2_000,
                         price: 100,
                         ..make_bid()
-                    }) => 1,
-                },
-                // The second batch has a new highest bid for the (currently) only auction.
-                zset! {
-                    Event::Bid(Bid {
-                        auction: 1,
-                        date_time: 9_000,
-                        price: 200,
-                        ..make_bid()
-                    }) => 1,
-                },
-                // The third batch has a new bid but it's not higher, so no effect.
-                zset! {
-                    Event::Bid(Bid {
-                        auction: 1,
-                        date_time: 9_500,
-                        price: 150,
-                        ..make_bid()
-                    }) => 1,
-                },
-            ]
-            .into_iter();
+                    }),
+                    1,
+                ),
+            ],
+            // The second batch has a new highest bid for the (currently) only auction.
+            vec![(
+                Event::Bid(Bid {
+                    auction: 1,
+                    date_time: 9_000,
+                    price: 200,
+                    ..make_bid()
+                }),
+                1,
+            )],
+            // The third batch has a new bid but it's not higher, so no effect.
+            vec![(
+                Event::Bid(Bid {
+                    auction: 1,
+                    date_time: 9_500,
+                    price: 150,
+                    ..make_bid()
+                }),
+                1,
+            )],
+        ]
+        .into_iter();
+
+        let (circuit, mut input_handle) = Circuit::build(move |circuit| {
+            let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let mut expected_output = vec![
                 // First batch has a single auction seller with best bid of 100.
@@ -174,63 +185,75 @@ mod tests {
                 // averaging).
                 zset! {(99, 100) => -1, (99, 200) => 1 },
                 // The third batch has a bid that isn't higher, so no change.
-                zset! {(99, 200) => 1 },
+                zset! {},
             ]
             .into_iter();
 
-            let input: Stream<_, OrdZSet<Event, isize>> =
-                circuit.add_source(Generator::new(move || source.next().unwrap()));
-
-            let output = q6(input);
+            let output = q6(stream);
 
             output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
-        })
-        .unwrap()
-        .0;
 
-        for _ in 0..2 {
+            input_handle
+        })
+        .unwrap();
+
+        for mut vec in input_vecs.into_iter() {
+            input_handle.append(&mut vec);
             circuit.step().unwrap();
         }
     }
 
     #[test]
     fn test_q6_single_seller_multiple_auctions() {
-        let circuit = Circuit::build(move |circuit| {
-            let mut source = vec![
-                // The first batch has a single auction for seller 99 with a highest bid of 100.
-                zset! {
+        let input_vecs = vec![
+            // The first batch has a single auction for seller 99 with a highest bid of 100.
+            vec![
+                (
                     Event::Auction(Auction {
                         id: 1,
                         seller: 99,
                         expires: 10_000,
                         ..make_auction()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Bid(Bid {
                         auction: 1,
                         date_time: 2_000,
                         price: 100,
                         ..make_bid()
-                    }) => 1,
-                },
-                // The second batch adds a new auction for the same seller, with
-                // a final bid of 200, so the average should be 150 for this seller.
-                zset! {
+                    }),
+                    1,
+                ),
+            ],
+            // The second batch adds a new auction for the same seller, with
+            // a final bid of 200, so the average should be 150 for this seller.
+            vec![
+                (
                     Event::Auction(Auction {
                         id: 2,
                         seller: 99,
                         expires: 20_000,
                         ..make_auction()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Bid(Bid {
                         auction: 2,
                         date_time: 15_000,
                         price: 200,
                         ..make_bid()
-                    }) => 1,
-                },
-            ]
-            .into_iter();
+                    }),
+                    1,
+                ),
+            ],
+        ]
+        .into_iter();
 
+        let (circuit, mut input_handle) = Circuit::build(move |circuit| {
+            let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
             let mut expected_output = vec![
                 // First batch has a single auction seller with best bid of 100.
                 zset! { (99, 100) => 1 },
@@ -240,171 +263,237 @@ mod tests {
             ]
             .into_iter();
 
-            let input: Stream<_, OrdZSet<Event, isize>> =
-                circuit.add_source(Generator::new(move || source.next().unwrap()));
-
-            let output = q6(input);
+            let output = q6(stream);
 
             output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
-        })
-        .unwrap()
-        .0;
 
-        for _ in 0..2 {
+            input_handle
+        })
+        .unwrap();
+
+        for mut vec in input_vecs.into_iter() {
+            input_handle.append(&mut vec);
             circuit.step().unwrap();
         }
     }
 
     #[test]
     fn test_q6_single_seller_more_than_10_auctions() {
-        let circuit = Circuit::build(move |circuit| {
-            let mut source = vec![
-                // The first batch has 5 auctions all with single bids of 100, except
-                // the first which is at 200.
-                zset! {
+        let input_vecs = vec![
+            // The first batch has 5 auctions all with single bids of 100, except
+            // the first which is at 200.
+            vec![
+                (
                     Event::Auction(Auction {
                         id: 1,
                         seller: 99,
                         expires: 10_000,
                         ..make_auction()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Bid(Bid {
                         auction: 1,
                         date_time: 2_000,
                         price: 200,
                         ..make_bid()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Auction(Auction {
                         id: 2,
                         seller: 99,
                         expires: 10_000,
                         ..make_auction()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Bid(Bid {
                         auction: 2,
                         date_time: 2_000,
                         price: 100,
                         ..make_bid()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Auction(Auction {
                         id: 3,
                         seller: 99,
                         expires: 10_000,
                         ..make_auction()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Bid(Bid {
                         auction: 3,
                         date_time: 2_000,
                         price: 100,
                         ..make_bid()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Auction(Auction {
                         id: 4,
                         seller: 99,
                         expires: 10_000,
                         ..make_auction()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Bid(Bid {
                         auction: 4,
                         date_time: 2_000,
                         price: 100,
                         ..make_bid()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Auction(Auction {
                         id: 5,
                         seller: 99,
                         expires: 10_000,
                         ..make_auction()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Bid(Bid {
                         auction: 5,
                         date_time: 2_000,
                         price: 100,
                         ..make_bid()
-                    }) => 1,
-                },
-                // The second batch has another 5 auctions all with single bids of 100.
-                zset! {
+                    }),
+                    1,
+                ),
+            ],
+            // The second batch has another 5 auctions all with single bids of 100.
+            vec![
+                (
                     Event::Auction(Auction {
                         id: 6,
                         seller: 99,
                         expires: 10_000,
                         ..make_auction()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Bid(Bid {
                         auction: 6,
                         date_time: 2_000,
                         price: 100,
                         ..make_bid()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Auction(Auction {
                         id: 7,
                         seller: 99,
                         expires: 10_000,
                         ..make_auction()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Bid(Bid {
                         auction: 7,
                         date_time: 2_000,
                         price: 100,
                         ..make_bid()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Auction(Auction {
                         id: 8,
                         seller: 99,
                         expires: 10_000,
                         ..make_auction()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Bid(Bid {
                         auction: 8,
                         date_time: 2_000,
                         price: 100,
                         ..make_bid()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Auction(Auction {
                         id: 9,
                         seller: 99,
                         expires: 10_000,
                         ..make_auction()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Bid(Bid {
                         auction: 9,
                         date_time: 2_000,
                         price: 100,
                         ..make_bid()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Auction(Auction {
                         id: 10,
                         seller: 99,
                         expires: 10_000,
                         ..make_auction()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Bid(Bid {
                         auction: 10,
                         date_time: 2_000,
                         price: 100,
                         ..make_bid()
-                    }) => 1,
-                },
-                // The third batch has a single auction and bid of 100. The last
-                // 10 auctions all have 100 now, so average is 100.
-                zset! {
+                    }),
+                    1,
+                ),
+            ],
+            // The third batch has a single auction and bid of 100. The last
+            // 10 auctions all have 100 now, so average is 100.
+            vec![
+                (
                     Event::Auction(Auction {
                         id: 11,
                         seller: 99,
                         expires: 10_000,
                         ..make_auction()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Bid(Bid {
                         auction: 11,
                         date_time: 2_000,
                         price: 100,
                         ..make_bid()
-                    }) => 1,
-                },
-            ]
-            .into_iter();
+                    }),
+                    1,
+                ),
+            ],
+        ]
+        .into_iter();
 
+        let (circuit, mut input_handle) = Circuit::build(move |circuit| {
+            let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
             let mut expected_output = vec![
                 // First has 5 auction for person 99, but average is (200 + 100 * 4) / 5.
                 zset! { (99, 120) => 1 },
@@ -416,88 +505,113 @@ mod tests {
             ]
             .into_iter();
 
-            let input: Stream<_, OrdZSet<Event, isize>> =
-                circuit.add_source(Generator::new(move || source.next().unwrap()));
-
-            let output = q6(input);
+            let output = q6(stream);
 
             output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
-        })
-        .unwrap()
-        .0;
 
-        for _ in 0..3 {
+            input_handle
+        })
+        .unwrap();
+
+        for mut vec in input_vecs.into_iter() {
+            input_handle.append(&mut vec);
             circuit.step().unwrap();
         }
     }
 
     #[test]
     fn test_q6_multiple_sellers_multiple_auctions() {
-        let circuit = Circuit::build(move |circuit| {
-            let mut source = vec![
-                // The first batch has a single auction for seller 99 with a highest bid of 100.
-                zset! {
+        let input_vecs = vec![
+            // The first batch has a single auction for seller 99 with a highest bid of 100.
+            vec![
+                (
                     Event::Auction(Auction {
                         id: 1,
                         seller: 99,
                         expires: 10_000,
                         ..make_auction()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Bid(Bid {
                         auction: 1,
                         date_time: 2_000,
                         price: 100,
                         ..make_bid()
-                    }) => 1,
-                },
-                // The second batch adds a new auction for a different seller, with
-                // a final bid of 200, so the two sellers have 100 and 200 as
-                // their averages.
-                zset! {
+                    }),
+                    1,
+                ),
+            ],
+            // The second batch adds a new auction for a different seller, with
+            // a final bid of 200, so the two sellers have 100 and 200 as
+            // their averages.
+            vec![
+                (
                     Event::Auction(Auction {
                         id: 2,
                         seller: 33,
                         expires: 20_000,
                         ..make_auction()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Bid(Bid {
                         auction: 2,
                         date_time: 15_000,
                         price: 200,
                         ..make_bid()
-                    }) => 1,
-                },
-                // The third batch adds a new auction for both sellers, with
-                // final bids of 200, so the two sellers have 150 and 200 as
-                // their averages.
-                zset! {
+                    }),
+                    1,
+                ),
+            ],
+            // The third batch adds a new auction for both sellers, with
+            // final bids of 200, so the two sellers have 150 and 200 as
+            // their averages.
+            vec![
+                (
                     Event::Auction(Auction {
                         id: 3,
                         seller: 99,
                         expires: 20_000,
                         ..make_auction()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Bid(Bid {
                         auction: 3,
                         date_time: 15_000,
                         price: 200,
                         ..make_bid()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Auction(Auction {
                         id: 4,
                         seller: 33,
                         expires: 20_000,
                         ..make_auction()
-                    }) => 1,
+                    }),
+                    1,
+                ),
+                (
                     Event::Bid(Bid {
                         auction: 4,
                         date_time: 15_000,
                         price: 200,
                         ..make_bid()
-                    }) => 1,
-                },
-            ]
-            .into_iter();
+                    }),
+                    1,
+                ),
+            ],
+        ]
+        .into_iter();
+
+        let (circuit, mut input_handle) = Circuit::build(move |circuit| {
+            let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let mut expected_output = vec![
                 // First batch has a single auction seller with best bid of 100.
@@ -510,17 +624,15 @@ mod tests {
             ]
             .into_iter();
 
-            let input: Stream<_, OrdZSet<Event, isize>> =
-                circuit.add_source(Generator::new(move || source.next().unwrap()));
-
-            let output = q6(input);
+            let output = q6(stream);
 
             output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
+            input_handle
         })
-        .unwrap()
-        .0;
+        .unwrap();
 
-        for _ in 0..3 {
+        for mut vec in input_vecs.into_iter() {
+            input_handle.append(&mut vec);
             circuit.step().unwrap();
         }
     }


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

Switches all remaining nexmark query tests to use the new input API and removes no longer used test code (CannedEventGenerator).