### PR TITLE
[nexmark] Use Runtime to support multiple cores.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,6 +590,7 @@ dependencies = [
  "num-format",
  "once_cell",
  "ordered-float",
+ "pbr",
  "petgraph",
  "priority-queue",
  "proptest",
@@ -857,7 +858,7 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1177,7 +1178,7 @@ checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -1428,6 +1429,18 @@ dependencies = [
  "hmac",
  "password-hash",
  "sha2",
+]
+
+[[package]]
+name = "pbr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff5751d87f7c00ae6403eb1fcbba229b9c76c9a30de8c1cf87182177b168cea2"
+dependencies = [
+ "crossbeam-channel",
+ "libc",
+ "time 0.1.44",
+ "winapi",
 ]
 
 [[package]]
@@ -2062,6 +2075,17 @@ dependencies = [
 
 [[package]]
 name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
+name = "time"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74b7cc93fc23ba97fde84f7eea56c55d1ba183f495c6715defdfc7b9cb8c870f"
@@ -2349,6 +2373,12 @@ dependencies = [
 
 [[package]]
 name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -2537,7 +2567,7 @@ dependencies = [
  "hmac",
  "pbkdf2",
  "sha1",
- "time",
+ "time 0.3.12",
  "zstd",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -858,7 +858,7 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -1178,7 +1178,7 @@ checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys",
 ]
 
@@ -1434,12 +1434,10 @@ dependencies = [
 [[package]]
 name = "pbr"
 version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff5751d87f7c00ae6403eb1fcbba229b9c76c9a30de8c1cf87182177b168cea2"
+source = "git+https://github.com/a8m/pb?rev=09a8e592c1bb0aa1d6215e35c5c8b49b7a5ad6bd#09a8e592c1bb0aa1d6215e35c5c8b49b7a5ad6bd"
 dependencies = [
  "crossbeam-channel",
  "libc",
- "time 0.1.44",
  "winapi",
 ]
 
@@ -2075,17 +2073,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74b7cc93fc23ba97fde84f7eea56c55d1ba183f495c6715defdfc7b9cb8c870f"
@@ -2373,12 +2360,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -2567,7 +2548,7 @@ dependencies = [
  "hmac",
  "pbkdf2",
  "sha1",
- "time 0.3.12",
+ "time",
  "zstd",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,10 @@ clap = { version = "3.2.8", features = ["derive", "env"] }
 reqwest = { version = "0.11.11", features = ["blocking"] }
 ascii_table = "4.0.2"
 num-format = "0.4.0"
-pbr = "1.0.4"
+# The latest release of pbr (1.0.4) depends on an old version of time (0.1.44) with
+# a vulnerability. The dependency has been removed but a new version is yet
+# to be released https://github.com/a8m/pb/issues/113
+pbr = { git = "https://github.com/a8m/pb", rev = "09a8e592c1bb0aa1d6215e35c5c8b49b7a5ad6bd"}
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = "0.2.127"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,13 +53,13 @@ clap = { version = "3.2.8", features = ["derive", "env"] }
 reqwest = { version = "0.11.11", features = ["blocking"] }
 ascii_table = "4.0.2"
 num-format = "0.4.0"
+
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2.127"
 # The latest release of pbr (1.0.4) depends on an old version of time (0.1.44) with
 # a vulnerability. The dependency has been removed but a new version is yet
 # to be released https://github.com/a8m/pb/issues/113
 pbr = { git = "https://github.com/a8m/pb", rev = "09a8e592c1bb0aa1d6215e35c5c8b49b7a5ad6bd"}
-
-[target.'cfg(unix)'.dev-dependencies]
-libc = "0.2.127"
 
 [profile.bench]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ clap = { version = "3.2.8", features = ["derive", "env"] }
 reqwest = { version = "0.11.11", features = ["blocking"] }
 ascii_table = "4.0.2"
 num-format = "0.4.0"
+pbr = "1.0.4"
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = "0.2.127"

--- a/src/nexmark/config.rs
+++ b/src/nexmark/config.rs
@@ -35,6 +35,10 @@ pub struct Config {
     #[clap(long, default_value = "200", env = "NEXMARK_AVG_PERSON_BYTE_SIZE")]
     pub avg_person_byte_size: usize,
 
+    /// Number of CPU cores to be available.
+    #[clap(long, default_value = "1", env = "NEXMARK_CPU_CORES")]
+    pub cpu_cores: usize,
+
     /// Specify the proportion of events that will be new bids.
     #[clap(long, default_value = "46", env = "NEXMARK_BID_PROPORTION")]
     pub bid_proportion: usize,
@@ -106,6 +110,7 @@ impl Default for Config {
             avg_bid_byte_size: 100,
             avg_person_byte_size: 200,
             bid_proportion: 46,
+            cpu_cores: 1,
             first_event_rate: 10_000,
             hot_auction_ratio: 2,
             hot_bidders_ratio: 4,


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

### Improved UX during testing

I've used a progress bar so that you can now see how many events as well as percentage, current rate and expected time to completion while each test is running, which is much nicer (especially when tests a taking a while).

```
Starting q4 bench of 10000000 events...
started spawning workers
finished spawning workers in 501.05µs
6239000 / 10000000 [====================================================================================================================>---------------------------------------------------------------------] 62.39 % 1586076.97/s 2s 
```

### Adapted calculation of CPU usage

Previously the call to `rusage` was returning the usage for that thread only (not the separate threads created by DBSP while running), so this is now improved so that:

1. `rusage` is now called before and after each query, noting the change in CPU usage for the whole process (`RUSAGE_SELF`), to get an accurate total CPU usage for the producer (thread generating events and calling  `input_handle.append()`) and consumer (the `dbsp.step()` thread),
2. `rusage` is also called for the producer thread (thread generating events and calling `input_handle.append()`) to note the CPU usage specifically for the producer thread (which is a single thread as it stands today).
3. The results now show both the input CPU usage and the DBSP usage (total - input) for each query:

```
┌───────┬────────────┬───────┬─────────┬─────────────────┬──────────────────┬───────────────┬───────────────┬──────────────┬──────────────┬─────────────┐
│ Query │ #Events    │ Cores │ Elapsed │ Cores * Elapsed │ Throughput/Cores │ Input Usr CPU │ Input Sys CPU │ DBSP Usr CPU │ DBSP Sys CPU │ Max RSS(Kb) │
├───────┼────────────┼───────┼─────────┼─────────────────┼──────────────────┼───────────────┼───────────────┼──────────────┼──────────────┼─────────────┤
│ q4    │ 10,000,000 │ 10    │ 6.651s  │ 66.508s         │ 150.358 K/s      │ 5.901s        │ 0.388s        │ 20.460s      │ 0.458s       │ 687,016     │
│ q6    │ 10,000,000 │ 10    │ 6.309s  │ 63.093s         │ 158.497 K/s      │ 5.875s        │ 0.208s        │ 20.698s      │ 0.365s       │ N/A         │
└───────┴────────────┴───────┴─────────┴─────────────────┴──────────────────┴───────────────┴───────────────┴──────────────┴──────────────┴─────────────┘
```

This shows the simple Cores * Elapsed time isn't very useful as an approximation. Also relevant is that the Max RSS is only discernible for the first query, so you need to run a query on its own to get the value.

### 10M events at 10M/sec with single CPU:

```
┌───────┬────────────┬───────┬─────────┬─────────────────┬──────────────────┬───────────────┬───────────────┬──────────────┬──────────────┬─────────────┐
│ Query │ #Events    │ Cores │ Elapsed │ Cores * Elapsed │ Throughput/Cores │ Input Usr CPU │ Input Sys CPU │ DBSP Usr CPU │ DBSP Sys CPU │ Max RSS(Kb) │
├───────┼────────────┼───────┼─────────┼─────────────────┼──────────────────┼───────────────┼───────────────┼──────────────┼──────────────┼─────────────┤
│ q0    │ 10,000,000 │ 1     │ 5.765s  │ 5.765s          │ 1734.727 K/s     │ 4.360s        │ 0.048s        │ 5.768s       │ 0.008s       │ 2,324       │
│ q1    │ 10,000,000 │ 1     │ 5.961s  │ 5.961s          │ 1677.559 K/s     │ 4.473s        │ 0.064s        │ 5.946s       │ 0.024s       │ N/A         │
│ q2    │ 10,000,000 │ 1     │ 4.238s  │ 4.238s          │ 2359.332 K/s     │ 4.040s        │ 0.140s        │ 3.545s       │ 0.057s       │ N/A         │
│ q3    │ 10,000,000 │ 1     │ 4.449s  │ 4.449s          │ 2247.543 K/s     │ 4.273s        │ 0.056s        │ 4.041s       │ 0.024s       │ N/A         │
│ q4    │ 10,000,000 │ 1     │ 35.968s │ 35.968s         │ 278.025 K/s      │ 4.738s        │ 0.040s        │ 35.664s      │ 0.336s       │ N/A         │
│ q6    │ 10,000,000 │ 1     │ 6.375s  │ 6.375s          │ 1568.733 K/s     │ 4.872s        │ 0.024s        │ 6.060s       │ 0.228s       │ N/A         │
└───────┴────────────┴───────┴─────────┴─────────────────┴──────────────────┴───────────────┴───────────────┴──────────────┴──────────────┴─────────────┘
```

Note small (3ms) discrepancy between the elapsed and DBSP usr CPU for q0 (in that the DBSP Usr CPU is 3ms greater which doesn't make sense unless reporting lags slightly?) 

### 10M events at 10M/sec with 10 CPUs:

```
┌───────┬────────────┬───────┬─────────┬─────────────────┬──────────────────┬───────────────┬───────────────┬──────────────┬──────────────┬─────────────┐
│ Query │ #Events    │ Cores │ Elapsed │ Cores * Elapsed │ Throughput/Cores │ Input Usr CPU │ Input Sys CPU │ DBSP Usr CPU │ DBSP Sys CPU │ Max RSS(Kb) │
├───────┼────────────┼───────┼─────────┼─────────────────┼──────────────────┼───────────────┼───────────────┼──────────────┼──────────────┼─────────────┤
│ q0    │ 10,000,000 │ 10    │ 6.274s  │ 62.742s         │ 159.383 K/s      │ 5.535s        │ 0.452s        │ 19.135s      │ 0.283s       │ 103,096     │
│ q1    │ 10,000,000 │ 10    │ 6.518s  │ 65.179s         │ 153.423 K/s      │ 5.777s        │ 0.412s        │ 19.898s      │ 0.284s       │ N/A         │
│ q2    │ 10,000,000 │ 10    │ 6.154s  │ 61.538s         │ 162.500 K/s      │ 5.247s        │ 0.413s        │ 11.870s      │ 0.160s       │ N/A         │
│ q3    │ 10,000,000 │ 10    │ 6.353s  │ 63.534s         │ 157.396 K/s      │ 5.448s        │ 0.357s        │ 13.170s      │ 0.220s       │ N/A         │
│ q4    │ 10,000,000 │ 10    │ 7.000s  │ 69.998s         │ 142.861 K/s      │ 6.335s        │ 0.313s        │ 23.812s      │ 0.483s       │ N/A         │
│ q6    │ 10,000,000 │ 10    │ 6.497s  │ 64.966s         │ 153.926 K/s      │ 6.155s        │ 0.140s        │ 21.324s      │ 0.444s       │ N/A         │
└───────┴────────────┴───────┴─────────┴─────────────────┴──────────────────┴───────────────┴───────────────┴──────────────┴──────────────┴─────────────┘
```

### 100M events at 10M/sec with 10 CPUs:

I can't run 100M events with a single CPU as the q4 gets slower and slower as it progresses, but with 10CPUs it works fine.

```
┌───────┬─────────────┬───────┬─────────┬─────────────────┬──────────────────┬───────────────┬───────────────┬──────────────┬──────────────┬─────────────┐
│ Query │ #Events     │ Cores │ Elapsed │ Cores * Elapsed │ Throughput/Cores │ Input Usr CPU │ Input Sys CPU │ DBSP Usr CPU │ DBSP Sys CPU │ Max RSS(Kb) │
├───────┼─────────────┼───────┼─────────┼─────────────────┼──────────────────┼───────────────┼───────────────┼──────────────┼──────────────┼─────────────┤
│ q0    │ 100,000,000 │ 10    │ 66.202s │ 662.018s        │ 151.053 K/s      │ 60.929s       │ 3.280s        │ 236.424s     │ 1.474s       │ 478,440     │
│ q1    │ 100,000,000 │ 10    │ 65.095s │ 650.951s        │ 153.621 K/s      │ 60.314s       │ 3.145s        │ 221.632s     │ 1.324s       │ N/A         │
│ q2    │ 100,000,000 │ 10    │ 59.614s │ 596.143s        │ 167.745 K/s      │ 55.678s       │ 2.207s        │ 169.224s     │ 0.989s       │ N/A         │
│ q3    │ 100,000,000 │ 10    │ 59.513s │ 595.131s        │ 168.030 K/s      │ 55.871s       │ 1.409s        │ 179.705s     │ 1.078s       │ N/A         │
│ q4    │ 100,000,000 │ 10    │ 95.573s │ 955.732s        │ 104.632 K/s      │ 67.715s       │ 0.788s        │ 357.755s     │ 4.472s       │ N/A         │
│ q6    │ 100,000,000 │ 10    │ 69.216s │ 692.155s        │ 144.476 K/s      │ 65.504s       │ 2.237s        │ 227.850s     │ 5.148s       │ N/A         │
└───────┴─────────────┴───────┴─────────┴─────────────────┴──────────────────┴───────────────┴───────────────┴──────────────┴──────────────┴─────────────┘
```

## Previous PR Description

I've updated to run the input generation in one thread, and the DBSP consumption (`step()`s), in another thread, while coordinating them in the main thread. Importantly, the amount of data inputted in each step increases until the time taken to process the data is longer than the time taken to input/hash the data. This provides a natural balance so that memory isn't exhausted (the backpressure) while still processing the steps as fast as possible.

### 10M events / second, 10M events, 1 core

```
┌───────┬────────────┬───────┬─────────┬─────────────────┬──────────────────┬─────────────┬───────────────┬─────────────┐
│ Query │ #Events    │ Cores │ Time(s) │ Cores * Time(s) │ Throughput/Cores │ User CPU(s) │ System CPU(s) │ Max RSS(Kb) │
├───────┼────────────┼───────┼─────────┼─────────────────┼──────────────────┼─────────────┼───────────────┼─────────────┤
│ q0    │ 10,000,000 │ 1     │ 4.507   │ 4.507           │ 2218.564 K/s     │ 0.054       │ 0.000         │ 41,076      │
│ q1    │ 10,000,000 │ 1     │ 4.666   │ 4.666           │ 2143.027 K/s     │ 0.030       │ 0.030         │ 48,264      │
│ q2    │ 10,000,000 │ 1     │ 4.028   │ 4.028           │ 2482.358 K/s     │ 0.013       │ 0.000         │ 133,808     │
│ q3    │ 10,000,000 │ 1     │ 4.080   │ 4.080           │ 2450.905 K/s     │ 0.004       │ 0.009         │ 256,976     │
│ q4    │ 10,000,000 │ 1     │ 29.027  │ 29.027          │ 344.505 K/s      │ 0.062       │ 0.042         │ 1,020,452   │
│ q6    │ 10,000,000 │ 1     │ 5.087   │ 5.087           │ 1965.731 K/s     │ 0.027       │ 0.013         │ 1,020,452   │
└───────┴────────────┴───────┴─────────┴─────────────────┴──────────────────┴─────────────┴───────────────┴─────────────┘
```
Note that the memory for 10M events is not exceesive. I need to investigate why q4 performs so badly (but consistently) above. From an initial look, it appears the number of batches never gets above a small threshold (because the data is not consumed more quickly, but not 100% yet). But, it is also the only query which improves (hugely) from more cores:

### 10M events / second, 10M events, 10 cores

```
┌───────┬────────────┬───────┬─────────┬─────────────────┬──────────────────┬─────────────┬───────────────┬─────────────┐
│ Query │ #Events    │ Cores │ Time(s) │ Cores * Time(s) │ Throughput/Cores │ User CPU(s) │ System CPU(s) │ Max RSS(Kb) │
├───────┼────────────┼───────┼─────────┼─────────────────┼──────────────────┼─────────────┼───────────────┼─────────────┤
│ q0    │ 10,000,000 │ 10    │ 6.160   │ 61.599          │ 162.341 K/s      │ 0.016       │ 0.010         │ 139,472     │
│ q1    │ 10,000,000 │ 10    │ 5.972   │ 59.720          │ 167.448 K/s      │ 0.029       │ 0.000         │ 154,296     │
│ q2    │ 10,000,000 │ 10    │ 5.699   │ 56.992          │ 175.462 K/s      │ 0.008       │ 0.019         │ 156,612     │
│ q3    │ 10,000,000 │ 10    │ 5.800   │ 57.999          │ 172.418 K/s      │ 0.012       │ 0.016         │ 157,212     │
│ q4    │ 10,000,000 │ 10    │ 6.430   │ 64.302          │ 155.516 K/s      │ 0.009       │ 0.026         │ 756,360     │
│ q6    │ 10,000,000 │ 10    │ 6.154   │ 61.545          │ 162.484 K/s      │ 0.006       │ 0.017         │ 866,260     │
└───────┴────────────┴───────┴─────────┴─────────────────┴──────────────────┴─────────────┴───────────────┴─────────────┘
```

### 10M events/second, 100M events, 1 core

So we can now run with 100M events, with memory only becoming excessive with q6

```
┌───────┬─────────────┬───────┬─────────┬─────────────────┬──────────────────┬─────────────┬───────────────┬─────────────┐
│ Query │ #Events     │ Cores │ Time(s) │ Cores * Time(s) │ Throughput/Cores │ User CPU(s) │ System CPU(s) │ Max RSS(Kb) │
├───────┼─────────────┼───────┼─────────┼─────────────────┼──────────────────┼─────────────┼───────────────┼─────────────┤
│ q0    │ 100,000,000 │ 1     │ 61.398  │ 61.398          │ 1628.712 K/s     │ 0.103       │ 0.037         │ 141,104     │
│ q1    │ 100,000,000 │ 1     │ 62.240  │ 62.240          │ 1606.696 K/s     │ 0.115       │ 0.050         │ 202,400     │
│ q2    │ 100,000,000 │ 1     │ 46.181  │ 46.181          │ 2165.409 K/s     │ 0.046       │ 0.000         │ 449,116     │
│ q3    │ 100,000,000 │ 1     │ 47.481  │ 47.481          │ 2106.087 K/s     │ 0.030       │ 0.011         │ 842,548     │
│ q6    │ 100,000,000 │ 1     │ 62.221  │ 62.221          │ 1607.185 K/s     │ 0.072       │ 0.066         │ 6,895,528   │
└───────┴─────────────┴───────┴─────────┴─────────────────┴──────────────────┴─────────────┴───────────────┴─────────────┘
```

### 10M events/second, 100M events, 10 cores

Again, it seems that splitting the input into the separate buffers (having to iterate the complete input?) is meaning that with 10 cores we're still seeing the same times (ie. much less throughput/core):

```
┌───────┬─────────────┬───────┬─────────┬─────────────────┬──────────────────┬─────────────┬───────────────┬─────────────┐
│ Query │ #Events     │ Cores │ Time(s) │ Cores * Time(s) │ Throughput/Cores │ User CPU(s) │ System CPU(s) │ Max RSS(Kb) │
├───────┼─────────────┼───────┼─────────┼─────────────────┼──────────────────┼─────────────┼───────────────┼─────────────┤
│ q0    │ 100,000,000 │ 10    │ 67.176  │ 671.756         │ 148.864 K/s      │ 0.032       │ 0.041         │ 475,348     │
│ q1    │ 100,000,000 │ 10    │ 68.581  │ 685.807         │ 145.814 K/s      │ 0.053       │ 0.018         │ 511,664     │
│ q2    │ 100,000,000 │ 10    │ 63.678  │ 636.778         │ 157.041 K/s      │ 0.040       │ 0.036         │ 511,664     │
│ q3    │ 100,000,000 │ 10    │ 60.087  │ 600.870         │ 166.425 K/s      │ 0.060       │ 0.007         │ 744,496     │
│ q6    │ 100,000,000 │ 10    │ 63.342  │ 633.419         │ 157.873 K/s      │ 0.022       │ 0.043         │ 7,461,464   │
└───────┴─────────────┴───────┴─────────┴─────────────────┴──────────────────┴─────────────┴───────────────┴─────────────┘
```

## Original PR description

From an initial play I need to spend some more time debugging why the (single-core) throughput remains around 1M/sec when the source emits at 10M events per second - probably something I've missed and need to test.

But for now, some examples. First, at the slower frequency of 1M events/sec with 1 CPU core, the batches begin being processed almost immediately, in batches of ~1000:

```
$ cargo bench --bench nexmark --features with-nexmark -- --first-event-rate=1000000 --max-events=1000000 --query q0 --cpu-cores 1
...
zs.len() = 1000
zs.len() = 1000
┌───────┬───────────┬───────┬─────────┬─────────────────┬──────────────────┬─────────────┬───────────────┬─────────────┐
│ Query │ #Events   │ Cores │ Time(s) │ Cores * Time(s) │ Throughput/Cores │ User CPU(s) │ System CPU(s) │ Max RSS(Kb) │
├───────┼───────────┼───────┼─────────┼─────────────────┼──────────────────┼─────────────┼───────────────┼─────────────┤
│ q0    │ 1,000,000 │ 1     │ 1.000   │ 1.000           │ 1000.406 K/s     │ 0.393       │ 0.011         │ 41,780      │
└───────┴───────────┴───────┴─────────┴─────────────────┴──────────────────┴─────────────┴───────────────┴─────────────┘

```

The same query with 10 cores results in batches of ~100 for each core:

```
$ cargo bench --bench nexmark --features with-nexmark -- --first-event-rate=1000000 --max-events=1000000 --query q0 --cpu-cores 10
...
zs.len() = 119
zs.len() = 105
zs.len() = 88
┌───────┬───────────┬───────┬─────────┬─────────────────┬──────────────────┬─────────────┬───────────────┬─────────────┐
│ Query │ #Events   │ Cores │ Time(s) │ Cores * Time(s) │ Throughput/Cores │ User CPU(s) │ System CPU(s) │ Max RSS(Kb) │
├───────┼───────────┼───────┼─────────┼─────────────────┼──────────────────┼─────────────┼───────────────┼─────────────┤
│ q0    │ 1,000,000 │ 10    │ 1.000   │ 9.998           │ 100.023 K/s      │ 0.484       │ 0.036         │ 41,876      │
└───────┴───────────┴───────┴─────────┴─────────────────┴──────────────────┴─────────────┴───────────────┴─────────────┘

```

So at only 1M events per second, it's the speed of the source limiting the throughput.

But at 10M events per second and a single CPU core, the stream is processed as a single batch (note the batch size of the output is slightly less than 1M due to duplicate events (bids), afaict), and still processing only at around 1M events per second:

```
$ cargo bench --bench nexmark --features with-nexmark -- --first-event-rate=10000000 --max-events=1000000 --query q0 --cpu-cores 1
...
Starting q0 bench of 1000000 events...
started spawning workers
finished spawning workers in 108.197µs
zs.len() = 998779
┌───────┬───────────┬───────┬─────────┬─────────────────┬──────────────────┬─────────────┬───────────────┬─────────────┐
│ Query │ #Events   │ Cores │ Time(s) │ Cores * Time(s) │ Throughput/Cores │ User CPU(s) │ System CPU(s) │ Max RSS(Kb) │
├───────┼───────────┼───────┼─────────┼─────────────────┼──────────────────┼─────────────┼───────────────┼─────────────┤
│ q0    │ 1,000,000 │ 1     │ 1.036   │ 1.036           │ 965.223 K/s      │ 0.272       │ 0.100         │ 711,704     │
└───────┴───────────┴───────┴─────────┴─────────────────┴──────────────────┴─────────────┴───────────────┴─────────────┘

```

Noticeably, the throughput is slightly degraded and the memory usage has gone up by a facor of ~20. Similarly if I use 10 cores, each core gets a batch of ~100,000 events, for a single clock-tick of the circuit:

```
$ cargo bench --bench nexmark --features with-nexmark -- --first-event-rate=10000000 --max-events=1000000 --query q0 --cpu-cores 10
    Finished bench [optimized + debuginfo] target(s) in 0.12s
     Running benches/nexmark/main.rs (target/release/deps/nexmark-6b95a3287d43cb6c)
Starting q0 bench of 1000000 events...
started spawning workers
finished spawning workers in 457.541µs
zs.len() = 100420
zs.len() = 99706
zs.len() = 99897
zs.len() = 99432
zs.len() = 99997
zs.len() = 100093
zs.len() = 99582
zs.len() = 99616
zs.len() = 99850
zs.len() = 100108
┌───────┬───────────┬───────┬─────────┬─────────────────┬──────────────────┬─────────────┬───────────────┬─────────────┐
│ Query │ #Events   │ Cores │ Time(s) │ Cores * Time(s) │ Throughput/Cores │ User CPU(s) │ System CPU(s) │ Max RSS(Kb) │
├───────┼───────────┼───────┼─────────┼─────────────────┼──────────────────┼─────────────┼───────────────┼─────────────┤
│ q0    │ 1,000,000 │ 10    │ 0.737   │ 7.371           │ 135.660 K/s      │ 0.327       │ 0.148         │ 865,832     │
└───────┴───────────┴───────┴─────────┴─────────────────┴──────────────────┴─────────────┴───────────────┴─────────────┘
``` 

Or using q6 with 10M events/sec and 10M events, it's still taking around 10 seconds for the single core:

```
$ cargo bench --bench nexmark --features with-nexmark -- --first-event-rate=10000000 --max-events=10000000 --query q6 --cpu-cores 1
    Finished bench [optimized + debuginfo] target(s) in 0.12s
     Running benches/nexmark/main.rs (target/release/deps/nexmark-6b95a3287d43cb6c)
Starting q6 bench of 10000000 events...
started spawning workers
finished spawning workers in 108.987µs
zs.len() = 106358
┌───────┬────────────┬───────┬─────────┬─────────────────┬──────────────────┬─────────────┬───────────────┬─────────────┐
│ Query │ #Events    │ Cores │ Time(s) │ Cores * Time(s) │ Throughput/Cores │ User CPU(s) │ System CPU(s) │ Max RSS(Kb) │
├───────┼────────────┼───────┼─────────┼─────────────────┼──────────────────┼─────────────┼───────────────┼─────────────┤
│ q6    │ 10,000,000 │ 1     │ 9.975   │ 9.975           │ 1002.494 K/s     │ 2.710       │ 1.083         │ 4,556,804   │
└───────┴────────────┴───────┴─────────┴─────────────────┴──────────────────┴─────────────┴───────────────┴─────────────┘
```

while with 10 cores it's reduced to around 7 seconds, but again, the complete input split up over the cores to run in a single circuit clock tick:

```
$ cargo bench --bench nexmark --features with-nexmark -- --first-event-rate=10000000 --max-events=10000000 --query q6 --cpu-cores 10
    Finished bench [optimized + debuginfo] target(s) in 0.10s
     Running benches/nexmark/main.rs (target/release/deps/nexmark-6b95a3287d43cb6c)
Starting q6 bench of 10000000 events...
started spawning workers
finished spawning workers in 503.092µs
zs.len() = 10542
zs.len() = 10542
zs.len() = 10604
zs.len() = 10526
zs.len() = 10428
zs.len() = 10709
zs.len() = 10740
zs.len() = 10706
zs.len() = 10716
zs.len() = 10759
┌───────┬────────────┬───────┬─────────┬─────────────────┬──────────────────┬─────────────┬───────────────┬─────────────┐
│ Query │ #Events    │ Cores │ Time(s) │ Cores * Time(s) │ Throughput/Cores │ User CPU(s) │ System CPU(s) │ Max RSS(Kb) │
├───────┼────────────┼───────┼─────────┼─────────────────┼──────────────────┼─────────────┼───────────────┼─────────────┤
│ q6    │ 10,000,000 │ 10    │ 7.347   │ 73.467          │ 136.116 K/s      │ 3.191       │ 1.559         │ 5,656,668   │
└───────┴────────────┴───────┴─────────┴─────────────────┴──────────────────┴─────────────┴───────────────┴─────────────┘
```

More to come.