### PR TITLE
[nexmark] Investigate NexmarkSource speed

### DIFF
--- a/benches/nexmark/main.rs
+++ b/benches/nexmark/main.rs
@@ -81,7 +81,7 @@ fn spawn_dbsp_consumer(
         loop {
             dbsp.step().unwrap();
             count += 1;
-            println!("Step called {count} times");
+            println!("\nStep called {count} times");
 
             // When the input is complete, we do one final step and return.
             if let Ok(()) = input_complete_rx.try_recv() {


### PR DESCRIPTION
Given that we'd found the NexmarkSource event generation was the bottleneck in #156 , I just wanted to try removing the coordination of event generation and consumption, to see what happens when both the consumer (DBSP's `step()`s) and the producer (NexmarkSource iterator) run as fast as they can. That's what this PR does.

But the results surprised me (again). Testing `q1` shows that progress begins with `step()` being called every time `append()` is called, but before 1% of the data is processed, 20,000 events are being `append()`ed for every call to `step()` (ie. the source iterator iterates 20 times). And it gets exponentially worse from there, with the just under 50% of the data added in one `step()` at the end.

```
cargo bench --bench nexmark --features with-nexmark -- --first-event-rate=10000000 --max-events=10000000 --cpu-cores 1 --query q1
   Compiling dbsp v0.1.0 (/home/michael/dev/vmware/database-stream-processor)
    Finished bench [optimized + debuginfo] target(s) in 4.39s
     Running benches/nexmark/main.rs (target/release/deps/nexmark-c782d17920c2b5ef)
Starting q1 bench of 10000000 events...
started spawning workers
finished spawning workers in 94.861µs
2000 / 10000000 [>-------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0.02 % 2050310.52/s 5s 
Step called 1 times
3000 / 10000000 [>-------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0.03 % 1837534.96/s 5s 
Step called 2 times
4000 / 10000000 [>-------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0.04 % 1813326.23/s 6s 
Step called 3 times
5000 / 10000000 [>-------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0.05 % 1879572.77/s 5s 
Step called 4 times
8000 / 10000000 [>-------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0.08 % 1887932.78/s 5s 
Step called 5 times
10000 / 10000000 [>------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0.10 % 1918260.25/s 5s 
Step called 6 times
12000 / 10000000 [>------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0.12 % 1937961.96/s 5s 
Step called 7 times
14000 / 10000000 [>------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0.14 % 1999761.46/s 5s 
Step called 8 times
16000 / 10000000 [>------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0.16 % 2051770.53/s 5s 
Step called 9 times
18000 / 10000000 [>------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0.18 % 2101107.39/s 5s 
Step called 10 times
20000 / 10000000 [>------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0.20 % 2131760.95/s 5s 
Step called 11 times
22000 / 10000000 [>------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0.22 % 2163641.94/s 5s 
Step called 12 times
24000 / 10000000 [>------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0.24 % 2193943.91/s 5s 
Step called 13 times
27000 / 10000000 [>------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0.27 % 2160030.59/s 5s 
Step called 14 times
31000 / 10000000 [>------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0.31 % 2160125.66/s 5s 
Step called 15 times
34000 / 10000000 [>------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0.34 % 2219054.05/s 4s 
Step called 16 times
37000 / 10000000 [>------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0.37 % 2247884.29/s 4s 
Step called 17 times
40000 / 10000000 [>------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0.40 % 2275474.78/s 4s 
Step called 18 times
43000 / 10000000 [>------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0.43 % 2293222.77/s 4s 
Step called 19 times
46000 / 10000000 [>------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0.46 % 2309462.10/s 4s 
Step called 20 times
51000 / 10000000 [>------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0.51 % 2343906.19/s 4s 
Step called 21 times
58000 / 10000000 [>------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0.58 % 2300359.90/s 4s 
Step called 22 times
65000 / 10000000 [=>-----------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0.65 % 2334589.49/s 4s 
Step called 23 times
74000 / 10000000 [=>-----------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0.74 % 2313168.65/s 4s 
Step called 24 times
87000 / 10000000 [=>-----------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0.87 % 2265630.72/s 4s 
Step called 25 times
103000 / 10000000 [=>----------------------------------------------------------------------------------------------------------------------------------------------------------------------] 1.03 % 2296391.25/s 4s 
Step called 26 times
132000 / 10000000 [==>---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 1.32 % 2264488.21/s 4s 
Step called 27 times
174000 / 10000000 [==>---------------------------------------------------------------------------------------------------------------------------------------------------------------------] 1.74 % 2203574.10/s 4s 
Step called 28 times
238000 / 10000000 [===>--------------------------------------------------------------------------------------------------------------------------------------------------------------------] 2.38 % 2229360.53/s 4s 
Step called 29 times
354000 / 10000000 [=====>------------------------------------------------------------------------------------------------------------------------------------------------------------------] 3.54 % 2266881.73/s 4s 
Step called 30 times
525000 / 10000000 [========>---------------------------------------------------------------------------------------------------------------------------------------------------------------] 5.25 % 2051615.70/s 5s 
Step called 31 times
842000 / 10000000 [==============>---------------------------------------------------------------------------------------------------------------------------------------------------------] 8.42 % 2152300.45/s 4s 
Step called 32 times
1447000 / 10000000 [========================>---------------------------------------------------------------------------------------------------------------------------------------------] 14.47 % 2113324.29/s 4s 
Step called 33 times
2686000 / 10000000 [============================================>-------------------------------------------------------------------------------------------------------------------------] 26.86 % 2148585.71/s 3s 
Step called 34 times
5368000 / 10000000 [=========================================================================================>----------------------------------------------------------------------------] 53.68 % 2195015.01/s 2s 
Step called 35 times
Done                                                                                                                                                                                                                
Step called 36 times
Step called 37 times
┌───────┬────────────┬───────┬─────────┬─────────────────┬──────────────────┬───────────────┬───────────────┬──────────────┬──────────────┬─────────────┐
│ Query │ #Events    │ Cores │ Elapsed │ Cores * Elapsed │ Throughput/Cores │ Input Usr CPU │ Input Sys CPU │ DBSP Usr CPU │ DBSP Sys CPU │ Max RSS(Kb) │
├───────┼────────────┼───────┼─────────┼─────────────────┼──────────────────┼───────────────┼───────────────┼──────────────┼──────────────┼─────────────┤
│ q1    │ 10,000,000 │ 1     │ 8.525s  │ 8.525s          │ 1172.987 K/s     │ 3.584s        │ 0.679s        │ 7.135s       │ 1.386s       │ 3,516,120   │
└───────┴────────────┴───────┴─────────┴─────────────────┴──────────────────┴───────────────┴───────────────┴──────────────┴──────────────┴─────────────┘
```
![flame-q1-1-cpu](https://user-images.githubusercontent.com/497518/186341464-bbaa8bc5-b220-463b-aa16-42dbbc77dc1f.png)

I checked that it wasn't something that was fixed in the `upsert_handle` branch by doing a rebase locally on that - similar results (slight improvement, but same effect).

If I run with 2 CPUs for DBSP, it easily consumes the generated data faster than its produced, as expected.

One possibility is that with 1 CPU, DBSP is the bottle-neck, not sure? Anyway, with more than one CPU it's not at all, so still need to work on generating events faster.

This isn't to land, just documenting what I found.