### PR TITLE
Stopped shifting elements during join

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ deepsize_derive = "0.1.2"
 textwrap = "0.15.0"
 fxhash = "0.2"
 ordered-float = "3.0.0"
+
 # TODO: Remove these dependencies
 rand = { version = "0.8", optional = true }
 clap = { version = "3.2", optional = true, features = ["derive", "env"] }

--- a/src/circuit/runtime.rs
+++ b/src/circuit/runtime.rs
@@ -129,9 +129,6 @@ impl Runtime {
     {
         let runtime = Self(Arc::new(RuntimeInner::new(workers)));
 
-        println!("started spawning workers");
-        let start = std::time::Instant::now();
-
         let mut handles = Vec::with_capacity(workers);
         handles.extend((0..workers).map(|worker_index| {
             let runtime = runtime.clone();
@@ -169,9 +166,6 @@ impl Runtime {
             let (unparker, kill_signal) = recv.recv().unwrap();
             WorkerHandle::new(handle, unparker, kill_signal)
         }));
-
-        let elapsed = start.elapsed();
-        println!("finished spawning workers in {elapsed:#?}");
 
         RuntimeHandle::new(runtime, workers)
     }

--- a/src/trace/layers/column_leaf/cursor.rs
+++ b/src/trace/layers/column_leaf/cursor.rs
@@ -1,7 +1,6 @@
 use crate::{
     algebra::{AddAssignByRef, HasZero},
     trace::layers::{advance, column_leaf::OrderedColumnLeaf, Cursor},
-    utils::assume,
 };
 use std::fmt::{self, Display};
 
@@ -89,7 +88,8 @@ where
     #[inline]
     fn key(&self) -> Self::Key<'s> {
         // Elide extra bounds checking
-        unsafe { assume(self.storage.keys.len() == self.storage.diffs.len()) }
+        unsafe { self.storage.assume_invariants() }
+
         if self.pos >= self.storage.keys.len() {
             cursor_position_oob(self.pos, self.storage.keys.len());
         }

--- a/src/trace/layers/column_leaf/mod.rs
+++ b/src/trace/layers/column_leaf/mod.rs
@@ -33,6 +33,16 @@ impl<K, R> OrderedColumnLeaf<K, R> {
     pub fn diffs_mut(&mut self) -> &mut [R] {
         &mut self.diffs
     }
+
+    /// Assume the invariants of the current builder
+    ///
+    /// # Safety
+    ///
+    /// Requires that `keys` and `diffs` have the exact same length
+    #[inline]
+    unsafe fn assume_invariants(&self) {
+        unsafe { assume(self.keys.len() == self.diffs.len()) }
+    }
 }
 
 impl<K, R> Trie for OrderedColumnLeaf<K, R>
@@ -47,19 +57,19 @@ where
 
     #[inline]
     fn keys(&self) -> usize {
-        unsafe { assume(self.keys.len() == self.diffs.len()) }
+        unsafe { self.assume_invariants() }
         self.keys.len()
     }
 
     #[inline]
     fn tuples(&self) -> usize {
-        unsafe { assume(self.keys.len() == self.diffs.len()) }
+        unsafe { self.assume_invariants() }
         self.keys.len()
     }
 
     #[inline]
     fn cursor_from(&self, lower: usize, upper: usize) -> Self::Cursor<'_> {
-        unsafe { assume(self.keys.len() == self.diffs.len()) }
+        unsafe { self.assume_invariants() }
         OrderedColumnLeafCursor::new(lower, self, (lower, upper))
     }
 }

--- a/src/trace/ord/mod.rs
+++ b/src/trace/ord/mod.rs
@@ -22,29 +22,27 @@
 //! Likewise, `OrdIndexedZSet` and `OrdZSet` are less general than `OrdVal` and
 //! `OrdKey` respectively, but are more light-weight.
 
-use crate::trace::spine_fueled::Spine;
+pub mod indexed_zset_batch;
+pub mod key_batch;
+pub mod val_batch;
+pub mod zset_batch;
 
 mod merge_batcher;
 
-pub mod val_batch;
+pub use indexed_zset_batch::OrdIndexedZSet;
+pub use key_batch::OrdKeyBatch;
 pub use val_batch::OrdValBatch;
+pub use zset_batch::OrdZSet;
+
+use crate::trace::spine_fueled::Spine;
 
 /// A trace implementation using a spine of ordered lists.
 pub type OrdValSpine<K, V, T, R, O = usize> = Spine<OrdValBatch<K, V, T, R, O>>;
 
-pub mod key_batch;
-pub use key_batch::OrdKeyBatch;
-
 /// A trace implementation for empty values using a spine of ordered lists.
 pub type OrdKeySpine<K, T, R, O = usize> = Spine<OrdKeyBatch<K, T, R, O>>;
 
-pub mod zset_batch;
-pub use zset_batch::OrdZSet;
-
 /// A trace implementation using a [`Spine`] of [`OrdZSet`].
 pub type OrdZSetSpine<K, R> = Spine<OrdZSet<K, R>>;
-
-pub mod indexed_zset_batch;
-pub use indexed_zset_batch::OrdIndexedZSet;
 
 pub type OrdIndexedZSetSpine<K, V, R, O = usize> = Spine<OrdIndexedZSet<K, V, R, O>>;


### PR DESCRIPTION
Previously we used `.drain()` on a vec to grab elements while joining, but this change switches us to use a `Vec<(T, MaybeUninit<U>)>` where we successively "claim" the `MaybeUninit` elements from the vector, meaning that we can skip out on a lot of unnecessary memcpy calls. Seems to shave off a not-insignificant amount of time from some benchmarks, around 2 seconds from bfs over `datagen-8_4-fb`