### PR TITLE
Pre-shard ldbc inputs and propagate stream sharding where possible

### DIFF
--- a/benches/ldbc-graphalytics/data.rs
+++ b/benches/ldbc-graphalytics/data.rs
@@ -27,7 +27,6 @@ pub type Weight = isize;
 pub type Distance = u64;
 
 pub type VertexSet<D = Present> = OrdZSet<Node, D>;
-pub type RankSet = OrdZSet<(Node, Rank), Weight>;
 pub type RankMap = OrdIndexedZSet<Node, Rank, Weight>;
 pub type EdgeMap<D = Present> = OrdIndexedZSet<Node, Node, D>;
 pub type DistanceSet<D = Present> = OrdZSet<(Node, Distance), D>;
@@ -35,9 +34,8 @@ pub type DistanceMap<D = Present> = OrdIndexedZSet<Node, Distance, D>;
 
 pub type Streamed<P, T> = Stream<Circuit<P>, T>;
 
+pub type Ranks<P> = Streamed<P, RankMap>;
 pub type Edges<P, D = Present> = Streamed<P, EdgeMap<D>>;
-pub type Ranks<P> = Streamed<P, RankSet>;
-pub type RankPairs<P> = Streamed<P, RankMap>;
 pub type Vertices<P, D = Present> = Streamed<P, VertexSet<D>>;
 
 type LoadedDataset<R> = (
@@ -644,7 +642,7 @@ impl EdgeParser {
 
             self.parse(|src, dest| {
                 forward_batches[fxhash::hash(&src) % workers].push(((src, dest), Present));
-                reverse_batches[fxhash::hash(&src) % workers].push(((dest, src), Present));
+                reverse_batches[fxhash::hash(&dest) % workers].push(((dest, src), Present));
             });
 
             forward_batches

--- a/src/circuit/cache.rs
+++ b/src/circuit/cache.rs
@@ -57,34 +57,34 @@ pub type CircuitCache = TypedMap<CircuitStoreMarker>;
 /// `Stream<C, D>`.
 #[macro_export]
 macro_rules! circuit_cache_key {
-    ($constructor:ident<$($typearg:ident),*>($key_type:ty => $val_type:ty)) => {
+    ($constructor:ident$(<$($typearg:ident),*>)?($key_type:ty => $val_type:ty)) => {
         #[repr(transparent)]
-        pub struct $constructor<$($typearg: 'static),*>(pub $key_type, std::marker::PhantomData<($($typearg),*)>);
+        pub struct $constructor$(<$($typearg: 'static),*>)?(pub $key_type, $(std::marker::PhantomData<($($typearg),*)>)?);
 
-        impl<$($typearg),*> $constructor<$($typearg),*> {
+        impl$(<$($typearg),*>)? $constructor$(<$($typearg),*>)? {
             pub fn new(key: $key_type) -> Self {
-                Self(key, std::marker::PhantomData)
+                Self(key, $(std::marker::PhantomData::<($($typearg),*)>)?)
             }
         }
 
-        impl<$($typearg),*> std::hash::Hash for $constructor<$($typearg),*> {
+        impl$(<$($typearg),*>)? std::hash::Hash for $constructor$(<$($typearg),*>)? {
             fn hash<H>(&self, state: &mut H)
             where
-                H: std::hash::Hasher
+                H: std::hash::Hasher,
             {
                 self.0.hash(state);
             }
         }
 
-        impl<$($typearg),*> PartialEq for $constructor<$($typearg),*> {
+        impl$(<$($typearg),*>)? PartialEq for $constructor$(<$($typearg),*>)? {
             fn eq(&self, other: &Self) -> bool {
                 self.0.eq(&other.0)
             }
         }
 
-        impl<$($typearg),*> Eq for $constructor<$($typearg),*> {}
+        impl$(<$($typearg),*>)? Eq for $constructor$(<$($typearg),*>)? {}
 
-        impl<$($typearg: 'static),*> typedmap::TypedMapKey<$crate::circuit::cache::CircuitStoreMarker> for $constructor<$($typearg),*> {
+        impl$(<$($typearg: 'static),*>)? typedmap::TypedMapKey<$crate::circuit::cache::CircuitStoreMarker> for $constructor$(<$($typearg),*>)? {
             type Value = $val_type;
         }
     }

--- a/src/circuit/circuit_builder.rs
+++ b/src/circuit/circuit_builder.rs
@@ -34,6 +34,7 @@ use std::{
     fmt::{Debug, Display, Write},
     iter::repeat,
     marker::PhantomData,
+    panic::Location,
     rc::Rc,
 };
 
@@ -1092,11 +1093,12 @@ where
     /// of the circuit.  This function creates a new region and executes
     /// closure `f` inside it.  Any operators or subcircuits created by
     /// `f` will belong to the new region.
+    #[track_caller]
     pub fn region<F, T>(&self, name: &str, f: F) -> T
     where
         F: FnOnce() -> T,
     {
-        self.log_circuit_event(&CircuitEvent::push_region(name));
+        self.log_circuit_event(&CircuitEvent::push_region(name, Some(Location::caller())));
         let res = f();
         self.log_circuit_event(&CircuitEvent::pop_region());
         res
@@ -1112,7 +1114,9 @@ where
             self.log_circuit_event(&CircuitEvent::operator(
                 GlobalNodeId::child_of(self, id),
                 operator.name(),
+                operator.location(),
             ));
+
             let node = SourceNode::new(operator, self.clone(), id);
             let output_stream = node.output_stream();
             (node, output_stream)
@@ -1181,7 +1185,9 @@ where
             self.log_circuit_event(&CircuitEvent::operator(
                 GlobalNodeId::child_of(self, id),
                 sender.name(),
+                sender.location(),
             ));
+
             let node = SinkNode::new(sender, input_stream.clone(), self.clone(), id);
             self.connect_stream(input_stream, id, input_preference);
             (node, id)
@@ -1191,7 +1197,9 @@ where
             self.log_circuit_event(&CircuitEvent::operator(
                 GlobalNodeId::child_of(self, id),
                 receiver.name(),
+                receiver.location(),
             ));
+
             let node = SourceNode::new(receiver, self.clone(), id);
             let output_stream = node.output_stream();
             (node, output_stream)
@@ -1228,6 +1236,7 @@ where
             self.log_circuit_event(&CircuitEvent::operator(
                 GlobalNodeId::child_of(self, id),
                 operator.name(),
+                operator.location(),
             ));
 
             self.connect_stream(input_stream, id, input_preference);
@@ -1270,6 +1279,7 @@ where
             self.log_circuit_event(&CircuitEvent::operator(
                 GlobalNodeId::child_of(self, id),
                 operator.name(),
+                operator.location(),
             ));
 
             let node = UnaryNode::new(operator, input_stream.clone(), self.clone(), id);
@@ -1323,6 +1333,7 @@ where
             self.log_circuit_event(&CircuitEvent::operator(
                 GlobalNodeId::child_of(self, id),
                 operator.name(),
+                operator.location(),
             ));
 
             let node = BinaryNode::new(
@@ -1390,6 +1401,7 @@ where
             self.log_circuit_event(&CircuitEvent::operator(
                 GlobalNodeId::child_of(self, id),
                 operator.name(),
+                operator.location(),
             ));
 
             let node = TernaryNode::new(
@@ -1443,6 +1455,7 @@ where
             self.log_circuit_event(&CircuitEvent::operator(
                 GlobalNodeId::child_of(self, id),
                 operator.name(),
+                operator.location(),
             ));
 
             let node = NaryNode::new(
@@ -1545,6 +1558,7 @@ where
             self.log_circuit_event(&CircuitEvent::strict_operator_output(
                 GlobalNodeId::child_of(self, id),
                 operator.name(),
+                operator.location(),
             ));
 
             let operator = Rc::new(UnsafeCell::new(operator));
@@ -1844,6 +1858,7 @@ where
             self.log_circuit_event(&CircuitEvent::operator(
                 GlobalNodeId::child_of(self, id),
                 operator.name(),
+                operator.location(),
             ));
             let node = ImportNode::new(operator, self.clone(), parent_stream.clone(), id);
             self.parent()

--- a/src/circuit/circuit_builder.rs
+++ b/src/circuit/circuit_builder.rs
@@ -501,13 +501,20 @@ impl OwnershipPreference {
     }
 }
 
+impl Default for OwnershipPreference {
+    #[inline]
+    fn default() -> Self {
+        Self::INDIFFERENT
+    }
+}
+
 impl Display for OwnershipPreference {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Self::INDIFFERENT => f.write_str("Indifferent"),
             Self::PREFER_OWNED => f.write_str("PreferOwned"),
             Self::STRONGLY_PREFER_OWNED => f.write_str("StronglyPreferOwned"),
-            _ => write!(f, "Preference({})", self.raw()),
+            Self(preference) => write!(f, "Preference({preference})"),
         }
     }
 }
@@ -1024,9 +1031,24 @@ where
     /// See [`cache`] module documentation for details.
     pub(crate) fn cache_insert<K>(&self, key: K, val: K::Value)
     where
-        K: 'static + TypedMapKey<CircuitStoreMarker>,
+        K: TypedMapKey<CircuitStoreMarker> + 'static,
     {
         self.inner_mut().store.insert(key, val);
+    }
+
+    pub(crate) fn cache_contains<K>(&self, key: &K) -> bool
+    where
+        K: TypedMapKey<CircuitStoreMarker> + 'static,
+    {
+        self.inner_mut().store.contains_key(key)
+    }
+
+    pub(crate) fn cache_get<K>(&self, key: &K) -> Option<K::Value>
+    where
+        K: TypedMapKey<CircuitStoreMarker> + 'static,
+        K::Value: Clone,
+    {
+        self.inner_mut().store.get(key).cloned()
     }
 
     pub(crate) fn register_ready_callback(&self, id: NodeId, cb: Box<dyn Fn() + Send + Sync>) {

--- a/src/circuit/operator_traits.rs
+++ b/src/circuit/operator_traits.rs
@@ -4,7 +4,7 @@
 //! consumes one or more input streams and produces an output stream.
 
 use crate::circuit::{OwnershipPreference, Scope};
-use std::borrow::Cow;
+use std::{borrow::Cow, panic::Location};
 
 /// Minimal requirements for values exchanged by operators.
 pub trait Data: Clone + 'static {}
@@ -15,6 +15,11 @@ impl<T: Clone + 'static> Data for T {}
 pub trait Operator: 'static {
     /// Human-readable operator name for debugging purposes.
     fn name(&self) -> Cow<'static, str>;
+
+    /// The location the operator was created at
+    fn location(&self) -> Option<&'static Location<'static>> {
+        None
+    }
 
     /// Notify the operator about the start of a new clock epoch.
     ///

--- a/src/nexmark/queries/q6.rs
+++ b/src/nexmark/queries/q6.rs
@@ -200,7 +200,7 @@ mod tests {
         })
         .unwrap();
 
-        for mut vec in input_vecs.into_iter() {
+        for mut vec in input_vecs {
             input_handle.append(&mut vec);
             circuit.step().unwrap();
         }
@@ -274,7 +274,7 @@ mod tests {
         })
         .unwrap();
 
-        for mut vec in input_vecs.into_iter() {
+        for mut vec in input_vecs {
             input_handle.append(&mut vec);
             circuit.step().unwrap();
         }
@@ -516,7 +516,7 @@ mod tests {
         })
         .unwrap();
 
-        for mut vec in input_vecs.into_iter() {
+        for mut vec in input_vecs {
             input_handle.append(&mut vec);
             circuit.step().unwrap();
         }
@@ -634,7 +634,7 @@ mod tests {
         })
         .unwrap();
 
-        for mut vec in input_vecs.into_iter() {
+        for mut vec in input_vecs {
             input_handle.append(&mut vec);
             circuit.step().unwrap();
         }

--- a/src/operator/aggregate/mod.rs
+++ b/src/operator/aggregate/mod.rs
@@ -316,9 +316,7 @@ where
             delta.done()
         });
 
-        if self.has_sharded_version() {
-            output.mark_sharded();
-        }
+        output.mark_sharded_if(self);
         output
     }
 }

--- a/src/operator/communication/shard.rs
+++ b/src/operator/communication/shard.rs
@@ -263,6 +263,7 @@ where
         self.clone()
     }
 
+    /// Returns `true` if a sharded version of the current stream exists
     pub fn has_sharded_version(&self) -> bool {
         self.circuit()
             .cache_contains(&ShardId::<Circuit<P>, T>::new((
@@ -281,6 +282,17 @@ where
                 sharding_policy(self.circuit()),
             )))
             .unwrap_or_else(|| self.clone())
+    }
+
+    /// Marks `self` as sharded if `input` has a sharded version of itself
+    pub fn mark_sharded_if<P2, U>(&self, input: &Stream<Circuit<P2>, U>)
+    where
+        P2: Clone + 'static,
+        U: 'static,
+    {
+        if input.has_sharded_version() {
+            self.mark_sharded();
+        }
     }
 }
 

--- a/src/operator/communication/shard.rs
+++ b/src/operator/communication/shard.rs
@@ -271,6 +271,9 @@ where
             )))
     }
 
+    /// Returns the sharded version of the stream if it exists
+    /// (which may be the stream itself or the result of applying
+    /// the `shard` operator to it).  Otherwise, returns `self`.
     pub fn try_sharded_version(&self) -> Self {
         self.circuit()
             .cache_get(&ShardId::new((

--- a/src/operator/consolidate.rs
+++ b/src/operator/consolidate.rs
@@ -38,10 +38,7 @@ where
                     &self.try_sharded_version(),
                     OwnershipPreference::STRONGLY_PREFER_OWNED,
                 );
-
-                if self.has_sharded_version() {
-                    consolidated.mark_sharded();
-                }
+                consolidated.mark_sharded_if(self);
 
                 consolidated
             })

--- a/src/operator/delta0.rs
+++ b/src/operator/delta0.rs
@@ -88,6 +88,7 @@ where
     fn name(&self) -> Cow<'static, str> {
         Cow::from("delta0")
     }
+
     fn fixedpoint(&self, scope: Scope) -> bool {
         if scope == 0 {
             // Output becomes stable (all zeros) after the first clock cycle.
@@ -107,6 +108,7 @@ where
         self.val = Some(val.clone());
         self.fixedpoint = false;
     }
+
     fn import_owned(&mut self, val: D) {
         self.val = Some(val);
         self.fixedpoint = false;

--- a/src/operator/delta0.rs
+++ b/src/operator/delta0.rs
@@ -31,10 +31,15 @@ where
     /// preference on the input stream with `input_preference`.
     pub fn delta0_with_preference(
         &self,
-        circuit: &Circuit<Circuit<P>>,
+        subcircuit: &Circuit<Circuit<P>>,
         input_preference: OwnershipPreference,
     ) -> Stream<Circuit<Circuit<P>>, D> {
-        let delta = circuit.import_stream_with_preference(Delta0::new(), self, input_preference);
+        let delta = subcircuit.import_stream_with_preference(
+            Delta0::new(),
+            &self.try_sharded_version(),
+            input_preference,
+        );
+
         if self.has_sharded_version() {
             delta.mark_sharded();
         }

--- a/src/operator/delta0.rs
+++ b/src/operator/delta0.rs
@@ -20,9 +20,7 @@ where
     /// See [`Delta0`] operator documentation.
     pub fn delta0(&self, subcircuit: &Circuit<Circuit<P>>) -> Stream<Circuit<Circuit<P>>, D> {
         let delta = subcircuit.import_stream(Delta0::new(), &self.try_sharded_version());
-        if self.has_sharded_version() {
-            delta.mark_sharded();
-        }
+        delta.mark_sharded_if(self);
 
         delta
     }
@@ -39,10 +37,7 @@ where
             &self.try_sharded_version(),
             input_preference,
         );
-
-        if self.has_sharded_version() {
-            delta.mark_sharded();
-        }
+        delta.mark_sharded_if(self);
 
         delta
     }

--- a/src/operator/delta0.rs
+++ b/src/operator/delta0.rs
@@ -19,7 +19,12 @@ where
     ///
     /// See [`Delta0`] operator documentation.
     pub fn delta0(&self, subcircuit: &Circuit<Circuit<P>>) -> Stream<Circuit<Circuit<P>>, D> {
-        subcircuit.import_stream(Delta0::new(), self)
+        let delta = subcircuit.import_stream(Delta0::new(), &self.try_sharded_version());
+        if self.has_sharded_version() {
+            delta.mark_sharded();
+        }
+
+        delta
     }
 
     /// Like [`Self::delta0`], but overrides the ownership
@@ -29,7 +34,12 @@ where
         circuit: &Circuit<Circuit<P>>,
         input_preference: OwnershipPreference,
     ) -> Stream<Circuit<Circuit<P>>, D> {
-        circuit.import_stream_with_preference(Delta0::new(), self, input_preference)
+        let delta = circuit.import_stream_with_preference(Delta0::new(), self, input_preference);
+        if self.has_sharded_version() {
+            delta.mark_sharded();
+        }
+
+        delta
     }
 }
 

--- a/src/operator/differentiate.rs
+++ b/src/operator/differentiate.rs
@@ -24,8 +24,17 @@ where
     pub fn differentiate(&self) -> Stream<Circuit<P>, D> {
         self.circuit()
             .cache_get_or_insert_with(DifferentiateId::new(self.origin_node_id().clone()), || {
-                self.circuit()
-                    .add_binary_operator(Minus::new(), self, &self.delay())
+                let differentiated = self.circuit().add_binary_operator(
+                    Minus::new(),
+                    &self.try_sharded_version(),
+                    &self.try_sharded_version().delay(),
+                );
+
+                if self.has_sharded_version() {
+                    differentiated.mark_sharded();
+                }
+
+                differentiated
             })
             .clone()
     }
@@ -36,8 +45,17 @@ where
             .cache_get_or_insert_with(
                 NestedDifferentiateId::new(self.origin_node_id().clone()),
                 || {
-                    self.circuit()
-                        .add_binary_operator(Minus::new(), self, &self.delay_nested())
+                    let differentiated = self.circuit().add_binary_operator(
+                        Minus::new(),
+                        &self.try_sharded_version(),
+                        &self.try_sharded_version().delay_nested(),
+                    );
+
+                    if self.has_sharded_version() {
+                        differentiated.mark_sharded();
+                    }
+
+                    differentiated
                 },
             )
             .clone()

--- a/src/operator/differentiate.rs
+++ b/src/operator/differentiate.rs
@@ -29,11 +29,7 @@ where
                     &self.try_sharded_version(),
                     &self.try_sharded_version().delay(),
                 );
-
-                if self.has_sharded_version() {
-                    differentiated.mark_sharded();
-                }
-
+                differentiated.mark_sharded_if(self);
                 differentiated
             })
             .clone()
@@ -50,11 +46,7 @@ where
                         &self.try_sharded_version(),
                         &self.try_sharded_version().delay_nested(),
                     );
-
-                    if self.has_sharded_version() {
-                        differentiated.mark_sharded();
-                    }
-
+                    differentiated.mark_sharded_if(self);
                     differentiated
                 },
             )

--- a/src/operator/filter_map.rs
+++ b/src/operator/filter_map.rs
@@ -168,8 +168,15 @@ where
     where
         F: Fn(Self::ItemRef<'_>) -> bool + 'static,
     {
-        self.circuit()
-            .add_unary_operator(FilterKeys::new(filter_func), self)
+        let filtered = self
+            .circuit()
+            .add_unary_operator(FilterKeys::new(filter_func), &self.try_sharded_version());
+
+        if self.has_sharded_version() {
+            filtered.mark_sharded();
+        }
+
+        filtered
     }
 
     fn map_generic<F, T, O>(&self, map_func: F) -> Stream<Circuit<P>, O>
@@ -236,8 +243,15 @@ where
     where
         F: Fn(Self::ItemRef<'_>) -> bool + 'static,
     {
-        self.circuit()
-            .add_unary_operator(FilterVals::new(filter_func), self)
+        let filtered = self
+            .circuit()
+            .add_unary_operator(FilterVals::new(filter_func), &self.try_sharded_version());
+
+        if self.has_sharded_version() {
+            filtered.mark_sharded();
+        }
+
+        filtered
     }
 
     fn map_generic<F, T, O>(&self, map_func: F) -> Stream<Circuit<P>, O>

--- a/src/operator/filter_map.rs
+++ b/src/operator/filter_map.rs
@@ -171,11 +171,7 @@ where
         let filtered = self
             .circuit()
             .add_unary_operator(FilterKeys::new(filter_func), &self.try_sharded_version());
-
-        if self.has_sharded_version() {
-            filtered.mark_sharded();
-        }
-
+        filtered.mark_sharded_if(self);
         filtered
     }
 
@@ -246,11 +242,7 @@ where
         let filtered = self
             .circuit()
             .add_unary_operator(FilterVals::new(filter_func), &self.try_sharded_version());
-
-        if self.has_sharded_version() {
-            filtered.mark_sharded();
-        }
-
+        filtered.mark_sharded_if(self);
         filtered
     }
 

--- a/src/operator/inspect.rs
+++ b/src/operator/inspect.rs
@@ -40,11 +40,7 @@ where
         let inspected = self
             .circuit()
             .add_unary_operator(Inspect::new(callback), &self.try_sharded_version());
-
-        if self.has_sharded_version() {
-            inspected.mark_sharded();
-        }
-
+        inspected.mark_sharded_if(self);
         inspected
     }
 }

--- a/src/operator/inspect.rs
+++ b/src/operator/inspect.rs
@@ -37,8 +37,15 @@ where
     where
         F: FnMut(&D) + 'static,
     {
-        self.circuit()
-            .add_unary_operator(Inspect::new(callback), self)
+        let inspected = self
+            .circuit()
+            .add_unary_operator(Inspect::new(callback), &self.try_sharded_version());
+
+        if self.has_sharded_version() {
+            inspected.mark_sharded();
+        }
+
+        inspected
     }
 }
 

--- a/src/operator/neg.rs
+++ b/src/operator/neg.rs
@@ -20,10 +20,7 @@ where
             .add_unary_operator(UnaryMinus::new(), &self.try_sharded_version());
 
         // If the input stream is sharded then the negated stream is sharded
-        if self.has_sharded_version() {
-            negated.mark_sharded();
-        }
-
+        negated.mark_sharded_if(self);
         negated
     }
 }

--- a/src/operator/plus.rs
+++ b/src/operator/plus.rs
@@ -53,7 +53,19 @@ where
     /// # }
     /// ```
     pub fn plus(&self, other: &Stream<Circuit<P>, D>) -> Stream<Circuit<P>, D> {
-        self.circuit().add_binary_operator(Plus::new(), self, other)
+        // If both inputs are properly sharded then the sum of those inputs will be
+        // sharded
+        if self.has_sharded_version() && other.has_sharded_version() {
+            self.circuit()
+                .add_binary_operator(
+                    Plus::new(),
+                    &self.try_sharded_version(),
+                    &other.try_sharded_version(),
+                )
+                .mark_sharded()
+        } else {
+            self.circuit().add_binary_operator(Plus::new(), self, other)
+        }
     }
 }
 
@@ -64,8 +76,20 @@ where
 {
     /// Apply the [`Minus`] operator to `self` and `other`.
     pub fn minus(&self, other: &Stream<Circuit<P>, D>) -> Stream<Circuit<P>, D> {
-        self.circuit()
-            .add_binary_operator(Minus::new(), self, other)
+        // If both inputs are properly sharded then the difference of those inputs will
+        // be sharded
+        if self.has_sharded_version() && other.has_sharded_version() {
+            self.circuit()
+                .add_binary_operator(
+                    Minus::new(),
+                    &self.try_sharded_version(),
+                    &other.try_sharded_version(),
+                )
+                .mark_sharded()
+        } else {
+            self.circuit()
+                .add_binary_operator(Minus::new(), self, other)
+        }
     }
 }
 

--- a/src/operator/trace.rs
+++ b/src/operator/trace.rs
@@ -98,6 +98,7 @@ where
     }
 
     // TODO: this method should replace `Stream::integrate()`.
+    #[track_caller]
     pub fn integrate_trace(&self) -> Stream<Circuit<P>, Spine<B>>
     where
         B: Batch + DeepSizeOf,


### PR DESCRIPTION
This PR shards graphalytics inputs at load time and provides the facilities for operators to propagate sharding information.  
For example, the `.semijoin()` operator shards both of its inputs before performing a join on their keys, but then it outputs the result stream without mutating its keys any, meaning that the output streams are already sharded. With the `.mark_sharded()` and `.is_sharded()` methods we can check if an input stream has been sharded and then conditionally mark the produced output as also being sharded, allowing us to potentially remove a lot of sync points from within our dataflow graph