### PR TITLE
Shard input Z-sets in the context of workers.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,5 +26,5 @@ pub use time::Timestamp;
 pub use circuit::{
     Circuit, CircuitHandle, DBSPHandle, Runtime, RuntimeError, SchedulerError, Stream,
 };
-pub use operator::{CollectionHandle, InputHandle};
+pub use operator::{CollectionHandle, InputHandle, UpsertHandle};
 pub use trace::ord::{OrdIndexedZSet, OrdZSet};

--- a/src/operator/mod.rs
+++ b/src/operator/mod.rs
@@ -42,7 +42,7 @@ pub use distinct::Distinct;
 pub use filter_map::{FilterKeys, FilterMap, FilterVals, FlatMap, Map, MapKeys};
 pub use generator::{Generator, GeneratorNested};
 pub use index::Index;
-pub use input::{CollectionHandle, InputHandle};
+pub use input::{CollectionHandle, InputHandle, UpsertHandle};
 pub use inspect::Inspect;
 pub use join::Join;
 pub use join_range::StreamJoinRange;


### PR DESCRIPTION
Our initial implementation of `CollectionHandle` partitioned input
records across workers based on the hash of the key.  The Nexmark
benchmark taught us that doing this sequentially (in the client
thread) can become a performance bottleneck.  We therefore change
the `CollectionHandle` implementation to split records across workers
using round robin scheduling, which ensures even distribution, but
does not guarantee that all updates for the same key are sent to the
same worker; hence workers may need to re-partition the inputs,
which is more efficient than doing it in the client thread,
as work will be evenly split across workers.

Round robin does not work for upserts, which must be processed in
the same order they were submitted by the client.  We therefore
introduce a new type of input handle, `UpsertHandle`, which
consistently maps keys to workers.