### PR TITLE
Code cleanup

### DIFF
--- a/benches/ldbc-graphalytics/bfs.rs
+++ b/benches/ldbc-graphalytics/bfs.rs
@@ -25,8 +25,6 @@ where
     P: Clone + 'static,
     Distances<Circuit<P>>: RecursiveStreams<Circuit<Circuit<P>>, Output = Distances<P>>,
 {
-    let (vertices, edges) = (vertices.mark_sharded(), edges.mark_sharded());
-
     // Initialize the roots to have a distance of zero
     let roots = roots
         .apply(|roots| {

--- a/benches/ldbc-graphalytics/data.rs
+++ b/benches/ldbc-graphalytics/data.rs
@@ -649,7 +649,7 @@ impl EdgeParser {
                 .into_iter()
                 .zip(reverse_batches)
                 .map(|(mut forward, mut reverse)| {
-                    let mut edges = <EdgeMap as Batch>::Batcher::new(());
+                    let mut edges = <EdgeMap as Batch>::Batcher::new_batcher(());
                     edges.push_consolidated_batch(&mut forward);
                     edges.push_batch(&mut reverse);
                     edges.seal()

--- a/src/algebra/zset/zset_macro.rs
+++ b/src/algebra/zset/zset_macro.rs
@@ -6,7 +6,7 @@
 #[macro_export]
 macro_rules! indexed_zset {
     ( $($key:expr => { $($value:expr => $weight:expr),* }),* $(,)?) => {{
-        let mut batcher = <<$crate::trace::ord::OrdIndexedZSet<_, _, _> as $crate::trace::Batch>::Batcher as $crate::trace::Batcher<_, _, _, _>>::new(());
+        let mut batcher = <<$crate::trace::ord::OrdIndexedZSet<_, _, _> as $crate::trace::Batch>::Batcher as $crate::trace::Batcher<_, _, _, _>>::new_batcher(());
         let mut batch = ::std::vec![ $( $( (($key, $value), $weight) ),* ),* ];
         $crate::trace::Batcher::push_batch(&mut batcher, &mut batch);
         $crate::trace::Batcher::seal(batcher)
@@ -20,7 +20,7 @@ macro_rules! indexed_zset {
 #[macro_export]
 macro_rules! zset {
     ( $( $key:expr => $weight:expr ),* $(,)?) => {{
-        let mut batcher = <<$crate::trace::ord::OrdZSet<_, _> as $crate::trace::Batch>::Batcher as $crate::trace::Batcher<_, _, _, _>>::new(());
+        let mut batcher = <<$crate::trace::ord::OrdZSet<_, _> as $crate::trace::Batch>::Batcher as $crate::trace::Batcher<_, _, _, _>>::new_batcher(());
 
         let mut batch = ::std::vec![ $( ($key, $weight) ),* ];
         $crate::trace::Batcher::push_batch(&mut batcher, &mut batch);
@@ -35,7 +35,7 @@ macro_rules! zset {
 #[macro_export]
 macro_rules! zset_set {
     ( $( $key:expr ),* $(,)?) => {{
-        let mut batcher = <<$crate::trace::ord::OrdZSet<_, _> as $crate::trace::Batch>::Batcher as $crate::trace::Batcher<_, _, _, _>>::new(());
+        let mut batcher = <<$crate::trace::ord::OrdZSet<_, _> as $crate::trace::Batch>::Batcher as $crate::trace::Batcher<_, _, _, _>>::new_batcher(());
 
         let mut batch = ::std::vec![ $( ($key, 1) ),* ];
         $crate::trace::Batcher::push_batch(&mut batcher, &mut batch);

--- a/src/operator/aggregate/mod.rs
+++ b/src/operator/aggregate/mod.rs
@@ -445,7 +445,7 @@ where
     pub fn new(aggregator: A) -> Self {
         Self {
             aggregator,
-            time: IT::Time::clock_start(),
+            time: <IT::Time as Timestamp>::clock_start(),
             empty_input: false,
             empty_output: false,
             keys_of_interest: BTreeMap::new(),

--- a/src/operator/communication/exchange.rs
+++ b/src/operator/communication/exchange.rs
@@ -164,6 +164,7 @@ where
     /// Fails if at least one of the sender's outgoing mailboxes is not empty.
     ///
     /// # Panics
+    ///
     /// Panics if `data` yields fewer than `self.npeers` items.
     pub(crate) fn try_send_all<I>(&self, sender: usize, data: &mut I) -> bool
     where
@@ -374,6 +375,7 @@ where
 ///         let (sender, receiver) = circuit.new_exchange_operators(
 ///             &Runtime::runtime().unwrap(),
 ///             Runtime::worker_index(),
+///             None,
 ///             // Partitioning function sends a copy of the input `n` to each peer.
 ///             |n, output| {
 ///                 for _ in 0..WORKERS {

--- a/src/operator/communication/shard.rs
+++ b/src/operator/communication/shard.rs
@@ -215,7 +215,7 @@ where
     // Partitions the batch into `nshards` partitions based on the hash of the key.
     fn shard_batch<OB>(
         batch: &IB,
-        nshards: usize,
+        shards: usize,
         builders: &mut Vec<OB::Builder>,
         outputs: &mut Vec<OB>,
     ) where
@@ -223,17 +223,17 @@ where
     {
         builders.clear();
 
-        for _ in 0..nshards {
+        for _ in 0..shards {
             // We iterate over tuples in the batch in order; hence tuples added
             // to each shard are also ordered, so we can use the more efficient
             // `Builder` API (instead of `Batcher`) to construct output batches.
-            builders.push(OB::Builder::with_capacity((), batch.len() / nshards));
+            builders.push(OB::Builder::with_capacity((), batch.len() / shards));
         }
 
         let mut cursor = batch.cursor();
 
         while cursor.key_valid() {
-            let batch_index = fxhash::hash(cursor.key()) % nshards;
+            let batch_index = fxhash::hash(cursor.key()) % shards;
             while cursor.val_valid() {
                 builders[batch_index].push((
                     OB::item_from(cursor.key().clone(), cursor.val().clone()),

--- a/src/operator/distinct.rs
+++ b/src/operator/distinct.rs
@@ -1,15 +1,5 @@
 //! Distinct operator.
 
-use std::{
-    borrow::Cow,
-    cmp::{max, Ordering},
-    collections::BTreeSet,
-    fmt::Write,
-    hash::Hash,
-    marker::PhantomData,
-    mem::take,
-    ops::{Add, Neg},
-};
 use crate::{
     algebra::{AddAssignByRef, AddByRef, HasOne, HasZero, ZRingValue, ZSet},
     circuit::{
@@ -22,6 +12,16 @@ use crate::{
     NumEntries, Timestamp,
 };
 use deepsize::DeepSizeOf;
+use std::{
+    borrow::Cow,
+    cmp::{max, Ordering},
+    collections::BTreeSet,
+    fmt::Write,
+    hash::Hash,
+    marker::PhantomData,
+    mem::take,
+    ops::{Add, Neg},
+};
 
 circuit_cache_key!(DistinctId<C, D>(GlobalNodeId => Stream<C, D>));
 circuit_cache_key!(DistinctIncrementalId<C, D>(GlobalNodeId => Stream<C, D>));

--- a/src/operator/distinct.rs
+++ b/src/operator/distinct.rs
@@ -10,7 +10,6 @@ use std::{
     mem::take,
     ops::{Add, Neg},
 };
-
 use crate::{
     algebra::{AddAssignByRef, AddByRef, HasOne, HasZero, ZRingValue, ZSet},
     circuit::{

--- a/src/operator/join.rs
+++ b/src/operator/join.rs
@@ -665,7 +665,7 @@ where
 
             self.output_batchers
                 .entry(batch_time)
-                .or_insert_with(|| Z::Batcher::new(()))
+                .or_insert_with(|| Z::Batcher::new_batcher(()))
                 .push_batch(&mut batch);
             batch.clear();
         }
@@ -674,7 +674,7 @@ where
         let batcher = self
             .output_batchers
             .remove(&self.time)
-            .unwrap_or_else(|| Z::Batcher::new(()));
+            .unwrap_or_else(|| Z::Batcher::new_batcher(()));
         self.time = self.time.advance(0);
         let result = batcher.seal();
         //println!("JoinTrace output:\n{}", result);

--- a/src/operator/join.rs
+++ b/src/operator/join.rs
@@ -461,7 +461,7 @@ where
         Self {
             join_func,
             location,
-            time: T::Time::clock_start(),
+            time: <T::Time as Timestamp>::clock_start(),
             output_batchers: HashMap::new(),
             empty_input: false,
             empty_output: false,

--- a/src/operator/mod.rs
+++ b/src/operator/mod.rs
@@ -5,7 +5,6 @@ pub mod communication;
 pub mod recursive;
 
 pub(crate) mod apply;
-mod input;
 pub(crate) mod inspect;
 pub(crate) mod upsert;
 
@@ -20,6 +19,7 @@ mod distinct;
 mod filter_map;
 mod generator;
 mod index;
+mod input;
 mod integrate;
 mod join;
 mod join_range;

--- a/src/trace/cursor/mod.rs
+++ b/src/trace/cursor/mod.rs
@@ -124,9 +124,7 @@ pub trait CursorDebug<'s, K: Clone, V: Clone, T: Clone, R: Clone>: Cursor<'s, K,
         while self.key_valid() {
             while self.val_valid() {
                 let mut kv_out = Vec::new();
-                self.map_times(|ts, r| {
-                    kv_out.push((ts.clone(), r.clone()));
-                });
+                self.map_times(|ts, r| kv_out.push((ts.clone(), r.clone())));
                 out.push(((self.key().clone(), self.val().clone()), kv_out));
                 self.step_val();
             }

--- a/src/trace/layers/column_leaf/mod.rs
+++ b/src/trace/layers/column_leaf/mod.rs
@@ -28,6 +28,13 @@ pub struct OrderedColumnLeaf<K, R> {
 }
 
 impl<K, R> OrderedColumnLeaf<K, R> {
+    pub const fn empty() -> Self {
+        Self {
+            keys: Vec::new(),
+            diffs: Vec::new(),
+        }
+    }
+
     #[inline]
     #[doc(hidden)]
     pub fn diffs_mut(&mut self) -> &mut [R] {

--- a/src/trace/layers/column_leaf/mod.rs
+++ b/src/trace/layers/column_leaf/mod.rs
@@ -20,7 +20,7 @@ use std::{
 };
 
 /// A layer of unordered values.
-#[derive(Debug, Clone, Eq, PartialEq, Default, DeepSizeOf)]
+#[derive(Debug, Clone, Eq, PartialEq, DeepSizeOf)]
 pub struct OrderedColumnLeaf<K, R> {
     // Invariant: keys.len == diffs.len
     keys: Vec<K>,
@@ -28,6 +28,7 @@ pub struct OrderedColumnLeaf<K, R> {
 }
 
 impl<K, R> OrderedColumnLeaf<K, R> {
+    /// Create an empty `OrderedColumnLeaf`
     pub const fn empty() -> Self {
         Self {
             keys: Vec::new(),
@@ -35,6 +36,7 @@ impl<K, R> OrderedColumnLeaf<K, R> {
         }
     }
 
+    /// Get a mutable reference to the current leaf's difference values
     #[inline]
     #[doc(hidden)]
     pub fn diffs_mut(&mut self) -> &mut [R] {
@@ -212,5 +214,11 @@ where
     fn num_entries_deep(&self) -> usize {
         // FIXME: Doesn't take element sizes into account
         self.keys()
+    }
+}
+
+impl<K, R> Default for OrderedColumnLeaf<K, R> {
+    fn default() -> Self {
+        Self::empty()
     }
 }

--- a/src/trace/layers/ordered.rs
+++ b/src/trace/layers/ordered.rs
@@ -217,6 +217,21 @@ where
     }
 }
 
+impl<K, L, O> Default for OrderedLayer<K, L, O>
+where
+    O: OrdOffset,
+    L: Default,
+{
+    fn default() -> Self {
+        Self {
+            keys: Vec::new(),
+            // `offs.len()` **must** be `keys.len() + 1`
+            offs: vec![O::zero()],
+            vals: L::default(),
+        }
+    }
+}
+
 impl<K, L, O> Display for OrderedLayer<K, L, O>
 where
     K: Ord + Clone + Display,

--- a/src/trace/layers/ordered_leaf.rs
+++ b/src/trace/layers/ordered_leaf.rs
@@ -22,8 +22,10 @@ pub struct OrderedLeaf<K, R> {
     pub vals: Vec<(K, R)>,
 }
 
-impl<K: Ord + Clone, R: Eq + HasZero + AddAssign + AddAssignByRef + Clone> Trie
-    for OrderedLeaf<K, R>
+impl<K, R> Trie for OrderedLeaf<K, R>
+where
+    K: Ord + Clone,
+    R: Eq + HasZero + AddAssign + AddAssignByRef + Clone,
 {
     type Item = (K, R);
     type Cursor<'s> = OrderedLeafCursor<'s, K, R> where K: 's, R: 's;

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -153,8 +153,10 @@ where
 
     /// The number of keys in the batch.
     fn key_count(&self) -> usize;
+
     /// The number of updates in the batch.
     fn len(&self) -> usize;
+
     /// True if the batch is empty.
     fn is_empty(&self) -> bool {
         self.len() == 0
@@ -162,6 +164,7 @@ where
 
     /// All times in the batch are greater or equal to an element of `lower`.
     fn lower(&self) -> &Antichain<Self::Time>;
+
     /// All times in the batch are not greater or equal to any element of
     /// `upper`.
     fn upper(&self) -> &Antichain<Self::Time>;

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -226,7 +226,7 @@ where
 
     /// Creates an empty batch.
     fn empty(time: Self::Time) -> Self {
-        <Self::Builder>::new_builder(time).done()
+        Self::Builder::new_builder(time).done()
     }
 
     /// Push all timestamps in the batch back to `frontier`.
@@ -484,7 +484,7 @@ pub mod rc_blanket_impls {
         #[inline]
         fn new_batcher(time: B::Time) -> Self {
             Self {
-                batcher: <B::Batcher as Batcher<B::Item, B::Time, B::R, B>>::new_batcher(time),
+                batcher: B::Batcher::new_batcher(time),
             }
         }
 
@@ -519,7 +519,7 @@ pub mod rc_blanket_impls {
         #[inline]
         fn new_builder(time: B::Time) -> Self {
             Self {
-                builder: <B::Builder as Builder<B::Item, B::Time, B::R, B>>::new_builder(time),
+                builder: B::Builder::new_builder(time),
             }
         }
 

--- a/src/trace/ord/indexed_zset_batch.rs
+++ b/src/trace/ord/indexed_zset_batch.rs
@@ -312,10 +312,22 @@ where
     }
 
     fn begin_merge(&self, other: &Self) -> Self::Merger {
-        OrdIndexedZSetMerger::new(self, other)
+        OrdIndexedZSetMerger::new_merger(self, other)
     }
 
     fn recede_to(&mut self, _frontier: &()) {}
+
+    fn empty(_time: Self::Time) -> Self {
+        Self {
+            layer: OrderedLayer {
+                keys: Vec::new(),
+                offs: Vec::new(),
+                vals: OrderedColumnLeaf::empty(),
+            },
+            lower: Antichain::from_elem(()),
+            upper: Antichain::new(),
+        }
+    }
 }
 
 /// State for an in-progress merge.
@@ -339,7 +351,10 @@ where
     O: OrdOffset,
 {
     #[inline]
-    fn new(batch1: &OrdIndexedZSet<K, V, R, O>, batch2: &OrdIndexedZSet<K, V, R, O>) -> Self {
+    fn new_merger(
+        batch1: &OrdIndexedZSet<K, V, R, O>,
+        batch2: &OrdIndexedZSet<K, V, R, O>,
+    ) -> Self {
         Self {
             result: <<Layers<K, V, R, O> as Trie>::MergeBuilder as MergeBuilder>::with_capacity(
                 &batch1.layer,
@@ -486,7 +501,7 @@ where
     O: OrdOffset,
 {
     #[inline]
-    fn new(_time: ()) -> Self {
+    fn new_builder(_time: ()) -> Self {
         Self {
             builder: IndexBuilder::<K, V, R, O>::new(),
         }

--- a/src/trace/ord/indexed_zset_batch.rs
+++ b/src/trace/ord/indexed_zset_batch.rs
@@ -4,9 +4,10 @@ use crate::{
     trace::{
         layers::{
             column_leaf::{OrderedColumnLeaf, OrderedColumnLeafBuilder},
-            ordered::{OrdOffset, OrderedBuilder, OrderedCursor, OrderedLayer},
+            ordered::{OrderedBuilder, OrderedCursor, OrderedLayer},
             ordered_leaf::OrderedLeaf,
-            Builder as TrieBuilder, Cursor as TrieCursor, MergeBuilder, Trie, TupleBuilder,
+            Builder as TrieBuilder, Cursor as TrieCursor, MergeBuilder, OrdOffset, Trie,
+            TupleBuilder,
         },
         ord::merge_batcher::MergeBatcher,
         Batch, BatchReader, Builder, Cursor, Merger,
@@ -16,7 +17,6 @@ use crate::{
 use deepsize::DeepSizeOf;
 use std::{
     cmp::max,
-    convert::{TryFrom, TryInto},
     fmt::{self, Debug, Display},
     ops::{Add, AddAssign, Neg},
     rc::Rc,
@@ -33,8 +33,6 @@ where
     V: Ord,
     R: Clone,
     O: OrdOffset,
-    <O as TryFrom<usize>>::Error: Debug,
-    <O as TryInto<usize>>::Error: Debug,
 {
     /// Where all the data is.
     pub layer: Layers<K, V, R, O>,
@@ -48,8 +46,6 @@ where
     V: Ord + Clone + Display + 'static,
     R: Eq + HasZero + AddAssign + AddAssignByRef + Clone + Display + 'static,
     O: OrdOffset,
-    <O as TryFrom<usize>>::Error: Debug,
-    <O as TryInto<usize>>::Error: Debug,
     OrderedLayer<K, OrderedLeaf<V, R>, O>: Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -69,8 +65,6 @@ where
     V: Ord + Clone,
     R: MonoidValue,
     O: OrdOffset,
-    <O as TryFrom<usize>>::Error: Debug,
-    <O as TryInto<usize>>::Error: Debug,
 {
     #[inline]
     fn default() -> Self {
@@ -84,8 +78,6 @@ where
     V: Ord,
     R: Clone,
     O: OrdOffset,
-    <O as TryFrom<usize>>::Error: Debug,
-    <O as TryInto<usize>>::Error: Debug,
 {
     #[inline]
     fn from(layer: Layers<K, V, R, O>) -> Self {
@@ -103,8 +95,6 @@ where
     V: Ord,
     R: Clone,
     O: OrdOffset,
-    <O as TryFrom<usize>>::Error: Debug,
-    <O as TryInto<usize>>::Error: Debug,
 {
     #[inline]
     fn from(layer: Layers<K, V, R, O>) -> Self {
@@ -118,8 +108,6 @@ where
     V: DeepSizeOf + Ord,
     R: DeepSizeOf + Clone,
     O: DeepSizeOf + OrdOffset,
-    <O as TryFrom<usize>>::Error: Debug,
-    <O as TryInto<usize>>::Error: Debug,
 {
     #[inline]
     fn deep_size_of_children(&self, context: &mut deepsize::Context) -> usize {
@@ -133,8 +121,6 @@ where
     V: Clone + Ord,
     R: Eq + HasZero + AddAssign + AddAssignByRef + Clone,
     O: OrdOffset,
-    <O as TryFrom<usize>>::Error: Debug,
-    <O as TryInto<usize>>::Error: Debug,
 {
     const CONST_NUM_ENTRIES: Option<usize> =
         <OrderedLayer<K, OrderedLeaf<V, R>, O>>::CONST_NUM_ENTRIES;
@@ -156,8 +142,6 @@ where
     V: Ord + Clone,
     R: MonoidValue + NegByRef,
     O: OrdOffset,
-    <O as TryFrom<usize>>::Error: Debug,
-    <O as TryInto<usize>>::Error: Debug,
 {
     #[inline]
     fn neg_by_ref(&self) -> Self {
@@ -175,8 +159,6 @@ where
     V: Ord + Clone,
     R: MonoidValue + Neg<Output = R>,
     O: OrdOffset,
-    <O as TryFrom<usize>>::Error: Debug,
-    <O as TryInto<usize>>::Error: Debug,
 {
     type Output = Self;
 
@@ -197,8 +179,6 @@ where
     V: Ord + Clone,
     R: MonoidValue,
     O: OrdOffset,
-    <O as TryFrom<usize>>::Error: Debug,
-    <O as TryInto<usize>>::Error: Debug,
 {
     type Output = Self;
     #[inline]
@@ -221,8 +201,6 @@ where
     V: Ord + Clone,
     R: MonoidValue,
     O: OrdOffset,
-    <O as TryFrom<usize>>::Error: Debug,
-    <O as TryInto<usize>>::Error: Debug,
 {
     #[inline]
     fn add_assign(&mut self, rhs: Self) {
@@ -238,8 +216,6 @@ where
     V: Ord + Clone,
     R: MonoidValue,
     O: OrdOffset,
-    <O as TryFrom<usize>>::Error: Debug,
-    <O as TryInto<usize>>::Error: Debug,
 {
     #[inline]
     fn add_assign_by_ref(&mut self, rhs: &Self) {
@@ -255,8 +231,6 @@ where
     V: Ord + Clone,
     R: MonoidValue,
     O: OrdOffset,
-    <O as TryFrom<usize>>::Error: Debug,
-    <O as TryInto<usize>>::Error: Debug,
 {
     #[inline]
     fn add_by_ref(&self, rhs: &Self) -> Self {
@@ -274,8 +248,6 @@ where
     V: Ord + Clone,
     R: MonoidValue,
     O: OrdOffset,
-    <O as TryFrom<usize>>::Error: Debug,
-    <O as TryInto<usize>>::Error: Debug,
 {
     type Key = K;
     type Val = V;
@@ -317,8 +289,6 @@ where
     V: Ord + Clone,
     R: MonoidValue,
     O: OrdOffset,
-    <O as TryFrom<usize>>::Error: Debug,
-    <O as TryInto<usize>>::Error: Debug,
 {
     type Item = (K, V);
     type Batcher = MergeBatcher<(K, V), (), R, Self>;
@@ -355,8 +325,6 @@ where
     V: Ord + Clone,
     R: MonoidValue,
     O: OrdOffset,
-    <O as TryFrom<usize>>::Error: Debug,
-    <O as TryInto<usize>>::Error: Debug,
 {
     // result that we are currently assembling.
     result: <Layers<K, V, R, O> as Trie>::MergeBuilder,
@@ -369,8 +337,6 @@ where
     V: Ord + Clone,
     R: MonoidValue,
     O: OrdOffset,
-    <O as TryFrom<usize>>::Error: Debug,
-    <O as TryInto<usize>>::Error: Debug,
 {
     #[inline]
     fn new(batch1: &OrdIndexedZSet<K, V, R, O>, batch2: &OrdIndexedZSet<K, V, R, O>) -> Self {
@@ -413,8 +379,6 @@ where
     V: Ord + Clone,
     R: MonoidValue,
     O: OrdOffset + PartialEq,
-    <O as TryInto<usize>>::Error: Debug,
-    <O as TryFrom<usize>>::Error: Debug,
 {
     cursor: OrderedCursor<'s, K, O, OrderedColumnLeaf<V, R>>,
 }
@@ -425,8 +389,6 @@ where
     V: Ord + Clone,
     R: MonoidValue,
     O: OrdOffset,
-    <O as TryFrom<usize>>::Error: Debug,
-    <O as TryInto<usize>>::Error: Debug,
 {
     #[inline]
     fn key(&self) -> &K {
@@ -511,8 +473,6 @@ where
     V: Ord,
     R: MonoidValue,
     O: OrdOffset,
-    <O as TryFrom<usize>>::Error: Debug,
-    <O as TryInto<usize>>::Error: Debug,
 {
     builder: IndexBuilder<K, V, R, O>,
 }
@@ -524,8 +484,6 @@ where
     V: Ord + Clone,
     R: MonoidValue,
     O: OrdOffset,
-    <O as TryFrom<usize>>::Error: Debug,
-    <O as TryInto<usize>>::Error: Debug,
 {
     #[inline]
     fn new(_time: ()) -> Self {

--- a/src/trace/ord/indexed_zset_batch.rs
+++ b/src/trace/ord/indexed_zset_batch.rs
@@ -319,11 +319,7 @@ where
 
     fn empty(_time: Self::Time) -> Self {
         Self {
-            layer: OrderedLayer {
-                keys: Vec::new(),
-                offs: Vec::new(),
-                vals: OrderedColumnLeaf::empty(),
-            },
+            layer: OrderedLayer::default(),
             lower: Antichain::from_elem(()),
             upper: Antichain::new(),
         }

--- a/src/trace/ord/key_batch.rs
+++ b/src/trace/ord/key_batch.rs
@@ -93,7 +93,7 @@ where
     }
 
     fn begin_merge(&self, other: &Self) -> Self::Merger {
-        <Self::Merger as Merger<_, _, _, _, _>>::new(self, other)
+        Self::Merger::new_merger(self, other)
     }
 
     fn recede_to(&mut self, frontier: &T) {
@@ -196,7 +196,7 @@ where
     R: MonoidValue,
     O: OrdOffset,
 {
-    fn new(batch1: &OrdKeyBatch<K, T, R, O>, batch2: &OrdKeyBatch<K, T, R, O>) -> Self {
+    fn new_merger(batch1: &OrdKeyBatch<K, T, R, O>, batch2: &OrdKeyBatch<K, T, R, O>) -> Self {
         // Leonid: we do not require batch bounds to grow monotonically.
         //assert!(batch1.upper() == batch2.lower());
 
@@ -210,6 +210,7 @@ where
             upper: batch2.upper().join(batch2.upper()),
         }
     }
+
     fn done(self) -> OrdKeyBatch<K, T, R, O> {
         assert!(self.lower1 == self.upper1);
         assert!(self.lower2 == self.upper2);
@@ -385,7 +386,7 @@ where
     O: OrdOffset,
 {
     #[inline]
-    fn new(time: T) -> Self {
+    fn new_builder(time: T) -> Self {
         Self {
             time,
             builder: <OrderedBuilder<K, OrderedLeafBuilder<T, R>, O> as TupleBuilder>::new(),

--- a/src/trace/ord/merge_batcher/mod.rs
+++ b/src/trace/ord/merge_batcher/mod.rs
@@ -32,7 +32,7 @@ where
     R: MonoidValue,
     B: Batch<Item = I, Time = T, R = R>,
 {
-    fn new(time: T) -> Self {
+    fn new_batcher(time: T) -> Self {
         Self {
             sorter: MergeSorter::new(),
             time,

--- a/src/trace/ord/val_batch.rs
+++ b/src/trace/ord/val_batch.rs
@@ -3,9 +3,10 @@ use crate::{
     lattice::Lattice,
     trace::{
         layers::{
-            ordered::{OrdOffset, OrderedBuilder, OrderedCursor, OrderedLayer},
+            ordered::{OrderedBuilder, OrderedCursor, OrderedLayer},
             ordered_leaf::{OrderedLeaf, OrderedLeafBuilder},
-            Builder as TrieBuilder, Cursor as TrieCursor, MergeBuilder, Trie, TupleBuilder,
+            Builder as TrieBuilder, Cursor as TrieCursor, MergeBuilder, OrdOffset, Trie,
+            TupleBuilder,
         },
         ord::merge_batcher::MergeBatcher,
         Batch, BatchReader, Builder, Cursor, Merger,

--- a/src/trace/ord/zset_batch.rs
+++ b/src/trace/ord/zset_batch.rs
@@ -3,7 +3,7 @@ use crate::{
     lattice::Lattice,
     trace::{
         layers::{
-            column_leaf::{OrderedColumnLeaf, OrderedColumnLeafBuilder, OrderedColumnLeafCursor},
+            column_leaf::{ColumnLeafCursor, OrderedColumnLeaf, OrderedColumnLeafBuilder},
             ordered_leaf::OrderedLeaf,
             Builder as TrieBuilder, Cursor as TrieCursor, MergeBuilder, Trie, TupleBuilder,
         },
@@ -307,7 +307,7 @@ where
     R: MonoidValue,
 {
     valid: bool,
-    cursor: OrderedColumnLeafCursor<'s, K, R>,
+    cursor: ColumnLeafCursor<'s, K, R>,
 }
 
 impl<'s, K, R> Cursor<'s, K, (), (), R> for OrdZSetCursor<'s, K, R>

--- a/src/trace/ord/zset_batch.rs
+++ b/src/trace/ord/zset_batch.rs
@@ -252,10 +252,18 @@ where
     }
 
     fn begin_merge(&self, other: &Self) -> Self::Merger {
-        OrdZSetMerger::new(self, other)
+        OrdZSetMerger::new_merger(self, other)
     }
 
     fn recede_to(&mut self, _frontier: &()) {}
+
+    fn empty(_time: Self::Time) -> Self {
+        Self {
+            layer: OrderedColumnLeaf::empty(),
+            lower: Antichain::from_elem(()),
+            upper: Antichain::new(),
+        }
+    }
 }
 
 /// State for an in-progress merge.
@@ -273,7 +281,7 @@ where
     K: Ord + Clone + 'static,
     R: MonoidValue,
 {
-    fn new(batch1: &OrdZSet<K, R>, batch2: &OrdZSet<K, R>) -> Self {
+    fn new_merger(batch1: &OrdZSet<K, R>, batch2: &OrdZSet<K, R>) -> Self {
         Self {
             result:
                 <<OrderedColumnLeaf<K, R> as Trie>::MergeBuilder as MergeBuilder>::with_capacity(
@@ -405,7 +413,7 @@ where
     R: MonoidValue,
 {
     #[inline]
-    fn new(_time: ()) -> Self {
+    fn new_builder(_time: ()) -> Self {
         Self {
             builder: OrderedColumnLeafBuilder::new(),
         }

--- a/src/trace/spine_fueled.rs
+++ b/src/trace/spine_fueled.rs
@@ -382,7 +382,7 @@ where
     B::Val: Ord,
 {
     fn default() -> Self {
-        Self::new(None)
+        <Self as Trace>::new(None)
     }
 }
 
@@ -794,12 +794,8 @@ where
                             for (index, batch) in self.merging[..(length - 2)].iter().enumerate() {
                                 match batch {
                                     MergeState::Vacant => {}
-                                    MergeState::Single(_) => {
-                                        smaller += 1 << index;
-                                    }
-                                    MergeState::Double(_) => {
-                                        smaller += 2 << index;
-                                    }
+                                    MergeState::Single(_) => smaller += 1 << index,
+                                    MergeState::Double(_) => smaller += 2 << index,
                                 }
                             }
 


### PR DESCRIPTION
* Added source locations to exchange operators
* Renamed renamed `Merger::new()` to `Merger::new_merger()`, `Batcher::new()` to `Batcher::new_batcher()` and `Builder::new()` to `Builder::new_builder()` to decrease method ambiguity
* Made a few `Batch::empty()` implementations simpler, they previously used `Self::Builder::new_builder(time).done()` which could conceivably allocate buffers but they now do exactly nothing (exactly what we want 'em to do)
* Removed a bunch of `<O as TryFrom<usize>>::Error: Debug` bounds that were infecting everything, usize conversion is now part of the `OrdOffset` trait