### PR TITLE
[nexmark] Reduce Send/Recv with batched receivers

### DIFF
--- a/src/nexmark/generator/mod.rs
+++ b/src/nexmark/generator/mod.rs
@@ -43,7 +43,7 @@ impl<R: Rng> NexmarkGenerator<R> {
 
     pub fn next_event(&mut self) -> Result<Option<NextEvent>> {
         let new_event_id = self.get_next_event_id();
-        if new_event_id > self.config.max_events {
+        if new_event_id >= self.config.max_events {
             return Ok(None);
         }
 


### PR DESCRIPTION
This PR abstracts the concept of a `BatchedReceiver` - a receiver of `VecDecue<T>`, and uses it for the generator to main collector communication, further reducing the CPU required for the generator. I've also then pulled out the batched sending functionality into a `BatchedSender` and added a `batched_channel()` helper to create the sender/receiver. The only difference in usage is that you need to call `.flush()` on the sender before finishing (in case any batched results remain unsent).

For example, q4 with 10M events, 4 CPUs and 2 generators (see the create_generators_for_config closure).
Before:
![before](https://user-images.githubusercontent.com/497518/187578184-eac3ce30-08b9-47a5-9b6c-5422d3b32405.png)

After:
![after](https://user-images.githubusercontent.com/497518/187578208-4c5759bc-a76e-440f-8535-af9e17d50e8e.png)

Timing-wise, easiest to see with the q0 results with different generators:
```
cargo bench --bench nexmark --features with-nexmark -- --first-event-rate=10000000 --max-events=10000000 --cpu-cores 4 --query q0 --num-event-generators 1 --source-buffer-size 10000 --input-batch-size 10000
    Finished bench [optimized + debuginfo] target(s) in 0.10s
     Running benches/nexmark/main.rs (target/release/deps/nexmark-c782d17920c2b5ef)
Starting q0 bench of 10000000 events...
Done                                                                                                                                                                                                                           ┌───────┬────────────┬───────┬─────────┬─────────────────┬──────────────────┬───────────────┬───────────────┬─────────────┐
│ Query │ #Events    │ Cores │ Elapsed │ Cores * Elapsed │ Throughput/Cores │ Total Usr CPU │ Total Sys CPU │ Max RSS(Kb) │
├───────┼────────────┼───────┼─────────┼─────────────────┼──────────────────┼───────────────┼───────────────┼─────────────┤
│ q0    │ 10,000,001 │ 4     │ 4.199s  │ 16.795s         │ 595.426 K/s      │ 12.113s       │ 0.146s        │ 0           │
└───────┴────────────┴───────┴─────────┴─────────────────┴──────────────────┴───────────────┴───────────────┴─────────────┘

cargo bench --bench nexmark --features with-nexmark -- --first-event-rate=10000000 --max-events=10000000 --cpu-cores 4 --query q0 --num-event-generators 2 --source-buffer-size 10000 --input-batch-size 10000
    Finished bench [optimized + debuginfo] target(s) in 0.10s
     Running benches/nexmark/main.rs (target/release/deps/nexmark-c782d17920c2b5ef)
Starting q0 bench of 10000000 events...
9990000 / 10000000 [=================================================================================================================================================================================] 99.90 % 4186248.08/s 0s thread 'nexmark collector' panicked at 'called `Option::unwrap()` on a `None` value', /home/michael/dev/vmware/database-stream-processor/src/nexmark/mod.rs:58:20
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Done                                                                                                                                                                                                                           ┌───────┬────────────┬───────┬─────────┬─────────────────┬──────────────────┬───────────────┬───────────────┬─────────────┐
│ Query │ #Events    │ Cores │ Elapsed │ Cores * Elapsed │ Throughput/Cores │ Total Usr CPU │ Total Sys CPU │ Max RSS(Kb) │
├───────┼────────────┼───────┼─────────┼─────────────────┼──────────────────┼───────────────┼───────────────┼─────────────┤
│ q0    │ 10,000,000 │ 4     │ 2.389s  │ 9.558s          │ 1046.281 K/s     │ 11.715s       │ 0.170s        │ 20,856      │
└───────┴────────────┴───────┴─────────┴─────────────────┴──────────────────┴───────────────┴───────────────┴─────────────┘

cargo bench --bench nexmark --features with-nexmark -- --first-event-rate=10000000 --max-events=10000000 --cpu-cores 4 --query q0 --num-event-generators 4 --source-buffer-size 10000 --input-batch-size 10000
    Finished bench [optimized + debuginfo] target(s) in 0.12s
     Running benches/nexmark/main.rs (target/release/deps/nexmark-c782d17920c2b5ef)
Starting q0 bench of 10000000 events...
9980000 / 10000000 [=================================================================================================================================================================================] 99.80 % 5325678.40/s 0s thread 'nexmark collector' panicked at 'called `Option::unwrap()` on a `None` value', /home/michael/dev/vmware/database-stream-processor/src/nexmark/mod.rs:58:20
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Done                                                                                                                                                                                                                           ┌───────┬────────────┬───────┬─────────┬─────────────────┬──────────────────┬───────────────┬───────────────┬─────────────┐
│ Query │ #Events    │ Cores │ Elapsed │ Cores * Elapsed │ Throughput/Cores │ Total Usr CPU │ Total Sys CPU │ Max RSS(Kb) │
├───────┼────────────┼───────┼─────────┼─────────────────┼──────────────────┼───────────────┼───────────────┼─────────────┤
│ q0    │ 10,000,000 │ 4     │ 1.882s  │ 7.526s          │ 1328.713 K/s     │ 12.525s       │ 0.204s        │ 53,692      │
└───────┴────────────┴───────┴─────────┴─────────────────┴──────────────────┴───────────────┴───────────────┴─────────────┘
```

~~Note: I need to fix one of the sync options (see above panic when it completes the input), but otherwise, think this is ready for review (but no rush - can wait until tomorrow).~~