### PR TITLE
[nexmark] Add support for ensuring average sizes of people, auctions and bids

### DIFF
--- a/src/nexmark/generator/auctions.rs
+++ b/src/nexmark/generator/auctions.rs
@@ -155,6 +155,18 @@ mod tests {
 
         let auction = ng.next_auction(0, 0, 0).unwrap();
 
+        // Note: due to usize differences on windows, need to calculate the
+        // size explicitly:
+        let current_size = size_of::<u64>()
+            + 3
+            + 3
+            // (initial_bid, reserve, category)
+            + size_of::<usize>() * 3
+            // seller, expires
+            + size_of::<u64>() * 2;
+        let delta = ((500 - current_size) as f32 * 0.2).round() as usize;
+        let expected_size = 500 - delta - current_size;
+
         assert_eq!(
             Auction {
                 id: FIRST_AUCTION_ID as u64,
@@ -166,9 +178,7 @@ mod tests {
                 expires: 1,
                 seller: 1000,
                 category: 10,
-                // Difference of 500 - 54 = 446, delta of 89 (446*0.2),
-                // so extra 357 chars (54 + 357 = 411 = 500 - delta)
-                extra: (0..357).map(|_| "A").collect::<String>(),
+                extra: (0..expected_size).map(|_| "A").collect::<String>(),
             },
             auction
         );

--- a/src/nexmark/generator/auctions.rs
+++ b/src/nexmark/generator/auctions.rs
@@ -9,7 +9,10 @@ use super::{
 };
 use anyhow::Result;
 use rand::Rng;
-use std::cmp;
+use std::{
+    cmp,
+    mem::{size_of, size_of_val},
+};
 
 /// Keep the number of categories small so the example queries will find results
 /// even with a small batch of events.
@@ -50,7 +53,16 @@ impl<R: Rng> NexmarkGenerator<R> {
         let item_name = self.next_string(20);
         let description = self.next_string(100);
         let reserve = initial_bid + self.next_price();
-        // TODO(absoludity): add the extra bytes for models.
+
+        // Not sure why original Java implementation doesn't include date_time, but
+        // following the same.
+        let current_size = size_of::<u64>()
+            + size_of_val(item_name.as_str())
+            + size_of_val(description.as_str())
+            // (initial_bid, reserve, category)
+            + size_of::<usize>() * 3
+            // seller, expires
+            + size_of::<u64>() * 2;
         Ok(Auction {
             id,
             item_name,
@@ -61,7 +73,10 @@ impl<R: Rng> NexmarkGenerator<R> {
             expires: timestamp + next_length_ms,
             seller,
             category,
-            extra: String::new(),
+            extra: self.next_extra(
+                current_size,
+                self.config.nexmark_config.avg_auction_byte_size,
+            ),
         })
     }
 
@@ -151,7 +166,9 @@ mod tests {
                 expires: 1,
                 seller: 1000,
                 category: 10,
-                extra: String::new(),
+                // Difference of 500 - 54 = 446, delta of 89 (446*0.2),
+                // so extra 357 chars (54 + 357 = 411 = 500 - delta)
+                extra: (0..357).map(|_| "A").collect::<String>(),
             },
             auction
         );

--- a/src/nexmark/generator/bids.rs
+++ b/src/nexmark/generator/bids.rs
@@ -9,6 +9,7 @@ use super::{
 };
 use cached::Cached;
 use rand::Rng;
+use std::mem::size_of;
 
 /// Fraction of people/auctions which may be 'hot' sellers/bidders/auctions are
 /// 1 over these values.
@@ -89,6 +90,11 @@ impl<R: Rng> NexmarkGenerator<R> {
                 (HOT_CHANNELS[hot_index].into(), HOT_URLS[hot_index].into())
             }
         };
+        // Original Java implementation calculates the size of the bid as
+        // 8 * 4 - which can only be the auction, bidder, price and date_time (only 4
+        // numbers on the record). Not sure why the channel and url (Strings)
+        // are not included, but following suit.
+        let current_size = size_of::<u64>() * 3 + size_of::<usize>();
 
         Bid {
             auction,
@@ -97,7 +103,7 @@ impl<R: Rng> NexmarkGenerator<R> {
             channel,
             url,
             date_time: timestamp,
-            extra: String::new(),
+            extra: self.next_extra(current_size, self.config.nexmark_config.avg_bid_byte_size),
         }
     }
 }
@@ -137,7 +143,9 @@ pub mod tests {
                 channel: "Google".into(),
                 url: "https://www.nexmark.com/googl/item.htm?query=1".into(),
                 date_time: 1_000_000_000_000,
-                extra: String::new(),
+                // Difference of 100 - 32 = 68, delta of 14 (68*0.2),
+                // so extra 54 chars (32 + 54 = 86 = 100 - delta)
+                extra: (0..54).map(|_| "A").collect::<String>(),
             },
             bid
         );

--- a/src/nexmark/generator/bids.rs
+++ b/src/nexmark/generator/bids.rs
@@ -135,6 +135,12 @@ pub mod tests {
 
         let bid = ng.next_bid(event_id, 1_000_000_000_000);
 
+        // Note: due to usize differences on windows, need to calculate the
+        // size explicitly:
+        let current_size = size_of::<u64>() * 3 + size_of::<usize>();
+        let delta = ((100 - current_size) as f32 * 0.2).round() as usize;
+        let expected_size = 100 - delta - current_size;
+
         assert_eq!(
             Bid {
                 auction: expected_auction_id,
@@ -145,7 +151,7 @@ pub mod tests {
                 date_time: 1_000_000_000_000,
                 // Difference of 100 - 32 = 68, delta of 14 (68*0.2),
                 // so extra 54 chars (32 + 54 = 86 = 100 - delta)
-                extra: (0..54).map(|_| "A").collect::<String>(),
+                extra: (0..expected_size).map(|_| "A").collect::<String>(),
             },
             bid
         );


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

This PR adds the missing functionality of ensuring that each event (person, auction or bid) matches (on average) the configured average size in bytes for that record.

As expected (extra strings), it hits the performance slightly, adding around and extra second to the processing of 10M events for q4.

## Before

```
cargo bench --bench nexmark --features with-nexmark -- --first-event-rate=10000000 --max-events=10000000 --cpu-cores 4 --query q4 --num-event-generators 4 --source-buffer-size 10000 --input-batch-size 10000
   Compiling dbsp v0.1.0 (/home/michael/dev/vmware/database-stream-processor)
    Finished bench [optimized + debuginfo] target(s) in 35.22s
     Running benches/nexmark/main.rs (target/release/deps/nexmark-c782d17920c2b5ef)
Starting q4 bench of 10000000 events...
Done                                                                                                                                                                                                                ┌───────┬────────────┬───────┬─────────┬─────────────────┬──────────────────┬───────────────┬───────────────┬─────────────┐
│ Query │ #Events    │ Cores │ Elapsed │ Cores * Elapsed │ Throughput/Cores │ Total Usr CPU │ Total Sys CPU │ Max RSS(Kb) │
├───────┼────────────┼───────┼─────────┼─────────────────┼──────────────────┼───────────────┼───────────────┼─────────────┤
│ q4    │ 10,000,000 │ 4     │ 3.391s  │ 13.565s         │ 737.203 K/s      │ 16.935s       │ 0.462s        │ 566,668     │
└───────┴────────────┴───────┴─────────┴─────────────────┴──────────────────┴───────────────┴───────────────┴─────────────┘
```

## After
```
$ cargo bench --bench nexmark --features with-nexmark -- --first-event-rate=10000000 --max-events=10000000 --cpu-cores 4 --query q4 --num-event-generators 4 --source-buffer-size 10000 --input-batch-size 10000
    Finished bench [optimized + debuginfo] target(s) in 0.10s
     Running benches/nexmark/main.rs (target/release/deps/nexmark-c782d17920c2b5ef)
Starting q4 bench of 10000000 events...
Done                                                                                                                                                                                                                ┌───────┬────────────┬───────┬─────────┬─────────────────┬──────────────────┬───────────────┬───────────────┬─────────────┐
│ Query │ #Events    │ Cores │ Elapsed │ Cores * Elapsed │ Throughput/Cores │ Total Usr CPU │ Total Sys CPU │ Max RSS(Kb) │
├───────┼────────────┼───────┼─────────┼─────────────────┼──────────────────┼───────────────┼───────────────┼─────────────┤
│ q4    │ 10,000,000 │ 4     │ 4.448s  │ 17.793s         │ 562.031 K/s      │ 25.061s       │ 0.975s        │ 608,756     │
└───────┴────────────┴───────┴─────────┴─────────────────┴──────────────────┴───────────────┴───────────────┴─────────────┘
```

Actually, you can just run the test so that no extra string is generated by setting the `--avg-*-byte-size` options to zero:

```
cargo bench --bench nexmark --features with-nexmark -- --first-event-rate=10000000 --max-events=10000000 --cpu-cores 4 --query q4 --num-event-generators 6 --source-buffer-size 10000 --input-batch-size 10000 --avg-person-byte-size 0 --avg-auction-byte-size 0 --avg-bid-byte-size 0
    Finished bench [optimized + debuginfo] target(s) in 0.11s
     Running benches/nexmark/main.rs (target/release/deps/nexmark-c782d17920c2b5ef)
Starting q4 bench of 10000000 events...
Done                                                                                                                                                                                                                ┌───────┬────────────┬───────┬─────────┬─────────────────┬──────────────────┬───────────────┬───────────────┬─────────────┐
│ Query │ #Events    │ Cores │ Elapsed │ Cores * Elapsed │ Throughput/Cores │ Total Usr CPU │ Total Sys CPU │ Max RSS(Kb) │
├───────┼────────────┼───────┼─────────┼─────────────────┼──────────────────┼───────────────┼───────────────┼─────────────┤
│ q4    │ 10,000,000 │ 4     │ 3.050s  │ 12.200s         │ 819.641 K/s      │ 14.447s       │ 0.571s        │ 608,988     │
└───────┴────────────┴───────┴─────────┴─────────────────┴──────────────────┴───────────────┴───────────────┴─────────────┘
```