### PR TITLE
[nexmark] Add query 14 showing custom types, functions and user-defined ranges.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,15 +41,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,21 +251,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
-dependencies = [
- "iana-time-zone",
- "js-sys",
- "num-integer",
- "num-traits",
- "time 0.1.44",
- "wasm-bindgen",
- "winapi",
-]
 
 [[package]]
 name = "cipher"
@@ -586,7 +562,6 @@ dependencies = [
  "anyhow",
  "ascii_table",
  "cached",
- "chrono",
  "clap 3.2.16",
  "criterion",
  "crossbeam",
@@ -863,7 +838,7 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -993,20 +968,6 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c495f162af0bf17656d0014a0eded5f3cd2f365fdd204548c2869db89359dc7"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "js-sys",
- "once_cell",
- "wasm-bindgen",
- "winapi",
 ]
 
 [[package]]
@@ -1197,7 +1158,7 @@ checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys",
 ]
 
@@ -2091,17 +2052,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74b7cc93fc23ba97fde84f7eea56c55d1ba183f495c6715defdfc7b9cb8c870f"
@@ -2337,12 +2287,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -2531,7 +2475,7 @@ dependencies = [
  "hmac",
  "pbkdf2",
  "sha1",
- "time 0.3.12",
+ "time",
  "zstd",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,6 +63,12 @@ checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
 dependencies = [
  "nodrop",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "ascii_table"
@@ -245,6 +260,21 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-integer",
+ "num-traits",
+ "time 0.1.44",
+ "wasm-bindgen",
+ "winapi",
+]
 
 [[package]]
 name = "cipher"
@@ -556,6 +586,7 @@ dependencies = [
  "anyhow",
  "ascii_table",
  "cached",
+ "chrono",
  "clap 3.2.16",
  "criterion",
  "crossbeam",
@@ -581,6 +612,7 @@ dependencies = [
  "rand_xoshiro",
  "reqwest",
  "rstest",
+ "rust_decimal",
  "serde",
  "tar",
  "textwrap 0.15.0",
@@ -831,7 +863,7 @@ checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -961,6 +993,20 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c495f162af0bf17656d0014a0eded5f3cd2f365fdd204548c2869db89359dc7"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "winapi",
 ]
 
 [[package]]
@@ -1151,7 +1197,7 @@ checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -1219,7 +1265,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.4.12",
  "itoa 0.4.8",
 ]
 
@@ -1292,9 +1338,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
 name = "oorandom"
@@ -1742,6 +1788,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_decimal"
+version = "1.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee9164faf726e4f3ece4978b25ca877ddc6802fa77f38cdccb32c7f805ecd70c"
+dependencies = [
+ "arrayvec 0.7.2",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2034,6 +2091,17 @@ dependencies = [
 
 [[package]]
 name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
+name = "time"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74b7cc93fc23ba97fde84f7eea56c55d1ba183f495c6715defdfc7b9cb8c870f"
@@ -2269,6 +2337,12 @@ dependencies = [
 
 [[package]]
 name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -2457,7 +2531,7 @@ dependencies = [
  "hmac",
  "pbkdf2",
  "sha1",
- "time",
+ "time 0.3.12",
  "zstd",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 default = ["with-serde"]
 with-serde = ["serde"]
 with-csv = ["csv"]
-with-nexmark = ["rand", "clap", "cached"]
+with-nexmark = ["cached", "chrono", "clap", "rust_decimal", "rand"]
 
 [dependencies]
 anyhow = "1.0.57"
@@ -26,6 +26,8 @@ deepsize_derive = "0.1.2"
 textwrap = "0.15.0"
 fxhash = "0.2"
 ordered-float = "3.0.0"
+chrono = { version = "0.4.22", optional = true }
+rust_decimal = { version = "1.26.1", optional = true }
 
 # TODO: Remove these dependencies
 rand = { version = "0.8", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 default = ["with-serde"]
 with-serde = ["serde"]
 with-csv = ["csv"]
-with-nexmark = ["cached", "chrono", "clap", "rust_decimal", "rand"]
+with-nexmark = ["cached", "clap", "rust_decimal", "rand"]
 
 [dependencies]
 anyhow = "1.0.57"
@@ -26,7 +26,6 @@ deepsize_derive = "0.1.2"
 textwrap = "0.15.0"
 fxhash = "0.2"
 ordered-float = "3.0.0"
-chrono = { version = "0.4.22", optional = true }
 rust_decimal = { version = "1.26.1", optional = true }
 
 # TODO: Remove these dependencies

--- a/benches/nexmark/main.rs
+++ b/benches/nexmark/main.rs
@@ -20,7 +20,7 @@ use dbsp::{
     nexmark::{
         config::Config as NexmarkConfig,
         model::Event,
-        queries::{q0, q1, q2, q3, q4, q6, q9},
+        queries::{q0, q1, q14, q2, q3, q4, q6, q9},
         NexmarkSource,
     },
     trace::ord::OrdZSet,
@@ -307,7 +307,8 @@ fn main() -> Result<()> {
         ("q3", q3),
         ("q4", q4),
         ("q6", q6),
-        ("q9", q9)
+        ("q9", q9),
+        ("q14", q14)
     );
 
     let ascii_table = create_ascii_table();

--- a/src/nexmark/queries/mod.rs
+++ b/src/nexmark/queries/mod.rs
@@ -11,6 +11,8 @@ pub use q6::q6;
 
 pub use q9::q9;
 
+pub use q14::q14;
+
 type NexmarkStream = Stream<Circuit<()>, OrdZSet<Event, isize>>;
 
 mod q0;
@@ -22,3 +24,5 @@ mod q4;
 mod q6;
 
 mod q9;
+
+mod q14;

--- a/src/nexmark/queries/q14.rs
+++ b/src/nexmark/queries/q14.rs
@@ -1,0 +1,131 @@
+use super::NexmarkStream;
+use crate::{nexmark::model::Event, operator::FilterMap, Circuit, OrdZSet, Stream};
+use chrono::{TimeZone, Timelike, Utc};
+use rust_decimal::Decimal;
+
+/// Query 14: Calculation (Not in original suite)
+///
+/// Convert bid timestamp into types and find bids with specific price.
+/// Illustrates duplicate expressions and usage of user-defined-functions.
+///
+/// ```sql
+/// CREATE FUNCTION count_char AS 'com.github.nexmark.flink.udf.CountChar';
+///
+/// CREATE TABLE discard_sink (
+///     auction BIGINT,
+///     bidder BIGINT,
+///     price  DECIMAL(23, 3),
+///     bidTimeType VARCHAR,
+///     dateTime TIMESTAMP(3),
+///     extra VARCHAR,
+///     c_counts BIGINT
+/// ) WITH (
+///   'connector' = 'blackhole'
+/// );
+///
+/// INSERT INTO discard_sink
+/// SELECT
+///     auction,
+///     bidder,
+///     0.908 * price as price,
+///     CASE
+///         WHEN HOUR(dateTime) >= 8 AND HOUR(dateTime) <= 18 THEN 'dayTime'
+///         WHEN HOUR(dateTime) <= 6 OR HOUR(dateTime) >= 20 THEN 'nightTime'
+///         ELSE 'otherTime'
+///     END AS bidTimeType,
+///     dateTime,
+///     extra,
+///     count_char(extra, 'c') AS c_counts
+/// FROM bid
+/// WHERE 0.908 * price > 1000000 AND 0.908 * price < 50000000;
+/// ```
+
+#[derive(Eq, Clone, Debug, PartialEq, PartialOrd, Ord)]
+enum BidTimeType {
+    Day,
+    Night,
+    Other,
+}
+
+#[derive(Eq, Clone, Debug, PartialEq, PartialOrd, Ord)]
+pub struct Q14Output(u64, u64, Decimal, BidTimeType, u64, String, usize);
+
+type Q14Stream = Stream<Circuit<()>, OrdZSet<Q14Output, isize>>;
+
+pub fn q14(input: NexmarkStream) -> Q14Stream {
+    input.flat_map(|event| match event {
+        Event::Bid(b) => {
+            let new_price = Decimal::new((b.price * 100) as i64, 2) * Decimal::new(908, 3);
+            match usize::try_from(new_price).unwrap() {
+                1_000_000..=50_000_000 => Some(Q14Output(
+                    b.auction,
+                    b.bidder,
+                    new_price,
+                    match Utc.timestamp_millis(b.date_time as i64).hour() {
+                        8..=18 => BidTimeType::Day,
+                        20..=23 | 0..=6 => BidTimeType::Night,
+                        _ => BidTimeType::Other,
+                    },
+                    b.date_time,
+                    b.extra.clone(),
+                    b.extra.matches('c').count(),
+                )),
+                _ => None,
+            }
+        }
+        _ => None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        nexmark::{generator::tests::make_bid, model::Bid},
+        zset,
+    };
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::decimal_price_converted(2_000_000, 0, "", zset![Q14Output(1, 1, Decimal::new(1_816_000_000, 3), BidTimeType::Night, 0, String::from(""), 0) => 1])]
+    #[case::decimal_price_converted_outside_range(1_000_000, 0, "", zset![])]
+    #[case::date_time_is_nighttime(2_000_000, 20*60*60*1000 + 1, "", zset![Q14Output(1, 1, Decimal::new(1_816_000_000, 3), BidTimeType::Night, 20*60*60*1000 + 1, String::from(""), 0) => 1])]
+    #[case::date_time_is_daytime(2_000_000, 8*60*60*1000 + 1, "", zset![Q14Output(1, 1, Decimal::new(1_816_000_000, 3), BidTimeType::Day, 8*60*60*1000 + 1, String::from(""), 0) => 1])]
+    #[case::date_time_is_othertime(2_000_000, 8*60*60*1000 - 1, "", zset![Q14Output(1, 1, Decimal::new(1_816_000_000, 3), BidTimeType::Other, 8*60*60*1000 - 1, String::from(""), 0) => 1])]
+    #[case::counts_cs_in_extra(2_000_000, 0, "cause I can't calculate has four of them.", zset![Q14Output(1, 1, Decimal::new(1_816_000_000, 3), BidTimeType::Night, 0, String::from("cause I can't calculate has four of them."), 4) => 1])]
+    fn test_q14(
+        #[case] price: usize,
+        #[case] date_time: u64,
+        #[case] extra: &str,
+        #[case] expected_zset: OrdZSet<Q14Output, isize>,
+    ) {
+        let input_vecs = vec![vec![(
+            Event::Bid(Bid {
+                price,
+                date_time,
+                extra: String::from(extra),
+                ..make_bid()
+            }),
+            1,
+        )]]
+        .into_iter();
+
+        let (circuit, mut input_handle) = Circuit::build(move |circuit| {
+            let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
+
+            let mut expected_output = vec![expected_zset].into_iter();
+
+            let output = q14(stream);
+
+            output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
+
+            input_handle
+        })
+        .unwrap();
+
+        for mut vec in input_vecs {
+            input_handle.append(&mut vec);
+            circuit.step().unwrap();
+        }
+    }
+}


### PR DESCRIPTION
This query uses a Decimal (3 decimal places) for price with a calculation, a custom type for whether the bid happens during the day, night (or other?!), a custom function for counting the 'c's in the extra data and a normal filter for bids in a certain range, as per the original java implementation.

Note, for now (until we can discuss them) I've skipped the following queries:
- [q10](https://github.com/nexmark/nexmark/blob/master/nexmark-flink/src/main/resources/queries/q10.sql) - tests logging to rolling files using flink-specific syntax (I think?). I can implement this using standard tools if we want to? (ie, csv output using serde).
- [q11](https://github.com/nexmark/nexmark/blob/master/nexmark-flink/src/main/resources/queries/q11.sql) - uses session windows... does dbsp have such a concept?
- [q12](https://github.com/nexmark/nexmark/blob/master/nexmark-flink/src/main/resources/queries/q12.sql) - windows in processing time... does dbsp have such a concept yet?
- [q13](https://github.com/nexmark/nexmark/blob/master/nexmark-flink/src/main/resources/queries/q13.sql) - uses side-loaded input from the filesystem to combine with the stream. This is another one that I could do manually, but I don't think we'd have something specific to DBSP?

Let me know what you think about the above 4 queries and I'll start those Monday (or continue past q14).

Thanks!

Signed-off-by: Michael Nelson <minelson@vmware.com>