### PR TITLE
[nexmark] Allow nexmark bench on windows without rusage.

### DIFF
--- a/benches/nexmark/main.rs
+++ b/benches/nexmark/main.rs
@@ -5,9 +5,9 @@
 
 #[cfg(unix)]
 use libc::{getrusage, rusage, timeval};
+#[cfg(unix)]
+use std::{io::Error, mem::MaybeUninit};
 use std::{
-    io::Error,
-    mem::MaybeUninit,
     sync::mpsc,
     thread::{self, JoinHandle},
     time::{Duration, Instant},
@@ -365,4 +365,10 @@ pub unsafe fn rusage(target: i32) -> (Duration, Duration, u64) {
         duration_for_timeval(ru.ru_stime),
         ru.ru_maxrss as u64,
     )
+}
+
+/// Define for non-unix so that bench can still run reporting on time etc.
+#[cfg(not(unix))]
+pub unsafe fn rusage(_target: i32) -> (Duration, Duration, u64) {
+    (Duration::from_millis(0), Duration::from_millis(0), 0)
 }


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

Simply provides a no-op `rusage()` function when running on non-unix for now, so that the bench can still run, but just doesn't report on CPU/Mem usage (which are less useful now that we're using multiple threads for the nexmark source).

If we later improve the CPU measurements generally (perhaps removing the source generation to a different process), then we could look at the w32api [getThreadTimes](https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getthreadtimes) etc., but I don't think it's worthwhile at this point.

EDIT: I noticed you're using [mimalloc_rust_sys](https://docs.rs/mimalloc-rust-sys/1.7.2/mimalloc_rust_sys/index.html) for process cpu usage, though that crate seems pretty undocumented... let me know if you prefer I update to that.