### PR TITLE
[nexmark] Remove pgb dep, using indicatif instead.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,6 @@ dependencies = [
  "num-format",
  "once_cell",
  "ordered-float",
- "pbr",
  "petgraph",
  "priority-queue",
  "proptest",
@@ -1402,16 +1401,6 @@ dependencies = [
  "hmac",
  "password-hash",
  "sha2",
-]
-
-[[package]]
-name = "pbr"
-version = "1.0.4"
-source = "git+https://github.com/a8m/pb?rev=09a8e592c1bb0aa1d6215e35c5c8b49b7a5ad6bd#09a8e592c1bb0aa1d6215e35c5c8b49b7a5ad6bd"
-dependencies = [
- "crossbeam-channel",
- "libc",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,10 +53,6 @@ num-format = "0.4.0"
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = "0.2.127"
-# The latest release of pbr (1.0.4) depends on an old version of time (0.1.44) with
-# a vulnerability. The dependency has been removed but a new version is yet
-# to be released https://github.com/a8m/pb/issues/113
-pbr = { git = "https://github.com/a8m/pb", rev = "09a8e592c1bb0aa1d6215e35c5c8b49b7a5ad6bd" }
 
 [profile.bench]
 debug = true


### PR DESCRIPTION
Looks like I can do everything I was doing with `indicatif` (and more, easy human formatting), so switched to that instead:

```
cargo bench --bench nexmark --features with-nexmark -- --first-event-rate=10000000 --max-events=10000000 --cpu-cores 1 --query q0 --num-event-generators 1 --source-buffer-size 10000 --input-batch-size 10000
   Compiling dbsp v0.1.0 (/home/michael/dev/vmware/database-stream-processor)
    Finished bench [optimized + debuginfo] target(s) in 4.95s
     Running benches/nexmark/main.rs (target/release/deps/nexmark-4d49cd6c13b4d173)
Starting q0 bench of 10000000 events...
1,380,000 / 10,000,000 [======================>---------------------------------------------------------------------------------------------------------------------------------------------] 14 % 1170673.0623/s 7s
```

Signed-off-by: Michael Nelson <minelson@vmware.com>