### PR TITLE
[nexmark] Add q15 - distinct aggregations with filters.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,6 +590,7 @@ dependencies = [
  "serde",
  "tar",
  "textwrap 0.15.0",
+ "time",
  "typedmap",
  "zip",
  "zstd",
@@ -2041,12 +2042,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.12"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b7cc93fc23ba97fde84f7eea56c55d1ba183f495c6715defdfc7b9cb8c870f"
+checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
 dependencies = [
  "itoa 1.0.3",
- "js-sys",
  "libc",
  "num_threads",
  "time-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 default = ["with-serde"]
 with-serde = ["serde"]
 with-csv = ["csv"]
-with-nexmark = ["cached", "clap", "csv", "rust_decimal", "rand"]
+with-nexmark = ["cached", "clap", "csv", "rust_decimal", "rand", "time"]
 
 [dependencies]
 anyhow = "1.0.57"
@@ -27,6 +27,7 @@ textwrap = "0.15.0"
 fxhash = "0.2"
 ordered-float = "3.0.0"
 rust_decimal = { version = "1.26.1", optional = true }
+time = { version = "0.3.14", features = ["formatting"], optional = true }
 
 # TODO: Remove these dependencies
 rand = { version = "0.8", optional = true }
@@ -51,7 +52,6 @@ clap = { version = "3.2.8", features = ["derive", "env"] }
 reqwest = { version = "0.11.11", features = ["blocking"] }
 ascii_table = "4.0.2"
 num-format = "0.4.0"
-time = { version = "0.3.14", features = ["formatting"] }
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = "0.2.127"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ clap = { version = "3.2.8", features = ["derive", "env"] }
 reqwest = { version = "0.11.11", features = ["blocking"] }
 ascii_table = "4.0.2"
 num-format = "0.4.0"
-time = "0.3.14"
+time = { version = "0.3.14", features = ["formatting"] }
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = "0.2.127"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ clap = { version = "3.2.8", features = ["derive", "env"] }
 reqwest = { version = "0.11.11", features = ["blocking"] }
 ascii_table = "4.0.2"
 num-format = "0.4.0"
+time = "0.3.14"
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = "0.2.127"

--- a/benches/nexmark/main.rs
+++ b/benches/nexmark/main.rs
@@ -20,7 +20,7 @@ use dbsp::{
     nexmark::{
         config::Config as NexmarkConfig,
         model::Event,
-        queries::{q0, q1, q13, q13_side_input, q14, q2, q3, q4, q6, q9},
+        queries::{q0, q1, q13, q13_side_input, q14, q15, q2, q3, q4, q6, q9},
         NexmarkSource,
     },
     trace::ord::OrdZSet,
@@ -335,7 +335,8 @@ fn main() -> Result<()> {
         ("q6", q6),
         ("q9", q9),
         ("q13", q13),
-        ("q14", q14)
+        ("q14", q14),
+        ("q15", q15)
     );
 
     let ascii_table = create_ascii_table();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,10 +17,10 @@ pub mod trace;
 #[cfg(feature = "with-nexmark")]
 pub mod nexmark;
 
-pub use error::Error;
-pub use num_entries::NumEntries;
-pub use ref_pair::RefPair;
-pub use time::Timestamp;
+pub use crate::error::Error;
+pub use crate::num_entries::NumEntries;
+pub use crate::ref_pair::RefPair;
+pub use crate::time::Timestamp;
 
 pub use circuit::{
     Circuit, CircuitHandle, DBSPHandle, Runtime, RuntimeError, SchedulerError, Stream,

--- a/src/nexmark/queries/mod.rs
+++ b/src/nexmark/queries/mod.rs
@@ -13,6 +13,7 @@ pub use q9::q9;
 
 pub use q13::{q13, q13_side_input};
 pub use q14::q14;
+pub use q15::q15;
 
 type NexmarkStream = Stream<Circuit<()>, OrdZSet<Event, isize>>;
 
@@ -28,3 +29,4 @@ mod q9;
 
 mod q13;
 mod q14;
+mod q15;

--- a/src/nexmark/queries/q15.rs
+++ b/src/nexmark/queries/q15.rs
@@ -1,0 +1,156 @@
+use super::NexmarkStream;
+use crate::{nexmark::model::Event, operator::FilterMap, Circuit, OrdZSet, Stream};
+use std::time::{Duration, SystemTime};
+use time::OffsetDateTime;
+
+/// Query 15: Bidding Statistics Report (Not in original suite)
+///
+/// How many distinct users join the bidding for different level of price?
+/// Illustrates multiple distinct aggregations with filters.
+///
+/// ```sql
+/// CREATE TABLE discard_sink (
+///   `day` VARCHAR,
+///   total_bids BIGINT,
+///   rank1_bids BIGINT,
+///   rank2_bids BIGINT,
+///   rank3_bids BIGINT,
+///   total_bidders BIGINT,
+///   rank1_bidders BIGINT,
+///   rank2_bidders BIGINT,
+///   rank3_bidders BIGINT,
+///   total_auctions BIGINT,
+///   rank1_auctions BIGINT,
+///   rank2_auctions BIGINT,
+///   rank3_auctions BIGINT
+/// ) WITH (
+///   'connector' = 'blackhole'
+/// );
+///
+/// INSERT INTO discard_sink
+/// SELECT
+///      DATE_FORMAT(dateTime, 'yyyy-MM-dd') as `day`,
+///      count(*) AS total_bids,
+///      count(*) filter (where price < 10000) AS rank1_bids,
+///      count(*) filter (where price >= 10000 and price < 1000000) AS rank2_bids,
+///      count(*) filter (where price >= 1000000) AS rank3_bids,
+///      count(distinct bidder) AS total_bidders,
+///      count(distinct bidder) filter (where price < 10000) AS rank1_bidders,
+///      count(distinct bidder) filter (where price >= 10000 and price < 1000000) AS rank2_bidders,
+///      count(distinct bidder) filter (where price >= 1000000) AS rank3_bidders,
+///      count(distinct auction) AS total_auctions,
+///      count(distinct auction) filter (where price < 10000) AS rank1_auctions,
+///      count(distinct auction) filter (where price >= 10000 and price < 1000000) AS rank2_auctions,
+///      count(distinct auction) filter (where price >= 1000000) AS rank3_auctions
+/// FROM bid
+/// GROUP BY DATE_FORMAT(dateTime, 'yyyy-MM-dd');
+/// ```
+
+#[derive(Eq, Clone, Debug, Default, PartialEq, PartialOrd, Ord)]
+pub struct Q15Output {
+    day: String,
+    total_bids: usize,
+    rank1_bids: usize,
+    rank2_bids: usize,
+    rank3_bids: usize,
+    total_bidders: usize,
+    rank1_bidders: usize,
+    rank2_bidders: usize,
+    rank3_bidders: usize,
+    total_auctions: usize,
+    rank1_auctions: usize,
+    rank2_auctions: usize,
+    rank3_auctions: usize,
+}
+
+type Q15Stream = Stream<Circuit<()>, OrdZSet<Q15Output, isize>>;
+
+pub fn q15(input: NexmarkStream) -> Q15Stream {
+    // Group/index and aggregate by day - keeping only the price, bidder, auction
+    input.flat_map_index(|event| match event {
+        Event::Bid(b) => {
+            let date_time = SystemTime::UNIX_EPOCH + SystemTime::Duration::from_millis(b.date_time);
+            let day = date_time.into().format("%Y-%m-%d");
+            Some((day, Q15Output::default()))
+        }
+        _ => None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        nexmark::{generator::tests::make_bid, model::Bid},
+        zset,
+    };
+
+    #[test]
+    fn test_q15_bids() {
+        let input_vecs = vec![
+            vec![(
+                Event::Bid(Bid {
+                    auction: 1,
+                    ..make_bid()
+                }),
+                1,
+            )],
+            vec![
+                (
+                    Event::Bid(Bid {
+                        auction: 2,
+                        ..make_bid()
+                    }),
+                    1,
+                ),
+                (
+                    Event::Bid(Bid {
+                        auction: 3,
+                        ..make_bid()
+                    }),
+                    1,
+                ),
+            ],
+        ]
+        .into_iter();
+
+        let (circuit, mut input_handle) = Circuit::build(move |circuit| {
+            let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
+
+            let mut expected_output = vec![
+                zset![
+                    Q15Output {
+                        day: String::from("1970-01-01"),
+                        total_bids: 1,
+                        ..Q15Output::default()
+                    } => 1,
+                ],
+                zset![
+                    Q15Output {
+                        day: String::from("1970-01-01"),
+                        total_bids: 1,
+                        ..Q15Output::default()
+                    } => -1,
+                    Q15Output {
+                        day: String::from("1970-01-01"),
+                        total_bids: 3,
+                        ..Q15Output::default()
+                    } => 1,
+                ],
+            ]
+            .into_iter();
+
+            let output = q15(stream);
+
+            output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
+
+            input_handle
+        })
+        .unwrap();
+
+        for mut vec in input_vecs {
+            input_handle.append(&mut vec);
+            circuit.step().unwrap();
+        }
+    }
+}

--- a/src/nexmark/queries/q15.rs
+++ b/src/nexmark/queries/q15.rs
@@ -103,8 +103,25 @@ pub fn q15(input: NexmarkStream) -> Q15Stream {
     });
 
     // Not sure of the best way to calculate the various distinct bidders and
-    // auctions. Seems I could maintain a zset for each, adding the bidder/auction,
-    // using distinct?
+    // auctions.
+    // I've initially use HashSets to count each while already dealing
+    // with the bids for the day, but probably should instead use filter operations
+    // like the original.
+    type Accumulator = (
+        usize,
+        usize,
+        usize,
+        usize,
+        HashSet<u64>,
+        HashSet<u64>,
+        HashSet<u64>,
+        HashSet<u64>,
+        HashSet<u64>,
+        HashSet<u64>,
+        HashSet<u64>,
+        HashSet<u64>,
+    );
+
     let bids_per_day = bids_indexed.aggregate::<(), _>(Fold::with_output(
         (
             0,
@@ -133,20 +150,7 @@ pub fn q15(input: NexmarkStream) -> Q15Stream {
             rank1_auctions,
             rank2_auctions,
             rank3_auctions,
-        ): &mut (
-            usize,
-            usize,
-            usize,
-            usize,
-            HashSet<u64>,
-            HashSet<u64>,
-            HashSet<u64>,
-            HashSet<u64>,
-            HashSet<u64>,
-            HashSet<u64>,
-            HashSet<u64>,
-            HashSet<u64>,
-        ),
+        ): &mut Accumulator,
          (auction, price, bidder): &(u64, usize, u64),
          _w| {
             *total_bids += 1;
@@ -179,20 +183,7 @@ pub fn q15(input: NexmarkStream) -> Q15Stream {
             rank1_auctions,
             rank2_auctions,
             rank3_auctions,
-        ): (
-            usize,
-            usize,
-            usize,
-            usize,
-            HashSet<u64>,
-            HashSet<u64>,
-            HashSet<u64>,
-            HashSet<u64>,
-            HashSet<u64>,
-            HashSet<u64>,
-            HashSet<u64>,
-            HashSet<u64>,
-        )| {
+        ): Accumulator| {
             Q15Output {
                 day: String::new(),
                 total_bids,


### PR DESCRIPTION
So this was a pain to write for a number of reasons, and even then, I'm not sure that the implementation I've added is a fair comparison: As we were already aggregating to count the number of bids per day, I've used a `Fold` within the same aggregation to also calculate the distinct filtered aggregations (total bidders, total auctions, and their respective ranked versions). The SQL query runs each as a separate filter, but I assume that's because there's no other way to express it. See what you think.

And it's slooow (it's slow in the original too, but faster than their q4, for example), so any performance tips here will be gratefully accepted.

```
$ cargo bench --bench nexmark --features with-nexmark -- --first-event-rate=10000000 --max-events=1000000 --cpu-cores 4 --query q15 --num-event-generators 4 --source-buffer-size 10000 --input-batch-size 10000
   Compiling dbsp v0.1.0 (/home/michael/dev/vmware/database-stream-processor)
    Finished bench [optimized + debuginfo] target(s) in 52.12s
     Running benches/nexmark/main.rs (target/release/deps/nexmark-db7e78eeb5fe8ae0)
Starting q15 bench of 1000000 events...
1,000,000 / 1,000,000 [=====================================================================================================================================================================] 100 % 176102.3803/s 0s
┌───────┬───────────┬───────┬─────────┬─────────────────┬──────────────────┬───────────────┬───────────────┬─────────────┐
│ Query │ #Events   │ Cores │ Elapsed │ Cores * Elapsed │ Throughput/Cores │ Total Usr CPU │ Total Sys CPU │ Max RSS(Kb) │
├───────┼───────────┼───────┼─────────┼─────────────────┼──────────────────┼───────────────┼───────────────┼─────────────┤
│ q15   │ 1,000,000 │ 4     │ 5.679s  │ 22.716s         │ 44.022 K/s       │ 7.434s        │ 0.151s        │ 138,344     │
└───────┴───────────┴───────┴─────────┴─────────────────┴──────────────────┴───────────────┴───────────────┴─────────────┘
```