### PR TITLE
[nexmark] Add q7 - Highest bid per tumbling window.

### DIFF
--- a/benches/nexmark/main.rs
+++ b/benches/nexmark/main.rs
@@ -20,7 +20,7 @@ use dbsp::{
     nexmark::{
         config::Config as NexmarkConfig,
         model::Event,
-        queries::{q0, q1, q13, q13_side_input, q14, q15, q2, q3, q4, q5, q6, q9},
+        queries::{q0, q1, q13, q13_side_input, q14, q15, q2, q3, q4, q5, q6, q7, q9},
         NexmarkSource,
     },
     trace::ord::OrdZSet,
@@ -334,6 +334,7 @@ fn main() -> Result<()> {
         ("q4", q4),
         ("q5", q5),
         ("q6", q6),
+        ("q7", q7),
         ("q9", q9),
         ("q13", q13),
         ("q14", q14),

--- a/src/nexmark/queries/mod.rs
+++ b/src/nexmark/queries/mod.rs
@@ -8,6 +8,7 @@ pub use q3::q3;
 pub use q4::q4;
 pub use q5::q5;
 pub use q6::q6;
+pub use q7::q7;
 
 pub use q9::q9;
 
@@ -24,6 +25,7 @@ mod q3;
 mod q4;
 mod q5;
 mod q6;
+mod q7;
 
 mod q9;
 

--- a/src/nexmark/queries/q7.rs
+++ b/src/nexmark/queries/q7.rs
@@ -1,0 +1,170 @@
+use super::NexmarkStream;
+use crate::{
+    nexmark::model::Event,
+    operator::{FilterMap, Max},
+    Circuit, OrdIndexedZSet, OrdZSet, Stream,
+};
+
+///
+/// Query 7: Highest Bid
+///
+/// What are the highest bids per period?
+///
+/// The original Nexmark Query7 calculate the highest bids in the last minute.
+/// We will use a shorter window (10 seconds) to help make testing easier.
+///
+/// ```sql
+/// CREATE TABLE discard_sink (
+///   auction  BIGINT,
+///   bidder  BIGINT,
+///   price  BIGINT,
+///   dateTime  TIMESTAMP(3),
+///   extra  VARCHAR
+/// ) WITH (
+///   'connector' = 'blackhole'
+/// );
+///
+/// INSERT INTO discard_sink
+/// SELECT B.auction, B.price, B.bidder, B.dateTime, B.extra
+/// from bid B
+/// JOIN (
+///   SELECT MAX(B1.price) AS maxprice, TUMBLE_ROWTIME(B1.dateTime, INTERVAL '10' SECOND) as dateTime
+///   FROM bid B1
+///   GROUP BY TUMBLE(B1.dateTime, INTERVAL '10' SECOND)
+/// ) B1
+/// ON B.price = B1.maxprice
+/// WHERE B.dateTime BETWEEN B1.dateTime  - INTERVAL '10' SECOND AND B1.dateTime;
+/// ```
+
+type Q7Stream = Stream<Circuit<()>, OrdZSet<(u64, u64, usize, u64, String), isize>>;
+type Q7Output = (u64, u64, usize, u64, String);
+
+const TUMBLE_SECONDS: u64 = 10;
+
+pub fn q7(input: NexmarkStream) -> Q7Stream {
+    // All bids indexed by date time to be able to window the result.
+    let bids_by_time: Stream<_, OrdIndexedZSet<u64, Q7Output, _>> =
+        input.flat_map_index(|event| match event {
+            Event::Bid(b) => Some((
+                b.date_time,
+                (b.auction, b.bidder, b.price, b.date_time, b.extra.clone()),
+            )),
+            _ => None,
+        });
+
+    // Similar to the sliding window of q5, we want to find the largest timestamp
+    // from the input stream for the current time, with the window ending at the
+    // previous 10 second multiple.
+    // Set the watermark to `TUMBLE_SECONDS` in the past.
+    let watermark = bids_by_time.watermark_monotonic(|date_time| date_time - TUMBLE_SECONDS * 1000);
+
+    // In this case we have a 10-second window with 10-second steps (tumbling).
+    let window_bounds = watermark.apply(|watermark| {
+        let watermark_rounded = *watermark - (*watermark % (TUMBLE_SECONDS * 1000));
+        (
+            watermark_rounded.saturating_sub(TUMBLE_SECONDS * 1000),
+            watermark_rounded,
+        )
+    });
+
+    // Only consider bids within the current window.
+    let windowed_bids: Stream<_, OrdZSet<Q7Output, _>> = bids_by_time.window(&window_bounds);
+
+    // Find the maximum bid across all bids.
+    windowed_bids
+        .map_index(|(auction, bidder, price, date_time, extra)| {
+            ((), (*price, *date_time, *auction, *bidder, extra.clone()))
+        })
+        .aggregate::<(), _>(Max)
+        .map(|((), (price, date_time, auction, bidder, extra))| {
+            (*auction, *bidder, *price, *date_time, extra.clone())
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        nexmark::{
+            generator::tests::make_bid,
+            model::{Bid, Event},
+        },
+        zset, Circuit,
+    };
+    use rstest::rstest;
+
+    #[rstest]
+    // The latest bid is at t=32_000, so the watermark as at t=22_000
+    // and the tumbled window is from 10_000 - 20_000.
+    #[case::latest_bid_determines_window(
+        vec![vec![(9_000, 1_000_000), (11_000, 50), (14_000, 90), (16_000, 70), (21_000, 1_000_000), (32_000, 1_000_000)]],
+        vec![zset! {(1, 1, 90, 14_000, String::new()) => 1}],
+    )]
+    // The window is rounded to the 10 second boundary
+    #[case::window_boundary_below(
+        vec![vec![(9_999, 50), (32_000, 1_000_000)]],
+        vec![zset! {}],
+    )]
+    #[case::window_boundary_lower(
+        vec![vec![(10_000, 50), (32_000, 1_000_000)]],
+        vec![zset! {(1, 1, 50, 10_000, String::new()) => 1}],
+    )]
+    #[case::window_boundary_upper(
+        vec![vec![(19_999, 50), (32_000, 1_000_000)]],
+        vec![zset! {(1, 1, 50, 19_999, String::new()) => 1}],
+    )]
+    #[case::window_boundary_above(
+        vec![vec![(20_000, 50), (32_000, 1_000_000)]],
+        vec![zset! {}],
+    )]
+    #[case::tumble_into_new_window(
+        vec![vec![(9_000, 1_000_000), (11_000, 50), (14_000, 90), (16_000, 70), (21_000, 1_000_000)], vec![(32_000, 10)], vec![(42_000, 10)]],
+        vec![
+            zset! {(1, 1, 1_000_000, 9_000, String::new()) => 1},
+            zset! {
+                (1, 1, 1_000_000, 9_000, String::new()) => -1,
+                (1, 1, 90, 14_000, String::new()) => 1,
+            },
+            zset! {
+                (1, 1, 90, 14_000, String::new()) => -1,
+                (1, 1, 1_000_000, 21_000, String::new()) => 1,
+            }],
+    )]
+    fn test_q7(
+        #[case] input_batches: Vec<Vec<(u64, usize)>>,
+        #[case] expected_zsets: Vec<OrdZSet<(u64, u64, usize, u64, String), isize>>,
+    ) {
+        let input_vecs = input_batches.into_iter().map(|batch| {
+            batch
+                .into_iter()
+                .map(|(date_time, price)| {
+                    (
+                        Event::Bid(Bid {
+                            date_time,
+                            price,
+                            ..make_bid()
+                        }),
+                        1,
+                    )
+                })
+                .collect()
+        });
+
+        let (circuit, mut input_handle) = Circuit::build(move |circuit| {
+            let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
+
+            let output = q7(stream);
+
+            let mut expected_output = expected_zsets.into_iter();
+            output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
+
+            input_handle
+        })
+        .unwrap();
+
+        for mut vec in input_vecs {
+            input_handle.append(&mut vec);
+            circuit.step().unwrap();
+        }
+    }
+}

--- a/src/nexmark/queries/q7.rs
+++ b/src/nexmark/queries/q7.rs
@@ -130,6 +130,10 @@ mod tests {
                 (1, 1, 1_000_000, 21_000, String::new()) => 1,
             }],
     )]
+    #[case::multiple_max_bids_latest_wins(
+        vec![vec![(11_000, 90), (14_000, 90), (16_000, 90), (21_000, 1_000_000), (32_000, 1_000_000)]],
+        vec![zset! {(1, 1, 90, 16_000, String::new()) => 1}],
+    )]
     fn test_q7(
         #[case] input_batches: Vec<Vec<(u64, usize)>>,
         #[case] expected_zsets: Vec<OrdZSet<(u64, u64, usize, u64, String), isize>>,


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

Very similar to Q5, just a max on bid rather than count (and different output, of course).

```
cargo bench --bench nexmark --features with-nexmark -- --first-event-rate=10000000 --max-events=10000000 --cpu-cores 4 --query q7 --num-event-generators 4 --source-buffer-size 10000 --input-batch-size 10000
   Compiling dbsp v0.1.0 (/home/michael/dev/vmware/database-stream-processor)
    Finished bench [optimized + debuginfo] target(s) in 54.82s
     Running benches/nexmark/main.rs (target/release/deps/nexmark-db7e78eeb5fe8ae0)
Starting q7 bench of 10000000 events...
10,000,000 / 10,000,000 [======================================================================================================================================================================================] 100 % 1200036.3645/s 0s
┌───────┬────────────┬───────┬─────────┬─────────────────┬──────────────────┬───────────────┬───────────────┬─────────────┐
│ Query │ #Events    │ Cores │ Elapsed │ Cores * Elapsed │ Throughput/Cores │ Total Usr CPU │ Total Sys CPU │ Max RSS(Kb) │
├───────┼────────────┼───────┼─────────┼─────────────────┼──────────────────┼───────────────┼───────────────┼─────────────┤
│ q7    │ 10,000,000 │ 4     │ 8.334s  │ 33.335s         │ 299.987 K/s      │ 31.673s       │ 1.054s        │ 1,465,516   │
└───────┴────────────┴───────┴─────────┴─────────────────┴──────────────────┴───────────────┴───────────────┴─────────────┘
```