### PR TITLE
[nexmark] Use a WATERMARK_INTERVAL_SECONDS of 4, matching Java impl.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(generic_associated_types)]
 #![cfg_attr(feature = "with-nexmark", feature(is_some_with))]
 
 mod error;

--- a/src/nexmark/queries/mod.rs
+++ b/src/nexmark/queries/mod.rs
@@ -18,6 +18,9 @@ pub use q15::q15;
 
 type NexmarkStream = Stream<Circuit<()>, OrdZSet<Event, isize>>;
 
+// Based on the WATERMARK FOR definition in the original [ddl_gen.sql](https://github.com/nexmark/nexmark/blob/54974ef36a0d01ef8ebc0b4ba39cfc50136af0f6/nexmark-flink/src/main/resources/queries/ddl_gen.sql#L37)
+const WATERMARK_INTERVAL_SECONDS: u64 = 4;
+
 mod q0;
 mod q1;
 mod q2;

--- a/src/nexmark/queries/q7.rs
+++ b/src/nexmark/queries/q7.rs
@@ -1,4 +1,4 @@
-use super::NexmarkStream;
+use super::{NexmarkStream, WATERMARK_INTERVAL_SECONDS};
 use crate::{
     nexmark::model::Event,
     operator::{FilterMap, Min},
@@ -55,8 +55,9 @@ pub fn q7(input: NexmarkStream) -> Q7Stream {
     // Similar to the sliding window of q5, we want to find the largest timestamp
     // from the input stream for the current time, with the window ending at the
     // previous 10 second multiple.
-    // Set the watermark to `TUMBLE_SECONDS` in the past.
-    let watermark = bids_by_time.watermark_monotonic(|date_time| date_time - TUMBLE_SECONDS * 1000);
+    // Set the watermark to `WATERMARK_INTERVAL_SECONDS` in the past.
+    let watermark =
+        bids_by_time.watermark_monotonic(|date_time| date_time - WATERMARK_INTERVAL_SECONDS * 1000);
 
     // In this case we have a 10-second window with 10-second steps (tumbling).
     let window_bounds = watermark.apply(|watermark| {


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

Based on conversation with Leonid. Although this [separate comment](https://github.com/vmware/database-stream-processor/pull/181#discussion_r969260608):

> We should use `WATERMARK` constant here, which should probably match the out-of-ordedness bounds used by the generator.

confuses me, in that the out-of-orderness bounds are configurable (`--out-of-order-group-size`) only in terms of the size of the group. Anyway, the small change here just updates to use the watermark constant set based on the Java implementation. Let me know if that's not what you meant.