### PR TITLE
[nexmark] Add Q12 demoing a process-time window.

### DIFF
--- a/benches/nexmark/main.rs
+++ b/benches/nexmark/main.rs
@@ -20,7 +20,7 @@ use dbsp::{
     nexmark::{
         config::Config as NexmarkConfig,
         model::Event,
-        queries::{q0, q1, q13, q13_side_input, q14, q15, q2, q3, q4, q5, q6, q7, q8, q9},
+        queries::{q0, q1, q12, q13, q13_side_input, q14, q15, q2, q3, q4, q5, q6, q7, q8, q9},
         NexmarkSource,
     },
     trace::ord::OrdZSet,
@@ -337,6 +337,7 @@ fn main() -> Result<()> {
         ("q7", q7),
         ("q8", q8),
         ("q9", q9),
+        ("q12", q12),
         ("q13", q13),
         ("q14", q14),
         ("q15", q15)

--- a/src/nexmark/queries/mod.rs
+++ b/src/nexmark/queries/mod.rs
@@ -1,6 +1,8 @@
 //! Nexmark Queries in DBSP.
 use super::model::Event;
 use crate::{Circuit, OrdZSet, Stream};
+use std::time::SystemTime;
+
 pub use q0::q0;
 pub use q1::q1;
 pub use q2::q2;
@@ -12,6 +14,7 @@ pub use q7::q7;
 pub use q8::q8;
 pub use q9::q9;
 
+pub use q12::q12;
 pub use q13::{q13, q13_side_input};
 pub use q14::q14;
 pub use q15::q15;
@@ -32,6 +35,14 @@ mod q7;
 mod q8;
 mod q9;
 
+mod q12;
 mod q13;
 mod q14;
 mod q15;
+
+fn process_time() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_millis() as u64
+}

--- a/src/nexmark/queries/q12.rs
+++ b/src/nexmark/queries/q12.rs
@@ -1,0 +1,150 @@
+use super::{process_time, NexmarkStream};
+use crate::{nexmark::model::Event, operator::FilterMap, Circuit, OrdZSet, Stream};
+
+///
+/// Query 12: Processing Time Windows (Not in original suite)
+///
+/// How many bids does a user make within a fixed processing time limit?
+/// Illustrates working in processing time window.
+///
+/// Group bids by the same user into processing time windows of 10 seconds.
+/// Emit the count of bids per window.
+///
+/// ```sql
+/// CREATE TABLE discard_sink (
+///   bidder BIGINT,
+///   bid_count BIGINT,
+///   starttime TIMESTAMP(3),
+///   endtime TIMESTAMP(3)
+/// ) WITH (
+///   'connector' = 'blackhole'
+/// );
+///
+/// INSERT INTO discard_sink
+/// SELECT
+///     B.bidder,
+///     count(*) as bid_count,
+///     TUMBLE_START(B.p_time, INTERVAL '10' SECOND) as starttime,
+///     TUMBLE_END(B.p_time, INTERVAL '10' SECOND) as endtime
+/// FROM (SELECT *, PROCTIME() as p_time FROM bid) B
+/// GROUP BY B.bidder, TUMBLE(B.p_time, INTERVAL '10' SECOND);
+/// ```
+
+type Q12Stream = Stream<Circuit<()>, OrdZSet<(u64, u64, u64, u64), isize>>;
+const TUMBLE_SECONDS: u64 = 10;
+
+fn window_for_process_time(ptime: u64) -> (u64, u64) {
+    let window_lower = ptime - (ptime % (TUMBLE_SECONDS * 1000));
+    (window_lower, window_lower + TUMBLE_SECONDS * 1000)
+}
+
+// This function enables us to test the q12 functionality without using the
+// actual process time, while the actual q12 function below uses the real
+// process time.
+// TODO: I originally planned to pass a FnMut closure for process_time that
+// just emits a new u64 each time it is called, but can't do this as the
+// closure of `flat_map_index` is Fn not FnMut, and would need to capture the
+// process_time closure. So right now, it's quite ugly: to avoid an `FnMut`,
+// I'm instead passing an optional vector of times with the assumption that
+// those times are indexed by the bid.auction.
+// There must be a better way without resorting to interior mutability? Anyway,
+// it works for the tests and is only used in the tests.
+fn q12_for_process_time(input: NexmarkStream, process_times: Option<Vec<u64>>) -> Q12Stream {
+    let bids_by_bidder_window = input.flat_map_index(move |event| match event {
+        // TODO: Can I call process_time() just once per batch, rather than for every Bid? How?
+        Event::Bid(b) => {
+            let t = match &process_times {
+                Some(v) => v[b.auction as usize],
+                None => process_time(),
+            };
+            let (starttime, endtime) = window_for_process_time(t);
+            Some(((b.bidder, starttime, endtime), ()))
+        }
+        _ => None,
+    });
+
+    bids_by_bidder_window
+        .aggregate_linear::<(), _, _>(|&_key, &()| -> isize { 1 })
+        .map(|(&(bidder, starttime, endtime), &count)| (bidder, count as u64, starttime, endtime))
+}
+
+pub fn q12(input: NexmarkStream) -> Q12Stream {
+    q12_for_process_time(input, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        nexmark::{
+            generator::tests::make_bid,
+            model::{Bid, Event},
+        },
+        zset, Circuit,
+    };
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::one_bidder_single_window(
+        vec![vec![(1, 0), (1, 1), (1, 2), (1, 3)], vec![(1, 4), (1, 5)]],
+        vec![3_000, 4_000, 5_000, 6_000, 7_000, 8_000],
+        vec![
+            zset! {(1, 4, 0, 10_000) => 1},
+            zset! { (1, 4, 0, 10_000) => -1, (1, 6, 0, 10_000) => 1},
+        ],
+    )]
+    #[case::one_bidder_multiple_windows(
+        vec![vec![(1, 0), (1, 1), (1, 2), (1, 3)], vec![(1, 4), (1, 5)]],
+        vec![3_000, 4_000, 5_000, 6_000, 11_000, 12_000],
+        vec![
+            zset! {(1, 4, 0, 10_000) => 1},
+            zset! {(1, 2, 10_000, 20_000) => 1},
+        ],
+    )]
+    #[case::multiple_bidders_multiple_windows(
+        vec![vec![(1, 0), (1, 1), (1, 2), (1, 3), (2, 5), (2, 6)], vec![(1, 7), (1, 8)]],
+        vec![3_000, 4_000, 5_000, 6_000, 7_000, 8_000, 9_000, 11_000, 12_000],
+        vec![
+            zset! {(1, 4, 0, 10_000) => 1, (2, 2, 0, 10_000) => 1},
+            zset! {(1, 2, 10_000, 20_000) => 1},
+        ],
+    )]
+    fn test_q12(
+        #[case] bidder_bid_batches: Vec<Vec<(u64, u64)>>,
+        #[case] proc_times: Vec<u64>,
+        #[case] expected_zsets: Vec<OrdZSet<(u64, u64, u64, u64), isize>>,
+    ) {
+        let input_vecs = bidder_bid_batches.into_iter().map(|batch| {
+            batch
+                .into_iter()
+                .map(|(bidder, auction)| {
+                    (
+                        Event::Bid(Bid {
+                            bidder,
+                            auction,
+                            ..make_bid()
+                        }),
+                        1,
+                    )
+                })
+                .collect()
+        });
+
+        let (circuit, mut input_handle) = Circuit::build(move |circuit| {
+            let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
+
+            let output = q12_for_process_time(stream, Some(proc_times));
+
+            let mut expected_output = expected_zsets.into_iter();
+            output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
+
+            input_handle
+        })
+        .unwrap();
+
+        for mut vec in input_vecs {
+            input_handle.append(&mut vec);
+            circuit.step().unwrap();
+        }
+    }
+}

--- a/src/nexmark/queries/q13.rs
+++ b/src/nexmark/queries/q13.rs
@@ -1,11 +1,10 @@
-use super::NexmarkStream;
+use super::{process_time, NexmarkStream};
 use crate::{nexmark::model::Event, operator::FilterMap, Circuit, OrdZSet, Stream};
 
 use csv;
 use std::{
     fs::File,
     io::{BufReader, Read, Result},
-    time::SystemTime,
 };
 
 /// Query 13: Bounded Side Input Join (Not in original suite)
@@ -82,13 +81,6 @@ pub fn q13_side_input() -> Vec<((usize, String, u64), isize)> {
         .into_iter()
         .map(|(k, v)| ((k, v, p_time), 1))
         .collect()
-}
-
-fn process_time() -> u64 {
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_millis() as u64
 }
 
 pub fn q13(input: NexmarkStream, side_input: SideInputStream) -> Q13Stream {


### PR DESCRIPTION
This query demo's grouping and aggregation using process-time windows.

There are two TODOs that I'd be keen for any insight on, one is DBSP related (calling process_time() once per batch rather than on every event?), the other is related to the way I'm testing this query by injecting a vector of process times to emit.

Otherwise, 40s elapsed for 100M events (4 cores), compared to the Java implementation of 96s with 13 cores. DBSP is faring pretty well!

```
cargo bench --bench nexmark --features with-nexmark -- --first-event-rate=10000000 --max-events=100000000 --cpu-cores 4 --query q12 --num-event-generators 4 --source-buffer-size 10000 --input-batch-size 10000
    Finished bench [optimized + debuginfo] target(s) in 0.12s
     Running benches/nexmark/main.rs (target/release/deps/nexmark-db7e78eeb5fe8ae0)
Starting q12 bench of 100000000 events...
100,000,000 / 100,000,000 [=====================================================================================================================================================] 100 % 2562005.5364/s 0s
┌───────┬─────────────┬───────┬─────────┬─────────────────┬──────────────────┬───────────────┬───────────────┬─────────────┐
│ Query │ #Events     │ Cores │ Elapsed │ Cores * Elapsed │ Throughput/Cores │ Total Usr CPU │ Total Sys CPU │ Max RSS(Kb) │
├───────┼─────────────┼───────┼─────────┼─────────────────┼──────────────────┼───────────────┼───────────────┼─────────────┤
│ q12   │ 100,000,000 │ 4     │ 39.033s │ 156.131s        │ 640.487 K/s      │ 258.609s      │ 6.593s        │ 369,768     │
└───────┴─────────────┴───────┴─────────┴─────────────────┴──────────────────┴───────────────┴───────────────┴─────────────┘
```