### PR TITLE
[nexmark] Add q18 - illustrating deduplicate query.

### DIFF
--- a/benches/nexmark/main.rs
+++ b/benches/nexmark/main.rs
@@ -21,7 +21,8 @@ use dbsp::{
         config::Config as NexmarkConfig,
         model::Event,
         queries::{
-            q0, q1, q12, q13, q13_side_input, q14, q15, q16, q17, q2, q3, q4, q5, q6, q7, q8, q9,
+            q0, q1, q12, q13, q13_side_input, q14, q15, q16, q17, q18, q2, q3, q4, q5, q6, q7, q8,
+            q9,
         },
         NexmarkSource,
     },
@@ -337,7 +338,8 @@ fn main() -> Result<()> {
         ("q14", q14),
         ("q15", q15),
         ("q16", q16),
-        ("q17", q17)
+        ("q17", q17),
+        ("q18", q18)
     );
 
     let ascii_table = create_ascii_table();

--- a/src/nexmark/model.rs
+++ b/src/nexmark/model.rs
@@ -43,7 +43,7 @@ pub struct Auction {
 ///
 /// Note that Rust can simply derive the equivalent methods on the Java
 /// class.
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, SizeOf)]
+#[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, SizeOf)]
 pub struct Bid {
     /// Id of auction this bid is for.
     pub auction: u64,

--- a/src/nexmark/queries/mod.rs
+++ b/src/nexmark/queries/mod.rs
@@ -20,6 +20,7 @@ pub use q14::q14;
 pub use q15::q15;
 pub use q16::q16;
 pub use q17::q17;
+pub use q18::q18;
 
 type NexmarkStream = Stream<Circuit<()>, OrdZSet<Event, isize>>;
 
@@ -45,6 +46,7 @@ mod q14;
 mod q15;
 mod q16;
 mod q17;
+mod q18;
 
 fn process_time() -> u64 {
     SystemTime::now()

--- a/src/nexmark/queries/q18.rs
+++ b/src/nexmark/queries/q18.rs
@@ -1,0 +1,401 @@
+use super::NexmarkStream;
+use crate::{
+    nexmark::model::{Bid, Event},
+    operator::{FilterMap, Max},
+    Circuit, OrdZSet, Stream,
+};
+
+//
+// Query 18: Find last bid (Not in original suite)
+//
+// What's a's last bid for bidder to auction?
+// Illustrates a Deduplicate query.
+//
+/// ```sql
+/// CREATE TABLE discard_sink (
+///     auction  BIGINT,
+///     bidder  BIGINT,
+///     price  BIGINT,
+///     channel  VARCHAR,
+///     url  VARCHAR,
+///     dateTime  TIMESTAMP(3),
+///     extra  VARCHAR
+/// ) WITH (
+///   'connector' = 'blackhole'
+/// );
+///
+/// INSERT INTO discard_sink
+/// SELECT auction, bidder, price, channel, url, dateTime, extra
+///  FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY bidder, auction ORDER BY dateTime DESC) AS rank_number
+///        FROM bid)
+///  WHERE rank_number <= 1;
+/// ```
+
+type Q18Stream = Stream<Circuit<()>, OrdZSet<Bid, isize>>;
+
+pub fn q18(input: NexmarkStream) -> Q18Stream {
+    let bids_by_auction_bidder = input.flat_map_index(|event| match event {
+        Event::Bid(b) => Some(((b.auction, b.bidder), b.date_time)),
+        _ => None,
+    });
+
+    let latest_bid_per_auction_bidder = bids_by_auction_bidder
+        .aggregate::<(), _>(Max)
+        .map(|(&(auction, bidder), &date_time)| ((auction, bidder, date_time), ()))
+        .index();
+
+    input
+        .flat_map_index(|event| match event {
+            Event::Bid(b) => Some(((b.auction, b.bidder, b.date_time), b.clone())),
+            _ => None,
+        })
+        .join::<(), _, _, _>(&latest_bid_per_auction_bidder, |_, bid, _| bid.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        nexmark::{generator::tests::make_bid, model::Bid},
+        zset,
+    };
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::last_bid_for_single_bidder_single_auction(
+        vec![vec![
+            Bid {
+                auction: 1,
+                bidder: 1,
+                price: 10,
+                date_time: 1_000,
+                ..make_bid()
+            },
+            Bid {
+                auction: 1,
+                bidder: 1,
+                price: 20,
+                date_time: 3_000,
+                ..make_bid()
+            },
+            Bid {
+                auction: 1,
+                bidder: 1,
+                price: 30,
+                date_time: 2_000,
+                ..make_bid()
+            },
+        ], vec![
+            Bid {
+                auction: 1,
+                bidder: 1,
+                price: 50,
+                date_time: 4_000,
+                ..make_bid()
+            },
+        ]],
+        vec![zset! {
+            Bid {
+                auction: 1,
+                bidder: 1,
+                price: 20,
+                date_time: 3_000,
+                ..make_bid()
+            } => 1,
+        }, zset! {
+            Bid {
+                auction: 1,
+                bidder: 1,
+                price: 20,
+                date_time: 3_000,
+                ..make_bid()
+            } => -1,
+            Bid {
+                auction: 1,
+                bidder: 1,
+                price: 50,
+                date_time: 4_000,
+                ..make_bid()
+            } => 1,
+        }]
+    )]
+    #[case::last_bid_for_multi_bidders_single_auction(
+        vec![vec![
+            Bid {
+                auction: 1,
+                bidder: 1,
+                price: 10,
+                date_time: 1_000,
+                ..make_bid()
+            },
+            Bid {
+                auction: 1,
+                bidder: 2,
+                price: 20,
+                date_time: 3_000,
+                ..make_bid()
+            },
+            Bid {
+                auction: 1,
+                bidder: 1,
+                price: 30,
+                date_time: 2_000,
+                ..make_bid()
+            },
+            Bid {
+                auction: 1,
+                bidder: 2,
+                price: 40,
+                date_time: 4_000,
+                ..make_bid()
+            },
+        ], vec! [
+            Bid {
+                auction: 1,
+                bidder: 1,
+                price: 40,
+                date_time: 5_000,
+                ..make_bid()
+            },
+            Bid {
+                auction: 1,
+                bidder: 2,
+                price: 50,
+                date_time: 6_000,
+                ..make_bid()
+            },
+            Bid {
+                auction: 1,
+                bidder: 1,
+                price: 70,
+                date_time: 7_000,
+                ..make_bid()
+            },
+            Bid {
+                auction: 1,
+                bidder: 2,
+                price: 80,
+                date_time: 8_000,
+                ..make_bid()
+            },
+        ]],
+        vec![zset! {
+            Bid {
+                auction: 1,
+                bidder: 1,
+                price: 30,
+                date_time: 2_000,
+                ..make_bid()
+            } => 1,
+            Bid {
+                auction: 1,
+                bidder: 2,
+                price: 40,
+                date_time: 4_000,
+                ..make_bid()
+            } => 1,
+        }, zset! {
+            Bid {
+                auction: 1,
+                bidder: 1,
+                price: 30,
+                date_time: 2_000,
+                ..make_bid()
+            } => -1,
+            Bid {
+                auction: 1,
+                bidder: 2,
+                price: 40,
+                date_time: 4_000,
+                ..make_bid()
+            } => -1,
+            Bid {
+                auction: 1,
+                bidder: 1,
+                price: 70,
+                date_time: 7_000,
+                ..make_bid()
+            } => 1,
+            Bid {
+                auction: 1,
+                bidder: 2,
+                price: 80,
+                date_time: 8_000,
+                ..make_bid()
+            } => 1,
+        }]
+    )]
+    #[case::last_bid_for_multi_bidders_multi_auctions(
+        vec![vec![
+            Bid {
+                auction: 1,
+                bidder: 1,
+                price: 10,
+                date_time: 1_000,
+                ..make_bid()
+            },
+            Bid {
+                auction: 1,
+                bidder: 2,
+                price: 20,
+                date_time: 2_000,
+                ..make_bid()
+            },
+            Bid {
+                auction: 2,
+                bidder: 1,
+                price: 30,
+                date_time: 3_000,
+                ..make_bid()
+            },
+            Bid {
+                auction: 2,
+                bidder: 2,
+                price: 40,
+                date_time: 4_000,
+                ..make_bid()
+            },
+        ], vec! [
+            Bid {
+                auction: 1,
+                bidder: 1,
+                price: 50,
+                date_time: 5_000,
+                ..make_bid()
+            },
+            Bid {
+                auction: 1,
+                bidder: 2,
+                price: 60,
+                date_time: 6_000,
+                ..make_bid()
+            },
+            Bid {
+                auction: 2,
+                bidder: 1,
+                price: 70,
+                date_time: 7_000,
+                ..make_bid()
+            },
+            Bid {
+                auction: 2,
+                bidder: 2,
+                price: 80,
+                date_time: 8_000,
+                ..make_bid()
+            },
+        ]],
+        vec![zset! {
+            Bid {
+                auction: 1,
+                bidder: 1,
+                price: 10,
+                date_time: 1_000,
+                ..make_bid()
+            } => 1,
+            Bid {
+                auction: 1,
+                bidder: 2,
+                price: 20,
+                date_time: 2_000,
+                ..make_bid()
+            } => 1,
+            Bid {
+                auction: 2,
+                bidder: 1,
+                price: 30,
+                date_time: 3_000,
+                ..make_bid()
+            } => 1,
+            Bid {
+                auction: 2,
+                bidder: 2,
+                price: 40,
+                date_time: 4_000,
+                ..make_bid()
+            } => 1,
+        }, zset! {
+            Bid {
+                auction: 1,
+                bidder: 1,
+                price: 10,
+                date_time: 1_000,
+                ..make_bid()
+            } => -1,
+            Bid {
+                auction: 1,
+                bidder: 2,
+                price: 20,
+                date_time: 2_000,
+                ..make_bid()
+            } => -1,
+            Bid {
+                auction: 2,
+                bidder: 1,
+                price: 30,
+                date_time: 3_000,
+                ..make_bid()
+            } => -1,
+            Bid {
+                auction: 2,
+                bidder: 2,
+                price: 40,
+                date_time: 4_000,
+                ..make_bid()
+            } => -1,
+            Bid {
+                auction: 1,
+                bidder: 1,
+                price: 50,
+                date_time: 5_000,
+                ..make_bid()
+            } => 1,
+            Bid {
+                auction: 1,
+                bidder: 2,
+                price: 60,
+                date_time: 6_000,
+                ..make_bid()
+            } => 1,
+            Bid {
+                auction: 2,
+                bidder: 1,
+                price: 70,
+                date_time: 7_000,
+                ..make_bid()
+            } => 1,
+            Bid {
+                auction: 2,
+                bidder: 2,
+                price: 80,
+                date_time: 8_000,
+                ..make_bid()
+            } => 1,
+        }]
+    )]
+    fn test_q18(
+        #[case] input_bid_batches: Vec<Vec<Bid>>,
+        #[case] expected_zsets: Vec<OrdZSet<Bid, isize>>,
+    ) {
+        let input_vecs = input_bid_batches
+            .into_iter()
+            .map(|batch| batch.into_iter().map(|b| (Event::Bid(b), 1)).collect());
+
+        let (circuit, mut input_handle) = Circuit::build(move |circuit| {
+            let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
+
+            let output = q18(stream);
+
+            let mut expected_output = expected_zsets.into_iter();
+            output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
+
+            input_handle
+        })
+        .unwrap();
+
+        for mut vec in input_vecs {
+            input_handle.append(&mut vec);
+            circuit.step().unwrap();
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

This one is simpler in DBSP than it is in Flink SQL, I think (ie. just create the index and join). Though it has an even higher memory usage than q17, as it never discards old data from the index?

```
cargo bench --bench nexmark --features with-nexmark -- --first-event-rate=10000000 --max-events=10000000 --cpu-cores 8 --query q18 --num-event-generators 6 --source-buffer-size 10000 --input-batch-size 40000 
    Finished bench [optimized + debuginfo] target(s) in 0.99s
     Running benches/nexmark/main.rs (target/release/deps/nexmark-733304a45ec676db)
Starting q18 bench of 10000000 events...
10,000,000 / 10,000,000 [==================================================================================================================================================================] 100 % 1767134.2974/s 0s
┌───────┬────────────┬───────┬─────────┬─────────────────┬──────────────────┬───────────────┬───────────────┬─────────────┐
│ Query │ #Events    │ Cores │ Elapsed │ Cores * Elapsed │ Throughput/Cores │ Total Usr CPU │ Total Sys CPU │ Max RSS(Kb) │
├───────┼────────────┼───────┼─────────┼─────────────────┼──────────────────┼───────────────┼───────────────┼─────────────┤
│ q18   │ 10,000,000 │ 8     │ 5.677s  │ 45.417s         │ 220.182 K/s      │ 34.054s       │ 1.477s        │ 2,161,116   │
└───────┴────────────┴───────┴─────────┴─────────────────┴──────────────────┴───────────────┴───────────────┴─────────────┘
```

(again, unable to run complete 100M query without EOM).

That said, although it's not in the original query explicitly (but is implicitly), this query will probably benefit from only indexing a window of the data?