### PR TITLE
[nexmark] Add q20 - illustrating filter-join.

### DIFF
--- a/benches/nexmark/main.rs
+++ b/benches/nexmark/main.rs
@@ -21,8 +21,8 @@ use dbsp::{
         config::Config as NexmarkConfig,
         model::Event,
         queries::{
-            q0, q1, q12, q13, q13_side_input, q14, q15, q16, q17, q18, q2, q3, q4, q5, q6, q7, q8,
-            q9,
+            q0, q1, q12, q13, q13_side_input, q14, q15, q16, q17, q18, q2, q20, q3, q4, q5, q6, q7,
+            q8, q9,
         },
         NexmarkSource,
     },
@@ -339,7 +339,8 @@ fn main() -> Result<()> {
         ("q15", q15),
         ("q16", q16),
         ("q17", q17),
-        ("q18", q18)
+        ("q18", q18),
+        ("q20", q20)
     );
 
     let ascii_table = create_ascii_table();

--- a/src/nexmark/model.rs
+++ b/src/nexmark/model.rs
@@ -25,7 +25,7 @@ pub struct Person {
 ///
 /// Note that Rust can simply derive the equivalent methods on the Java
 /// class.
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, SizeOf)]
+#[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd, SizeOf)]
 pub struct Auction {
     pub id: u64,
     pub item_name: ArcStr,

--- a/src/nexmark/queries/mod.rs
+++ b/src/nexmark/queries/mod.rs
@@ -21,6 +21,7 @@ pub use q15::q15;
 pub use q16::q16;
 pub use q17::q17;
 pub use q18::q18;
+pub use q20::q20;
 
 type NexmarkStream = Stream<Circuit<()>, OrdZSet<Event, isize>>;
 
@@ -47,6 +48,8 @@ mod q15;
 mod q16;
 mod q17;
 mod q18;
+
+mod q20;
 
 fn process_time() -> u64 {
     SystemTime::now()

--- a/src/nexmark/queries/q20.rs
+++ b/src/nexmark/queries/q20.rs
@@ -1,0 +1,212 @@
+use super::NexmarkStream;
+use crate::{
+    nexmark::model::{Auction, Bid, Event},
+    operator::FilterMap,
+    Circuit, OrdZSet, Stream,
+};
+
+///
+/// Query 20: Expand bid with auction (Not in original suite)
+///
+/// Get bids with the corresponding auction information where category is 10.
+/// Illustrates a filter join.
+//
+// -- TODO: streaming join doesn't support rowtime attribute in input, this
+// should be fixed by FLINK-18651. --  As a workaround, we re-create a new view
+// without rowtime attribute for now. DROP VIEW IF EXISTS auction;
+// DROP VIEW IF EXISTS bid;
+// CREATE VIEW auction AS SELECT auction.* FROM ${NEXMARK_TABLE} WHERE
+// event_type = 1; CREATE VIEW bid AS SELECT bid.* FROM ${NEXMARK_TABLE} WHERE
+// event_type = 2;
+//
+// CREATE TABLE discard_sink (
+//     auction  BIGINT,
+//     bidder  BIGINT,
+//     price  BIGINT,
+//     channel  VARCHAR,
+//     url  VARCHAR,
+//     bid_dateTime  TIMESTAMP(3),
+//     bid_extra  VARCHAR,
+//
+//     itemName  VARCHAR,
+//     description  VARCHAR,
+//     initialBid  BIGINT,
+//     reserve  BIGINT,
+//     auction_dateTime  TIMESTAMP(3),
+//     expires  TIMESTAMP(3),
+//     seller  BIGINT,
+//     category  BIGINT,
+//     auction_extra  VARCHAR
+// ) WITH (
+//     'connector' = 'blackhole'
+// );
+//
+// INSERT INTO discard_sink
+// SELECT
+//     auction, bidder, price, channel, url, B.dateTime, B.extra,
+//     itemName, description, initialBid, reserve, A.dateTime, expires, seller,
+// category, A.extra FROM
+//     bid AS B INNER JOIN auction AS A on B.auction = A.id
+// WHERE A.category = 10;
+//
+
+type Q20Stream = Stream<Circuit<()>, OrdZSet<(Bid, Auction), isize>>;
+
+pub fn q20(input: NexmarkStream) -> Q20Stream {
+    let bids_by_auction = input.flat_map_index(|event| match event {
+        Event::Bid(b) => Some((b.auction, b.clone())),
+        _ => None,
+    });
+
+    let auctions_indexed = input.flat_map_index(|event| match event {
+        Event::Auction(a) => Some((a.id, a.clone())),
+        _ => None,
+    });
+
+    bids_by_auction.join::<(), _, _, _>(&auctions_indexed, |_, bid, auction| {
+        (bid.clone(), auction.clone())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        nexmark::{
+            generator::tests::{make_auction, make_bid},
+            model::{Auction, Bid},
+        },
+        zset,
+    };
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::auction_bids_single_auction(
+        vec![vec![
+            Event::Auction(Auction {
+                id: 1,
+                ..make_auction()
+            }),
+            Event::Bid(Bid {
+                auction: 1,
+                bidder: 10,
+                price: 10,
+                ..make_bid()
+            }),
+            Event::Bid(Bid {
+                auction: 1,
+                bidder: 20,
+                price: 20,
+                ..make_bid()
+            }),
+            // This bid should not appear anywhere as the auction does not exist.
+            Event::Bid(Bid {
+                auction: 2,
+                bidder: 50,
+                price: 50,
+                ..make_bid()
+            }),
+            Event::Bid(Bid {
+                auction: 1,
+                bidder: 30,
+                price: 30,
+                ..make_bid()
+            }),
+        ], vec![
+            Event::Bid(Bid {
+                auction: 1,
+                bidder: 40,
+                price: 40,
+                ..make_bid()
+            }),
+        ]],
+        vec![zset! {
+            (Bid { auction: 1, bidder: 10, price: 10, ..make_bid()}, Auction { id: 1, ..make_auction() }) => 1,
+            (Bid { auction: 1, bidder: 20, price: 20, ..make_bid()}, Auction { id: 1, ..make_auction() }) => 1,
+            (Bid { auction: 1, bidder: 30, price: 30, ..make_bid()}, Auction { id: 1, ..make_auction() }) => 1,
+        }, zset! {
+            (Bid { auction: 1, bidder: 40, price: 40, ..make_bid()}, Auction { id: 1, ..make_auction() }) => 1,
+        }])]
+    #[case::auction_bids_multiple_auctions(
+        vec![vec![
+            Event::Auction(Auction {
+                id: 1,
+                ..make_auction()
+            }),
+            Event::Bid(Bid {
+                auction: 1,
+                bidder: 10,
+                price: 10,
+                ..make_bid()
+            }),
+            Event::Bid(Bid {
+                auction: 1,
+                bidder: 20,
+                price: 20,
+                ..make_bid()
+            }),
+            Event::Auction(Auction {
+                id: 2,
+                ..make_auction()
+            }),
+            Event::Bid(Bid {
+                auction: 2,
+                bidder: 50,
+                price: 50,
+                ..make_bid()
+            }),
+            Event::Bid(Bid {
+                auction: 1,
+                bidder: 30,
+                price: 30,
+                ..make_bid()
+            }),
+        ], vec![
+            Event::Bid(Bid {
+                auction: 1,
+                bidder: 40,
+                price: 40,
+                ..make_bid()
+            }),
+            Event::Bid(Bid {
+                auction: 2,
+                bidder: 60,
+                price: 60,
+                ..make_bid()
+            }),
+        ]],
+        vec![zset! {
+            (Bid { auction: 1, bidder: 10, price: 10, ..make_bid()}, Auction { id: 1, ..make_auction() }) => 1,
+            (Bid { auction: 1, bidder: 20, price: 20, ..make_bid()}, Auction { id: 1, ..make_auction() }) => 1,
+            (Bid { auction: 1, bidder: 30, price: 30, ..make_bid()}, Auction { id: 1, ..make_auction() }) => 1,
+            (Bid { auction: 2, bidder: 50, price: 50, ..make_bid()}, Auction { id: 2, ..make_auction() }) => 1,
+        }, zset! {
+            (Bid { auction: 1, bidder: 40, price: 40, ..make_bid()}, Auction { id: 1, ..make_auction() }) => 1,
+            (Bid { auction: 2, bidder: 60, price: 60, ..make_bid()}, Auction { id: 2, ..make_auction() }) => 1,
+        }])]
+    fn test_q20(
+        #[case] input_event_batches: Vec<Vec<Event>>,
+        #[case] expected_zsets: Vec<OrdZSet<(Bid, Auction), isize>>,
+    ) {
+        let input_vecs = input_event_batches
+            .into_iter()
+            .map(|batch| batch.into_iter().map(|e| (e, 1)).collect());
+
+        let (circuit, mut input_handle) = Circuit::build(move |circuit| {
+            let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
+
+            let output = q20(stream);
+
+            let mut expected_output = expected_zsets.into_iter();
+            output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
+
+            input_handle
+        })
+        .unwrap();
+
+        for mut vec in input_vecs {
+            input_handle.append(&mut vec);
+            circuit.step().unwrap();
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

So I jumped to this one after failing to find a way to do [q19](https://github.com/nexmark/nexmark/blob/master/nexmark-flink/src/main/resources/queries/q19.sql) (is there a way to do top-10 efficiently with DBSP?). Anyway, q20 itself was pretty straight-forward, if memory intensive (given the auction index that is never pruned?):

With 10M it's using 2Gb:
```
$ cargo bench --bench nexmark --features with-nexmark -- --first-event-rate=10000000 --max-events=10000000 --cpu-cores 8 --query q20 --num-event-generators 6 --source-buffer-size 10000 --input-batch-size 40000
   Compiling dbsp v0.1.0 (/home/michael/dev/vmware/database-stream-processor)
    Finished bench [optimized + debuginfo] target(s) in 3m 32s
     Running benches/nexmark/main.rs (target/release/deps/nexmark-733304a45ec676db)
Starting q20 bench of 10000000 events...
10,000,000 / 10,000,000 [=======================================================================================================================================================] 100 % 1771803.5181/s 0s
┌───────┬────────────┬───────┬─────────┬─────────────────┬──────────────────┬───────────────┬───────────────┬─────────────┐
│ Query │ #Events    │ Cores │ Elapsed │ Cores * Elapsed │ Throughput/Cores │ Total Usr CPU │ Total Sys CPU │ Max RSS(Kb) │
├───────┼────────────┼───────┼─────────┼─────────────────┼──────────────────┼───────────────┼───────────────┼─────────────┤
│ q20   │ 10,000,000 │ 8     │ 5.645s  │ 45.163s         │ 221.418 K/s      │ 31.675s       │ 1.423s        │ 2,059,816   │
└───────┴────────────┴───────┴─────────┴─────────────────┴──────────────────┴───────────────┴───────────────┴─────────────┘
```

With 100M it gets killed:

```
$ cargo bench --bench nexmark --features with-nexmark -- --first-event-rate=10000000 --max-events=100000000 --cpu-cores 8 --query q20 --num-event-generators 6 --source-buffer-size 10000 --input-batch-size 40000
    Finished bench [optimized + debuginfo] target(s) in 0.11s
     Running benches/nexmark/main.rs (target/release/deps/nexmark-733304a45ec676db)
Starting q20 bench of 100000000 events...
81,320,000 / 100,000,000 [=========================================================================================================================>----------------------------] 81 % 1926052.9179/s 10serror: bench failed, to rerun pass `--bench nexmark`

Caused by:
  process didn't exit successfully: `/home/michael/dev/vmware/database-stream-processor/target/release/deps/nexmark-733304a45ec676db --first-event-rate=10000000 --max-events=100000000 --cpu-cores 8 --query q20 --num-event-generators 6 --source-buffer-size 10000 --input-batch-size 40000 --bench` (signal: 9, SIGKILL: kill)
```