### PR TITLE
[nexmark] Add q22 - Flink's SPLIT_INDEX but a trivial split for Rust

### DIFF
--- a/benches/nexmark/main.rs
+++ b/benches/nexmark/main.rs
@@ -21,8 +21,8 @@ use dbsp::{
         config::Config as NexmarkConfig,
         model::Event,
         queries::{
-            q0, q1, q12, q13, q13_side_input, q14, q15, q16, q17, q18, q19, q2, q20, q21, q3, q4,
-            q5, q6, q7, q8, q9,
+            q0, q1, q12, q13, q13_side_input, q14, q15, q16, q17, q18, q19, q2, q20, q21, q22, q3,
+            q4, q5, q6, q7, q8, q9,
         },
         NexmarkSource,
     },
@@ -342,7 +342,8 @@ fn main() -> Result<()> {
         ("q18", q18),
         ("q19", q19),
         ("q20", q20),
-        ("q21", q21)
+        ("q21", q21),
+        ("q22", q22)
     );
 
     let ascii_table = create_ascii_table();

--- a/src/nexmark/queries/mod.rs
+++ b/src/nexmark/queries/mod.rs
@@ -24,6 +24,7 @@ pub use q18::q18;
 pub use q19::q19;
 pub use q20::q20;
 pub use q21::q21;
+pub use q22::q22;
 
 type NexmarkStream = Stream<Circuit<()>, OrdZSet<Event, isize>>;
 
@@ -53,6 +54,7 @@ mod q18;
 mod q19;
 mod q20;
 mod q21;
+mod q22;
 
 fn process_time() -> u64 {
     SystemTime::now()

--- a/src/nexmark/queries/q22.rs
+++ b/src/nexmark/queries/q22.rs
@@ -1,0 +1,130 @@
+use super::NexmarkStream;
+use crate::{nexmark::model::Event, operator::FilterMap, Circuit, OrdZSet, Stream};
+use arcstr::ArcStr;
+
+///
+/// Query 22: Get URL Directories (Not in original suite)
+///
+/// What is the directory structure of the URL?
+/// Illustrates a SPLIT_INDEX SQL.
+///
+/// ```sql
+/// CREATE TABLE discard_sink (
+///       auction  BIGINT,
+///       bidder  BIGINT,
+///       price  BIGINT,
+///       channel  VARCHAR,
+///       dir1  VARCHAR,
+///       dir2  VARCHAR,
+///       dir3  VARCHAR
+/// ) WITH (
+///     'connector' = 'blackhole'
+/// );
+///
+/// INSERT INTO discard_sink
+/// SELECT
+///     auction, bidder, price, channel,
+///     SPLIT_INDEX(url, '/', 3) as dir1,
+///     SPLIT_INDEX(url, '/', 4) as dir2,
+///     SPLIT_INDEX(url, '/', 5) as dir3 FROM bid;
+/// ```
+
+type Q22Stream =
+    Stream<Circuit<()>, OrdZSet<(u64, u64, usize, ArcStr, ArcStr, ArcStr, ArcStr), isize>>;
+
+pub fn q22(input: NexmarkStream) -> Q22Stream {
+    input.flat_map(|event| match event {
+        Event::Bid(b) => {
+            // Just ensure the split vector has a length of at least 6 to index 5.
+            let mut split: Vec<&str> = b.channel.as_str().split('/').collect();
+            if split.len() < 6 {
+                split.extend(vec![""; 6 - split.len()])
+            }
+            let (dir1, dir2, dir3) = (split[3], split[4], split[5]);
+            Some((
+                b.auction,
+                b.bidder,
+                b.price,
+                b.channel.clone(),
+                dir1.into(),
+                dir2.into(),
+                dir3.into(),
+            ))
+        }
+        _ => None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        nexmark::{generator::tests::make_bid, model::Bid},
+        zset,
+    };
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::bids_with_well_formed_urls(
+        vec![vec![
+            Event::Bid(Bid {
+                channel: ArcStr::from("https://example.com/foo/bar/zed"),
+                ..make_bid()
+            }),
+            Event::Bid(Bid {
+                channel: ArcStr::from("https://example.com/dir1/dir2/dir3/dir4/dir5"),
+                ..make_bid()
+            }),
+        ]],
+        vec![zset!{
+            (1, 1, 99, ArcStr::from("https://example.com/foo/bar/zed"), ArcStr::from("foo"), ArcStr::from("bar"), ArcStr::from("zed")) => 1,
+            (1, 1, 99, ArcStr::from("https://example.com/dir1/dir2/dir3/dir4/dir5"), ArcStr::from("dir1"), ArcStr::from("dir2"), ArcStr::from("dir3")) => 1,
+        }])]
+    #[case::bids_mixed_with_non_urls(
+        vec![vec![
+            Event::Bid(Bid {
+                channel: ArcStr::from("https://example.com/foo/bar/zed"),
+                ..make_bid()
+            }),
+            Event::Bid(Bid {
+                channel: ArcStr::from("Google"),
+                ..make_bid()
+            }),
+            Event::Bid(Bid {
+                channel: ArcStr::from("https:badly.formed/dir1/dir2/dir3"),
+                ..make_bid()
+            }),
+        ]],
+        vec![zset!{
+            (1, 1, 99, ArcStr::from("https://example.com/foo/bar/zed"), ArcStr::from("foo"), ArcStr::from("bar"), ArcStr::from("zed")) => 1,
+            (1, 1, 99, ArcStr::from("Google"), ArcStr::from(""), ArcStr::from(""), ArcStr::from("")) => 1,
+            (1, 1, 99, ArcStr::from("https:badly.formed/dir1/dir2/dir3"), ArcStr::from("dir3"), ArcStr::from(""), ArcStr::from("")) => 1,
+        }])]
+    fn test_q22(
+        #[case] input_event_batches: Vec<Vec<Event>>,
+        #[case] expected_zsets: Vec<
+            OrdZSet<(u64, u64, usize, ArcStr, ArcStr, ArcStr, ArcStr), isize>,
+        >,
+    ) {
+        let input_vecs = input_event_batches
+            .into_iter()
+            .map(|batch| batch.into_iter().map(|e| (e, 1)).collect());
+
+        let (circuit, mut input_handle) = Circuit::build(move |circuit| {
+            let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
+
+            let output = q22(stream);
+
+            let mut expected_output = expected_zsets.into_iter();
+            output.inspect(move |batch| assert_eq!(batch, &expected_output.next().unwrap()));
+
+            input_handle
+        })
+        .unwrap();
+
+        for mut vec in input_vecs {
+            input_handle.append(&mut vec);
+            circuit.step().unwrap();
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Michael Nelson <minelson@vmware.com>

```
cargo bench --bench nexmark --features with-nexmark -- --first-event-rate=10000000 --max-events=100000000 --cpu-cores 8 --query q22 --num-event-generators 6 --source-buffer-size 10000 --input-batch-size 40000 
   Compiling dbsp v0.1.0 (/home/michael/dev/vmware/database-stream-processor)
    Finished bench [optimized + debuginfo] target(s) in 3m 49s
     Running benches/nexmark/main.rs (target/release/deps/nexmark-5744354f98061c26)
Starting q22 bench of 100000000 events...
100,000,000 / 100,000,000 [=================================================================================================================================================================================================] 100 % 2722658.5899/s 0s
┌───────┬─────────────┬───────┬─────────┬─────────────────┬──────────────────┬───────────────┬───────────────┬─────────────┐
│ Query │ #Events     │ Cores │ Elapsed │ Cores * Elapsed │ Throughput/Cores │ Total Usr CPU │ Total Sys CPU │ Max RSS(Kb) │
├───────┼─────────────┼───────┼─────────┼─────────────────┼──────────────────┼───────────────┼───────────────┼─────────────┤
│ q22   │ 100,000,000 │ 8     │ 36.730s │ 293.844s        │ 340.317 K/s      │ 288.768s      │ 30.813s       │ 110,540     │
└───────┴─────────────┴───────┴─────────┴─────────────────┴──────────────────┴───────────────┴───────────────┴─────────────┘
```