### PR TITLE
Enhanced nexmark cli and cleaned up code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,6 +584,7 @@ dependencies = [
  "num-format",
  "once_cell",
  "ordered-float",
+ "paste",
  "petgraph",
  "priority-queue",
  "proptest",
@@ -1385,6 +1386,12 @@ dependencies = [
  "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "pbkdf2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ with-nexmark = [
     "time",
     "size-of/rust_decimal",
     "size-of/arcstr",
+    "paste",
 ]
 
 [dependencies]
@@ -40,6 +41,7 @@ arcstr = { version = "1.1.4", optional = true }
 rust_decimal = { version = "1.26.1", optional = true }
 regex = { version = "1.6.0", optional = true }
 time = { version = "0.3.14", features = ["formatting"], optional = true }
+paste = { version = "1.0.9", optional = true }
 
 # TODO: Remove these dependencies
 rand = { version = "0.8", optional = true }

--- a/benches/galen.rs
+++ b/benches/galen.rs
@@ -1,6 +1,8 @@
 //! Galen benchmark from
 //! `https://github.com/frankmcsherry/dynamic-datalog/tree/master/problems/galen`
 
+mod mimalloc;
+
 use anyhow::{Context, Result};
 use clap::Parser;
 use csv::ReaderBuilder;
@@ -8,6 +10,7 @@ use dbsp::{
     monitor::TraceMonitor, operator::CsvSource, time::NestedTimestamp32, trace::BatchReader,
     Circuit, OrdZSet, Runtime, Stream,
 };
+use mimalloc::MiMalloc;
 use std::{
     fs::{self, File},
     io::BufReader,
@@ -16,6 +19,9 @@ use std::{
     time::Instant,
 };
 use zip::ZipArchive;
+
+#[global_allocator]
+static ALLOC: MiMalloc = MiMalloc;
 
 /*
 .decl p(X: Number, Z: Number)

--- a/benches/galen.rs
+++ b/benches/galen.rs
@@ -6,7 +6,7 @@ use clap::Parser;
 use csv::ReaderBuilder;
 use dbsp::{
     monitor::TraceMonitor, operator::CsvSource, time::NestedTimestamp32, trace::BatchReader,
-    Circuit, OrdIndexedZSet, OrdZSet, Runtime, Stream,
+    Circuit, OrdZSet, Runtime, Stream,
 };
 use std::{
     fs::{self, File},

--- a/benches/mimalloc.rs
+++ b/benches/mimalloc.rs
@@ -1,0 +1,113 @@
+use mimalloc_rust_sys::{
+    aligned_allocation::{mi_malloc_aligned, mi_realloc_aligned, mi_zalloc_aligned},
+    basic_allocation::{mi_free, mi_malloc, mi_realloc, mi_zalloc},
+    extended_functions::{mi_process_info, mi_stats_reset},
+};
+use std::alloc::{GlobalAlloc, Layout};
+
+/// `MI_MAX_ALIGN_SIZE` is 16 unless manually overridden:
+/// https://github.com/microsoft/mimalloc/blob/15220c68/include/mimalloc-types.h#L22
+const MI_MAX_ALIGN_SIZE: usize = 16;
+
+/// Allocation and process statistics
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AllocStats {
+    pub elapsed_ms: usize,
+    pub user_ms: usize,
+    pub system_ms: usize,
+    pub current_rss: usize,
+    pub peak_rss: usize,
+    pub current_commit: usize,
+    pub peak_commit: usize,
+    pub page_faults: usize,
+}
+
+/// A [`GlobalAlloc`] implementation that uses `mimalloc`
+#[derive(Debug, Clone, Copy, Default)]
+pub struct MiMalloc;
+
+// The dead code lint triggers if the function is unused within any benchmark,
+// not if it's unused in all of them
+#[allow(dead_code)]
+impl MiMalloc {
+    /// Collect allocation stats
+    pub fn stats(&self) -> AllocStats {
+        let mut stats = AllocStats::default();
+        unsafe {
+            mi_process_info(
+                &mut stats.elapsed_ms,
+                &mut stats.user_ms,
+                &mut stats.system_ms,
+                &mut stats.current_rss,
+                &mut stats.peak_rss,
+                &mut stats.current_commit,
+                &mut stats.peak_commit,
+                &mut stats.page_faults,
+            );
+        }
+
+        stats
+    }
+
+    /// Reset allocation statistics
+    pub fn reset_stats(&self) {
+        unsafe { mi_stats_reset() };
+    }
+}
+
+// Using the normal (unaligned) mimalloc apis is apparently marginally faster
+// and better supported than using the aligned api for everything, so we do a
+// check to see if the allocation falls within the range where it's better to
+// use the unaligned api
+//
+// See https://github.com/microsoft/mimalloc/issues/314
+unsafe impl GlobalAlloc for MiMalloc {
+    #[inline]
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if use_unaligned_api(layout.size(), layout.align()) {
+            mi_malloc(layout.size())
+        } else {
+            mi_malloc_aligned(layout.size(), layout.align())
+        }
+        .cast()
+    }
+
+    #[inline]
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        if use_unaligned_api(layout.size(), layout.align()) {
+            mi_zalloc(layout.size())
+        } else {
+            mi_zalloc_aligned(layout.size(), layout.align())
+        }
+        .cast()
+    }
+
+    #[inline]
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let ptr = ptr.cast();
+        if use_unaligned_api(layout.size(), layout.align()) {
+            mi_realloc(ptr, new_size)
+        } else {
+            mi_realloc_aligned(ptr, new_size, layout.align())
+        }
+        .cast()
+    }
+
+    #[inline]
+    unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
+        // Deallocation doesn't care about alignment which is nice
+        mi_free(ptr.cast());
+    }
+}
+
+#[inline(always)]
+const fn use_unaligned_api(size: usize, alignment: usize) -> bool {
+    // This logic is based on the discussion [here]. We don't bother with the
+    // 3rd suggested test due to it being high cost (calling `mi_good_size`)
+    // compared to the other checks, and also feeling like it relies on too much
+    // implementation-specific behavior.
+    //
+    // [here]: https://github.com/microsoft/mimalloc/issues/314#issuecomment-708541845
+    (alignment <= MI_MAX_ALIGN_SIZE && size >= alignment)
+        || (alignment == size && alignment <= 4096)
+}

--- a/benches/nexmark/allocation.rs
+++ b/benches/nexmark/allocation.rs
@@ -1,0 +1,62 @@
+use mimalloc_rust_sys::{
+    aligned_allocation::{mi_malloc_aligned, mi_realloc_aligned, mi_zalloc_aligned},
+    basic_allocation::mi_free,
+    extended_functions::mi_process_info,
+};
+use std::alloc::{GlobalAlloc, Layout};
+
+pub struct MiMalloc;
+
+impl MiMalloc {
+    pub fn stats(&self) -> AllocStats {
+        let mut stats = AllocStats::default();
+        unsafe {
+            mi_process_info(
+                &mut stats.elapsed_ms,
+                &mut stats.user_ms,
+                &mut stats.system_ms,
+                &mut stats.current_rss,
+                &mut stats.peak_rss,
+                &mut stats.current_commit,
+                &mut stats.peak_commit,
+                &mut stats.page_faults,
+            );
+        }
+
+        stats
+    }
+}
+
+unsafe impl GlobalAlloc for MiMalloc {
+    #[inline]
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        mi_malloc_aligned(layout.size(), layout.align()).cast()
+    }
+
+    #[inline]
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        mi_zalloc_aligned(layout.size(), layout.align()).cast()
+    }
+
+    #[inline]
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        mi_realloc_aligned(ptr.cast(), new_size, layout.align()).cast()
+    }
+
+    #[inline]
+    unsafe fn dealloc(&self, ptr: *mut u8, _layout: Layout) {
+        mi_free(ptr.cast());
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct AllocStats {
+    pub elapsed_ms: usize,
+    pub user_ms: usize,
+    pub system_ms: usize,
+    pub current_rss: usize,
+    pub peak_rss: usize,
+    pub current_commit: usize,
+    pub peak_commit: usize,
+    pub page_faults: usize,
+}

--- a/benches/nexmark/main.rs
+++ b/benches/nexmark/main.rs
@@ -3,22 +3,17 @@
 //! CLI for running Nexmark benchmarks with DBSP.
 #![feature(is_some_with)]
 
-#[cfg(unix)]
-use libc::{getrusage, rusage, timeval};
-#[cfg(unix)]
-use std::{io::Error, mem::MaybeUninit};
-use std::{
-    sync::mpsc,
-    thread::{self, JoinHandle},
-    time::{Duration, Instant},
-};
+#[macro_use]
+mod run_queries;
+mod allocation;
 
+use crate::allocation::{AllocStats, MiMalloc};
 use anyhow::{anyhow, Result};
 use ascii_table::AsciiTable;
 use clap::Parser;
 use dbsp::{
     nexmark::{
-        config::Config as NexmarkConfig,
+        config::{Config as NexmarkConfig, Query as NexmarkQuery},
         model::Event,
         queries::{
             q0, q1, q12, q13, q13_side_input, q14, q15, q16, q17, q18, q19, q2, q20, q21, q22, q3,
@@ -31,44 +26,20 @@ use dbsp::{
 };
 use indicatif::{ProgressBar, ProgressStyle};
 use num_format::{Locale, ToFormattedString};
+use size_of::HumanBytes;
+use std::{
+    sync::mpsc,
+    thread::{self, JoinHandle},
+    time::{Duration, Instant},
+};
+
+#[global_allocator]
+static ALLOC: MiMalloc = MiMalloc;
 
 // TODO: Ideally these macros would be in a separate `lib.rs` in this benchmark
 // crate, but benchmark binaries don't appear to work like that (in that, I
 // haven't yet found a way to import from a `lib.rs` in the same directory as
 // the benchmark's `main.rs`)
-
-/// Returns a closure for a circuit with the nexmark source that returns
-/// the input handle.
-macro_rules! nexmark_circuit {
-    ( "q13", $q:expr ) => {
-        |circuit: &mut Circuit<()>| {
-            let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
-            let (side_stream, mut side_input_handle) =
-                circuit.add_input_zset::<(usize, String, u64), isize>();
-
-            let output = $q(stream, side_stream);
-
-            output.inspect(move |_zs| ());
-
-            // Ensure the side-input is loaded here so we can return a single input
-            // handle like the other queries.
-            side_input_handle.append(&mut q13_side_input());
-
-            input_handle
-        }
-    };
-    ( $q_name:expr, $q:expr ) => {
-        |circuit: &mut Circuit<()>| {
-            let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
-
-            let output = $q(stream);
-
-            output.inspect(move |_zs| ());
-
-            input_handle
-        }
-    };
-}
 
 /// Currently just the elapsed time, but later add CPU and Mem.
 #[derive(Default)]
@@ -76,9 +47,8 @@ struct NexmarkResult {
     name: String,
     num_events: u64,
     elapsed: Duration,
-    total_usr_cpu: Duration,
-    total_sys_cpu: Duration,
-    max_rss: Option<u64>,
+    before_stats: AllocStats,
+    after_stats: AllocStats,
 }
 
 struct InputStats {
@@ -206,100 +176,29 @@ fn coordinate_input_and_steps(
     }
 }
 
-macro_rules! run_query {
-    ( $q_name:tt, $q:expr, $nexmark_config:expr) => {{
-        // let circuit_closure = nexmark_circuit!($q_name, $q);
-        let circuit_closure = nexmark_circuit!($q_name, $q);
-
-        let num_cores = $nexmark_config.cpu_cores;
-        let expected_num_events = $nexmark_config.max_events;
-        let (dbsp, input_handle) = Runtime::init_circuit(num_cores, circuit_closure).unwrap();
-
-        // Create a channel for the coordinating thread to determine whether the
-        // producer or consumer step is completed first.
-        let (step_done_tx, step_done_rx) = mpsc::sync_channel(2);
-
-        // Start the DBSP runtime processing steps only when it receives a message to do
-        // so. The DBSP processing happens in its own thread where the resource usage
-        // calculation can also happen.
-        let (dbsp_step_tx, dbsp_step_rx) = mpsc::sync_channel(1);
-        let dbsp_join_handle = spawn_dbsp_consumer(dbsp, dbsp_step_rx, step_done_tx.clone());
-
-        // Start the generator inputting the specified number of batches to the circuit
-        // whenever it receives a message.
-        let (source_step_tx, source_step_rx): (mpsc::SyncSender<()>, mpsc::Receiver<()>) =
-            mpsc::sync_channel(1);
-        let (source_exhausted_tx, source_exhausted_rx) = mpsc::sync_channel(1);
-        spawn_source_producer(
-            $nexmark_config,
-            input_handle,
-            source_step_rx,
-            step_done_tx,
-            source_exhausted_tx,
-        );
-
-        let input_stats = coordinate_input_and_steps(
-            expected_num_events,
-            dbsp_step_tx,
-            source_step_tx,
-            step_done_rx,
-            source_exhausted_rx,
-            dbsp_join_handle,
-        )
-        .unwrap();
-
-        // Return the user/system CPU overhead from the generator/input thread.
-        NexmarkResult {
-            num_events: input_stats.num_events,
-            ..NexmarkResult::default()
-        }
-    }};
-}
-
-macro_rules! run_queries {
-    ( $nexmark_config:expr, $max_events:expr, $queries_to_run:expr, $( ($q_name:tt, $q:expr) ),+ ) => {{
-        let mut results: Vec<NexmarkResult> = Vec::new();
-        // We have no way (currently) of finding the max memory usage for each
-        // subsequent query as the value is for the process. So only the first
-        // query will have a value.
-        let mut query_count = 0;
-        $(
-        if $queries_to_run.len() == 0 || $queries_to_run.contains(&$q_name.to_string()) {
-            query_count += 1;
-            println!("Starting {} bench of {} events...", $q_name, $max_events);
-
-            let start = Instant::now();
-            let (before_usr_cpu, before_sys_cpu, before_max_rss) = unsafe { rusage(RUSAGE_SELF) };
-
-            let thread_nexmark_config = $nexmark_config.clone();
-            let result = run_query!($q_name, $q, thread_nexmark_config);
-            let (after_usr_cpu, after_sys_cpu, after_max_rss) = unsafe { rusage(RUSAGE_SELF) };
-            results.push(NexmarkResult {
-                name: $q_name.to_string(),
-                total_usr_cpu: after_usr_cpu - before_usr_cpu,
-                total_sys_cpu: after_sys_cpu - before_sys_cpu,
-                max_rss: match query_count { 1 => Some(after_max_rss - before_max_rss), _ => None},
-                elapsed: start.elapsed(),
-                ..result
-            });
-        }
-        )+
-        results
-    }};
-}
-
 fn create_ascii_table() -> AsciiTable {
     let mut ascii_table = AsciiTable::default();
     ascii_table.set_max_width(200);
-    ascii_table.column(0).set_header("Query");
-    ascii_table.column(1).set_header("#Events");
-    ascii_table.column(2).set_header("Cores");
-    ascii_table.column(3).set_header("Elapsed");
-    ascii_table.column(4).set_header("Cores * Elapsed");
-    ascii_table.column(5).set_header("Throughput/Cores");
-    ascii_table.column(6).set_header("Total Usr CPU");
-    ascii_table.column(7).set_header("Total Sys CPU");
-    ascii_table.column(8).set_header("Max RSS(Kb)");
+
+    let columns = [
+        "Query",
+        "#Events",
+        "Cores",
+        "Elapsed",
+        "Cores * Elapsed",
+        "Throughput/Cores",
+        "Total Usr CPU",
+        "Total Sys CPU",
+        "Current RSS",
+        "Peak RSS",
+        "Current Commit",
+        "Peak Commit",
+        "Page Faults",
+    ];
+    for (idx, column_name) in columns.into_iter().enumerate() {
+        ascii_table.column(idx).set_header(column_name);
+    }
+
     ascii_table
 }
 
@@ -323,90 +222,60 @@ fn main() -> Result<()> {
         nexmark_config,
         max_events,
         queries_to_run,
-        ("q0", q0),
-        ("q1", q1),
-        ("q2", q2),
-        ("q3", q3),
-        ("q4", q4),
-        ("q5", q5),
-        ("q6", q6),
-        ("q7", q7),
-        ("q8", q8),
-        ("q9", q9),
-        ("q12", q12),
-        ("q13", q13),
-        ("q14", q14),
-        ("q15", q15),
-        ("q16", q16),
-        ("q17", q17),
-        ("q18", q18),
-        ("q19", q19),
-        ("q20", q20),
-        ("q21", q21),
-        ("q22", q22)
+        queries => {
+            q0,
+            q1,
+            q2,
+            q3,
+            q4,
+            q5,
+            q6,
+            q7,
+            q8,
+            q9,
+            q12,
+            q13,
+            q14,
+            q15,
+            q16,
+            q17,
+            q18,
+            q19,
+            q20,
+            q21,
+            q22,
+        }
     );
 
     let ascii_table = create_ascii_table();
-    ascii_table.print(results.into_iter().map(|r| {
+    ascii_table.print(results.into_iter().map(|result| {
+        let (before, after) = (result.before_stats, result.after_stats);
+
         vec![
-            r.name,
-            format!("{}", r.num_events.to_formatted_string(&Locale::en)),
+            result.name,
+            format!("{}", result.num_events.to_formatted_string(&Locale::en)),
             format!("{cpu_cores}"),
-            format!("{0:.3}s", r.elapsed.as_secs_f32()),
-            format!("{0:.3}s", cpu_cores as f32 * r.elapsed.as_secs_f32()),
+            format!("{:#.3?}", result.elapsed),
+            format!("{:#.3?}", result.elapsed * cpu_cores as u32),
             format!(
                 "{0:.3} K/s",
-                r.num_events as f32 / r.elapsed.as_secs_f32() / cpu_cores as f32 / 1000.0
+                result.num_events as f32 / result.elapsed.as_secs_f32() / cpu_cores as f32 / 1000.0,
             ),
-            format!("{0:.3}s", (r.total_usr_cpu).as_secs_f32()),
-            format!("{0:.3}s", (r.total_sys_cpu).as_secs_f32()),
             format!(
-                "{}",
-                if let Some(max_rss) = r.max_rss {
-                    max_rss.to_formatted_string(&Locale::en)
-                } else {
-                    "N/A".to_string()
-                }
+                "{:#.3?}",
+                Duration::from_millis((after.user_ms - before.user_ms) as u64),
             ),
+            format!(
+                "{:#.3?}",
+                Duration::from_millis((after.system_ms - before.system_ms) as u64),
+            ),
+            format!("{}", HumanBytes::from(after.current_rss)),
+            format!("{}", HumanBytes::from(after.peak_rss)),
+            format!("{}", HumanBytes::from(after.current_commit)),
+            format!("{}", HumanBytes::from(after.peak_commit)),
+            format!("{}", after.page_faults - before.page_faults),
         ]
     }));
 
     Ok(())
-}
-
-#[cfg(unix)]
-const RUSAGE_SELF: i32 = libc::RUSAGE_SELF;
-
-#[cfg(not(unix))]
-const RUSAGE_SELF: i32 = 0;
-
-#[cfg(unix)]
-fn duration_for_timeval(tv: timeval) -> Duration {
-    Duration::new(tv.tv_sec as u64, tv.tv_usec as u32 * 1_000)
-}
-
-/// Returns the user CPU, system CPU and maxrss (in Kb) for the current process.
-#[cfg(unix)]
-pub unsafe fn rusage(target: i32) -> (Duration, Duration, u64) {
-    let mut ru: MaybeUninit<rusage> = MaybeUninit::uninit();
-    let err_code = getrusage(target, ru.as_mut_ptr());
-    if err_code != 0 {
-        panic!("getrusage returned {}", Error::last_os_error());
-    }
-    let ru = ru.assume_init();
-    (
-        duration_for_timeval(ru.ru_utime),
-        duration_for_timeval(ru.ru_stime),
-        ru.ru_maxrss as u64,
-    )
-}
-
-/// Define for non-unix so that bench can still run reporting on time etc.
-///
-/// # Safety
-///
-/// N/A
-#[cfg(not(unix))]
-pub unsafe fn rusage(_target: i32) -> (Duration, Duration, u64) {
-    (Duration::from_millis(0), Duration::from_millis(0), 0)
 }

--- a/benches/nexmark/main.rs
+++ b/benches/nexmark/main.rs
@@ -5,9 +5,9 @@
 
 #[macro_use]
 mod run_queries;
-mod allocation;
+#[path = "../mimalloc.rs"]
+mod mimalloc;
 
-use crate::allocation::{AllocStats, MiMalloc};
 use anyhow::{anyhow, Result};
 use ascii_table::AsciiTable;
 use clap::Parser;
@@ -25,6 +25,7 @@ use dbsp::{
     Circuit, CollectionHandle, DBSPHandle, Runtime,
 };
 use indicatif::{ProgressBar, ProgressStyle};
+use mimalloc::{AllocStats, MiMalloc};
 use num_format::{Locale, ToFormattedString};
 use size_of::HumanBytes;
 use std::{

--- a/benches/nexmark/run_queries.rs
+++ b/benches/nexmark/run_queries.rs
@@ -1,0 +1,107 @@
+macro_rules! run_queries {
+    // Runs a single query
+    (@single $query:ident, $nexmark_config:expr) => {{
+        let circuit_closure = run_queries!(@circuit $query);
+
+        let num_cores = $nexmark_config.cpu_cores;
+        let expected_num_events = $nexmark_config.max_events;
+        let (dbsp, input_handle) = Runtime::init_circuit(num_cores, circuit_closure).unwrap();
+
+        // Create a channel for the coordinating thread to determine whether the
+        // producer or consumer step is completed first.
+        let (step_done_tx, step_done_rx) = mpsc::sync_channel(2);
+
+        // Start the DBSP runtime processing steps only when it receives a message to do
+        // so. The DBSP processing happens in its own thread where the resource usage
+        // calculation can also happen.
+        let (dbsp_step_tx, dbsp_step_rx) = mpsc::sync_channel(1);
+        let dbsp_join_handle = spawn_dbsp_consumer(dbsp, dbsp_step_rx, step_done_tx.clone());
+
+        // Start the generator inputting the specified number of batches to the circuit
+        // whenever it receives a message.
+        let (source_step_tx, source_step_rx): (mpsc::SyncSender<()>, mpsc::Receiver<()>) =
+            mpsc::sync_channel(1);
+        let (source_exhausted_tx, source_exhausted_rx) = mpsc::sync_channel(1);
+        spawn_source_producer(
+            $nexmark_config,
+            input_handle,
+            source_step_rx,
+            step_done_tx,
+            source_exhausted_tx,
+        );
+
+        let input_stats = coordinate_input_and_steps(
+            expected_num_events,
+            dbsp_step_tx,
+            source_step_tx,
+            step_done_rx,
+            source_exhausted_rx,
+            dbsp_join_handle,
+        )
+        .unwrap();
+
+        // Return the user/system CPU overhead from the generator/input thread.
+        NexmarkResult {
+            num_events: input_stats.num_events,
+            ..NexmarkResult::default()
+        }
+    }};
+
+    // Returns a closure for a circuit with the nexmark source that returns
+    // the input handle.
+    (@circuit q13) => {
+        |circuit: &mut Circuit<()>| {
+            let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
+            let (side_stream, mut side_input_handle) =
+                circuit.add_input_zset::<(usize, String, u64), isize>();
+
+            let output = q13(stream, side_stream);
+
+            output.inspect(move |_zs| ());
+
+            // Ensure the side-input is loaded here so we can return a single input
+            // handle like the other queries.
+            side_input_handle.append(&mut q13_side_input());
+
+            input_handle
+        }
+    };
+    (@circuit $query:ident) => {
+        |circuit: &mut Circuit<()>| {
+            let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
+
+            let output = $query(stream);
+
+            output.inspect(move |_zs| ());
+
+            input_handle
+        }
+    };
+
+    ($nexmark_config:expr, $max_events:expr, $queries_to_run:expr, queries => { $($query:ident),+ $(,)? } $(,)?) => {{
+        let mut results: Vec<NexmarkResult> = Vec::new();
+
+        $(
+            if $queries_to_run.len() == 0 || $queries_to_run.contains(&paste::paste!(NexmarkQuery::[<$query:upper>])) {
+                println!("Starting {} bench of {} events...", stringify!($query), $max_events);
+
+                let before_stats = ALLOC.stats();
+                let start = Instant::now();
+
+                let thread_nexmark_config = $nexmark_config.clone();
+                let result = run_queries!(@single $query, thread_nexmark_config);
+                let after_stats = ALLOC.stats();
+
+                results.push(NexmarkResult {
+                    name: stringify!($query).to_owned(),
+                    before_stats,
+                    after_stats,
+                    elapsed: start.elapsed(),
+                    ..result
+                });
+            }
+        )+
+
+        results
+    }};
+}

--- a/benches/path.rs
+++ b/benches/path.rs
@@ -1,9 +1,15 @@
+mod mimalloc;
+
 use dbsp::{
     operator::{FilterMap, Generator},
     time::NestedTimestamp32,
     trace::{ord::OrdZSet, Batch, BatchReader},
     Circuit, Runtime, Stream,
 };
+use mimalloc::MiMalloc;
+
+#[global_allocator]
+static ALLOC: MiMalloc = MiMalloc;
 
 fn main() {
     let hruntime = Runtime::run(16, || {

--- a/src/nexmark/config.rs
+++ b/src/nexmark/config.rs
@@ -2,6 +2,8 @@
 //!
 //! API based on the equivalent [Nexmark Flink Configuration API](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/java/com/github/nexmark/flink/NexmarkConfiguration.java)
 //! and the specific [Nexmark Flink Generator config](https://github.com/nexmark/nexmark/blob/v0.2.0/nexmark-flink/src/main/java/com/github/nexmark/flink/generator/GeneratorConfig.java).
+
+pub use crate::nexmark::queries::Query;
 use clap::Parser;
 
 // Number of yet-to-be-created people and auction ids allowed.
@@ -89,8 +91,8 @@ pub struct Config {
     pub person_proportion: usize,
 
     /// Queries to run, all by default.
-    #[clap(long, env = "NEXMARK_QUERIES", multiple = true)]
-    pub query: Vec<String>,
+    #[clap(long, env = "NEXMARK_QUERIES", value_enum)]
+    pub query: Vec<Query>,
 
     /// The size of the buffer (channel) to use in the Nexmark Source.
     #[clap(long, default_value = "1000", env = "NEXMARK_SOURCE_BUFFER_SIZE")]
@@ -130,7 +132,7 @@ impl Default for Config {
             num_in_flight_auctions: 100,
             out_of_order_group_size: 1,
             person_proportion: 1,
-            query: vec![],
+            query: Vec::new(),
             source_buffer_size: 1000,
             input_batch_size: 1000,
         }

--- a/src/nexmark/queries/mod.rs
+++ b/src/nexmark/queries/mod.rs
@@ -1,30 +1,8 @@
 //! Nexmark Queries in DBSP.
+
 use super::model::Event;
 use crate::{Circuit, OrdZSet, Stream};
 use std::time::SystemTime;
-
-pub use q0::q0;
-pub use q1::q1;
-pub use q2::q2;
-pub use q3::q3;
-pub use q4::q4;
-pub use q5::q5;
-pub use q6::q6;
-pub use q7::q7;
-pub use q8::q8;
-pub use q9::q9;
-
-pub use q12::q12;
-pub use q13::{q13, q13_side_input};
-pub use q14::q14;
-pub use q15::q15;
-pub use q16::q16;
-pub use q17::q17;
-pub use q18::q18;
-pub use q19::q19;
-pub use q20::q20;
-pub use q21::q21;
-pub use q22::q22;
 
 type NexmarkStream = Stream<Circuit<()>, OrdZSet<Event, isize>>;
 
@@ -33,28 +11,48 @@ type OrdinalDate = (i32, u16);
 // Based on the WATERMARK FOR definition in the original [ddl_gen.sql](https://github.com/nexmark/nexmark/blob/54974ef36a0d01ef8ebc0b4ba39cfc50136af0f6/nexmark-flink/src/main/resources/queries/ddl_gen.sql#L37)
 const WATERMARK_INTERVAL_SECONDS: u64 = 4;
 
-mod q0;
-mod q1;
-mod q2;
-mod q3;
-mod q4;
-mod q5;
-mod q6;
-mod q7;
-mod q8;
-mod q9;
+macro_rules! declare_queries {
+    ($($query:ident),* $(,)?) => {
+        $(
+            mod $query;
+            pub use $query::$query;
+        )*
 
-mod q12;
-mod q13;
-mod q14;
-mod q15;
-mod q16;
-mod q17;
-mod q18;
-mod q19;
-mod q20;
-mod q21;
-mod q22;
+        paste::paste! {
+            /// All available nexmark queries
+            #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+            pub enum Query {
+                $([<$query:upper>],)*
+            }
+        }
+    };
+}
+
+declare_queries! {
+    q0,
+    q1,
+    q2,
+    q3,
+    q4,
+    q5,
+    q6,
+    q7,
+    q8,
+    q9,
+    q12,
+    q13,
+    q14,
+    q15,
+    q16,
+    q17,
+    q18,
+    q19,
+    q20,
+    q21,
+    q22,
+}
+
+pub use q13::q13_side_input;
 
 fn process_time() -> u64 {
     SystemTime::now()

--- a/src/nexmark/queries/q16.rs
+++ b/src/nexmark/queries/q16.rs
@@ -714,7 +714,6 @@ mod tests {
                         rank1_auctions: 1,
                         rank2_auctions: 1,
                         rank3_auctions: 1,
-                        ..Q16Output::default()
                     } => 1,
                     Q16Output {
                         channel: String::from("channel-1").into(),

--- a/src/operator/join.rs
+++ b/src/operator/join.rs
@@ -598,8 +598,8 @@ where
     fn summary(&self, summary: &mut String) {
         let sizes: Vec<usize> = self
             .output_batchers
-            .iter()
-            .map(|(_, batcher)| batcher.tuples())
+            .values()
+            .map(|batcher| batcher.tuples())
             .collect();
         writeln!(summary, "sizes: {:?}", sizes).unwrap();
         writeln!(summary, "total size: {}", sizes.iter().sum::<usize>()).unwrap();


### PR DESCRIPTION
This is an extraction of code from #193 since I got kinda sidetracked there

* Switched nexmark to use [mimalloc](https://github.com/microsoft/mimalloc) for the global allocator
* Cleaned up nexmark benchmark code
* Enhanced nexmark cli

I enhanced nexmark query parsing somewhat, where previously invalid query names passed to `--query` would result in a silent failure (that is, using `--query something_invalid` would simply do nothing), it now knows what the available queries are and therefore can validate them, which leads to this behavior now
```
λ  cargo bench --bench nexmark ... --query something_invalid
error: "something_invalid" isn't a valid value for '--query <QUERY>'
        [possible values: q0, q1, q2, q3, q4, q5, q6, q7, q8, q9, q12, q13, q14, q15, q16, q17, q18, q19, q20, q21, q22]

For more information try --help
error: bench failed, to rerun pass `--bench nexmark`
```
Additionally the help prompt now tells you the available queries
```
λ  cargo bench --bench nexmark --help
...
        --query <QUERY>
            Queries to run, all by default

            [env: NEXMARK_QUERIES=]
            [possible values: q0, q1, q2, q3, q4, q5, q6, q7, q8, q9, q12, q13, q14, q15, q16, q17,
            q18, q19, q20, q21, q22]
...
```
I also took advantage of using `mimalloc` to get more/richer/better stats on each query
```
┌───────┬─────────────┬───────┬─────────┬─────────────────┬──────────────────┬───────────────┬───────────────┬─────────────┬────────────┬────────────────┬─────────────┬─────────────┐
│ Query │ #Events     │ Cores │ Elapsed │ Cores * Elapsed │ Throughput/Cores │ Total Usr CPU │ Total Sys CPU │ Current RSS │ Peak RSS   │ Current Commit │ Peak Commit │ Page Faults │
├───────┼─────────────┼───────┼─────────┼─────────────────┼──────────────────┼───────────────┼───────────────┼─────────────┼────────────┼────────────────┼─────────────┼─────────────┤
│ q22   │ 100,000,000 │ 8     │ 14.426s │ 115.412s        │ 866.462 K/s      │ 129.468s      │ 203.000ms     │ 140.55 MiB  │ 142.25 MiB │ 401.77 MiB     │ 408.84 MiB  │ 57885       │
└───────┴─────────────┴───────┴─────────┴─────────────────┴──────────────────┴───────────────┴───────────────┴─────────────┴────────────┴────────────────┴─────────────┴─────────────┘
```