### PR TITLE
Update defaults to be more useful (even if different from Flink Nexmark)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,31 @@ Execute the following command to make `git commit` check the code before commit:
 GITDIR=$(git rev-parse --git-dir)
 ln -sf $(pwd)/tools/pre-push ${GITDIR}/hooks/pre-push
 ```
+
+## Running Benchmarks against DBSP
+
+The repository has a number of benchmarks available in the `benches` directory that provide a comparison of DBSP's performance against a known set of tests.
+
+Each benchmark has its own options and behavior, as outlined below.
+
+### Nexmark Benchmark
+
+You can run the complete set of Nexmark queries, with the default settings, with:
+
+```shell
+cargo bench --bench nexmark --features with-nexmark
+```
+
+By default this will run each query with a total of 100 million events emitted at 10M per second (by two event generator threads), using 2 CPU cores for processing the data.
+
+To run just the one query, q3, with only 10 million events, but using 8 CPU cores to process the data and 6 event generator threads, you can run:
+
+```shell
+cargo bench --bench nexmark --features with-nexmark -- --query q3 --max-events 10000000 --cpu-cores 8 --num-event-generators 6
+```
+
+For further options that you can use with the Nexmark benchmark,
+
+```shell
+cargo bench --bench nexmark --features with-nexmark -- --help
+```

--- a/src/nexmark/config.rs
+++ b/src/nexmark/config.rs
@@ -38,7 +38,7 @@ pub struct Config {
     pub avg_person_byte_size: usize,
 
     /// Number of CPU cores to be available.
-    #[clap(long, default_value = "1", env = "NEXMARK_CPU_CORES")]
+    #[clap(long, default_value = "2", env = "NEXMARK_CPU_CORES")]
     pub cpu_cores: usize,
 
     /// Specify the proportion of events that will be new bids.
@@ -46,7 +46,7 @@ pub struct Config {
     pub bid_proportion: usize,
 
     /// Initial overall event rate (per second).
-    #[clap(long, default_value = "10000", env = "NEXMARK_FIRST_EVENT_RATE")]
+    #[clap(long, default_value = "10000000", env = "NEXMARK_FIRST_EVENT_RATE")]
     pub first_event_rate: usize,
 
     /// Ratio of bids to 'hot' auctions compared to all other auctions.
@@ -62,7 +62,7 @@ pub struct Config {
     pub hot_sellers_ratio: usize,
 
     /// Max number of events to be generated. 0 is unlimited.
-    #[clap(long, default_value = "1000000", env = "NEXMARK_MAX_EVENTS")]
+    #[clap(long, default_value = "100000000", env = "NEXMARK_MAX_EVENTS")]
     pub max_events: u64,
 
     /// Maximum number of people to consider as active for placing auctions or
@@ -72,7 +72,7 @@ pub struct Config {
 
     /// Number of event generators to use. Each generates events in its own
     /// timeline.
-    #[clap(long, default_value = "1", env = "NEXMARK_NUM_EVENT_GENERATORS")]
+    #[clap(long, default_value = "2", env = "NEXMARK_NUM_EVENT_GENERATORS")]
     pub num_event_generators: usize,
 
     /// Average number of auctions which should be inflight at any time, per
@@ -95,12 +95,12 @@ pub struct Config {
     pub query: Vec<Query>,
 
     /// The size of the buffer (channel) to use in the Nexmark Source.
-    #[clap(long, default_value = "1000", env = "NEXMARK_SOURCE_BUFFER_SIZE")]
+    #[clap(long, default_value = "10000", env = "NEXMARK_SOURCE_BUFFER_SIZE")]
     pub source_buffer_size: usize,
 
     /// DBSP-specific configuration options.
     /// The size of the batches to be inputted to DBSP per step.
-    #[clap(long, default_value = "1000", env = "DBSP_INPUT_BATCH_SIZE")]
+    #[clap(long, default_value = "40000", env = "DBSP_INPUT_BATCH_SIZE")]
     pub input_batch_size: usize,
 }
 
@@ -121,20 +121,20 @@ impl Default for Config {
             avg_bid_byte_size: 100,
             avg_person_byte_size: 200,
             bid_proportion: 46,
-            cpu_cores: 1,
-            first_event_rate: 10_000,
+            cpu_cores: 2,
+            first_event_rate: 10_000_000,
             hot_auction_ratio: 2,
             hot_bidders_ratio: 4,
             hot_sellers_ratio: 4,
-            max_events: 1_000_000,
+            max_events: 100_000_000,
             num_active_people: 1000,
-            num_event_generators: 1,
+            num_event_generators: 2,
             num_in_flight_auctions: 100,
             out_of_order_group_size: 1,
             person_proportion: 1,
             query: Vec::new(),
-            source_buffer_size: 1000,
-            input_batch_size: 1000,
+            source_buffer_size: 10_000,
+            input_batch_size: 40_000,
         }
     }
 }

--- a/src/nexmark/generator/config.rs
+++ b/src/nexmark/generator/config.rs
@@ -39,7 +39,7 @@ pub struct Config {
     /// Delay between events, in microseconds. If the array has more than one
     /// entry then the rate is changed every {@link #stepLengthSec}, and wraps
     /// around.
-    pub inter_event_delay_us: [usize; 5],
+    pub inter_event_delay_us: [f64; 1],
 }
 
 /// Implementation of config methods based on the Java implementation at
@@ -51,8 +51,15 @@ impl Config {
         first_event_id: u64,
         first_event_number: usize,
     ) -> Config {
-        let inter_event_delay =
-            1_000_000 / nexmark_config.first_event_rate * nexmark_config.num_event_generators;
+        // The inter_event_delay is calculated as the number (or fraction) of
+        // micro seconds that pass between each event. Unlike the Java
+        // implementation, this is not dependent on the number of generators
+        // because each generator here returns interleaved events. For example,
+        // with 3 generators, the first generator emits events based on the
+        // event numbers 0, 3 and 6 etc., where as the Java implementation uses
+        // 0, 1 and 2 locally for each generator and so adds a factor of
+        // num_generators.
+        let inter_event_delay = 1_000_000.0 / (nexmark_config.first_event_rate as f64);
 
         // Original Java implementation says:
         // "Scale maximum down to avoid overflow in getEstimatedSizeBytes."
@@ -77,7 +84,7 @@ impl Config {
             first_event_id,
             max_events,
             first_event_number,
-            inter_event_delay_us: [inter_event_delay, 0, 0, 0, 0],
+            inter_event_delay_us: [inter_event_delay],
         }
     }
 
@@ -109,7 +116,7 @@ impl Config {
     // What timestamp should the event with `eventNumber` have for this
     // generator?
     pub fn timestamp_for_event(&self, event_number: u64) -> u64 {
-        self.base_time + self.inter_event_delay_us[0] as u64 * event_number / 1000
+        self.base_time + (self.inter_event_delay_us[0] * event_number as f64) as u64 / 1000
     }
 }
 
@@ -169,7 +176,33 @@ pub mod tests {
     #[case(1, 1)]
     #[case(2, 2)]
     #[case(199, 199)]
+    fn test_next_adjusted_event_number_single_generator(
+        #[case] num_events: u64,
+        #[case] expected: u64,
+    ) {
+        assert_eq!(
+            Config::new(
+                NexmarkConfig {
+                    num_event_generators: 1,
+                    ..NexmarkConfig::default()
+                },
+                0,
+                0,
+                0
+            )
+            .next_adjusted_event_number(num_events),
+            expected
+        );
+    }
+
+    #[rstest]
+    #[case(0, 0)]
+    #[case(1, 2)]
+    #[case(2, 4)]
+    #[case(199, 398)]
     fn test_next_adjusted_event_number_default(#[case] num_events: u64, #[case] expected: u64) {
+        // The default config has 2 generators, so the 0th generator emits
+        // events 0, 2, 4 etc.
         assert_eq!(
             Config::default().next_adjusted_event_number(num_events),
             expected
@@ -185,7 +218,38 @@ pub mod tests {
     #[case(3, 3)]
     #[case(4, 5)]
     #[case(5, 4)]
-    fn test_next_adjusted_event_number_custom_group_size_3(
+    #[case(6, 6)]
+    #[case(7, 8)]
+    #[case(8, 7)]
+    fn test_next_adjusted_event_number_custom_group_size_3_single_generator(
+        #[case] num_events: u64,
+        #[case] expected: u64,
+    ) {
+        // Seems to be issues in the Java implementation?!
+        let config = Config {
+            nexmark_config: NexmarkConfig {
+                num_event_generators: 1,
+                out_of_order_group_size: 3,
+                ..NexmarkConfig::default()
+            },
+            ..Config::default()
+        };
+        assert_eq!(config.next_adjusted_event_number(num_events), expected);
+    }
+
+    // When the out-of-order-group-size is 3, each group of three numbers will
+    // have a pseudo-random order, but only from within the same group of three.
+    // With two generators, this single generator is emitting every second event
+    // [0, 2, 4, 6, 8, 10], so the out of order numbers are (based on the previous
+    // test expectations) [0, 1, 5, 6, 7, 11]
+    #[rstest]
+    #[case(0, 0)]
+    #[case(1, 1)]
+    #[case(2, 5)]
+    #[case(3, 6)]
+    #[case(4, 7)]
+    #[case(5, 11)]
+    fn test_next_adjusted_event_number_custom_group_size_3_default(
         #[case] num_events: u64,
         #[case] expected: u64,
     ) {
@@ -200,14 +264,14 @@ pub mod tests {
         assert_eq!(config.next_adjusted_event_number(num_events), expected);
     }
 
-    // With the default first event rate of 10_000 events per second and one
-    // generator, there is 1_000_000 µs/s / 10_000 events/s = 100µs / event, so
-    // the timestamp increases by 100µs, ie. 0.1ms for each event.
+    // With the default first event rate of 10_000_000 events per second there
+    // is 1_000_000 µs/s / 10_000_000 events/s = 0.1µs / event, so the timestamp
+    // should increase by 0.1µs, or 0.0001ms for each event.
     #[rstest]
-    #[case(10, 1)]
-    #[case(20, 2)]
-    #[case(50, 5)]
-    fn test_timestamp_for_event(#[case] event_number: u64, #[case] expected: u64) {
+    #[case(10_000, 1)]
+    #[case(20_000, 2)]
+    #[case(50_000, 5)]
+    fn test_timestamp_for_event_single_generator(#[case] event_number: u64, #[case] expected: u64) {
         assert_eq!(
             Config::default().timestamp_for_event(event_number),
             expected,

--- a/src/nexmark/generator/mod.rs
+++ b/src/nexmark/generator/mod.rs
@@ -145,7 +145,17 @@ pub mod tests {
     use rstest::rstest;
 
     pub fn make_test_generator() -> NexmarkGenerator<StepRng> {
-        NexmarkGenerator::new(Config::default(), StepRng::new(0, 1), 0)
+        NexmarkGenerator::new(
+            Config {
+                nexmark_config: NexmarkConfig {
+                    num_event_generators: 1,
+                    ..NexmarkConfig::default()
+                },
+                ..Config::default()
+            },
+            StepRng::new(0, 1),
+            0,
+        )
     }
 
     pub fn make_person() -> Person {
@@ -255,7 +265,17 @@ pub mod tests {
     // helper for the data.
     #[test]
     fn test_next_event() {
-        let mut ng = NexmarkGenerator::new(Config::default(), thread_rng(), 0);
+        let mut ng = NexmarkGenerator::new(
+            Config {
+                nexmark_config: NexmarkConfig {
+                    num_event_generators: 1,
+                    ..NexmarkConfig::default()
+                },
+                ..Config::default()
+            },
+            thread_rng(),
+            0,
+        );
 
         // The first event with the default config is the person
         let next_event = ng.next_event().unwrap();
@@ -284,7 +304,7 @@ pub mod tests {
         }
 
         // And the rest of the events in the first epoch are bids.
-        for event_num in 4..=49 {
+        for _ in 4..=49 {
             let next_event = ng.next_event().unwrap();
             assert!(next_event.is_some());
             let next_event = next_event.unwrap();
@@ -294,7 +314,6 @@ pub mod tests {
                 "got: {:?}, want: Event::NewBid(_)",
                 next_event.event
             );
-            assert_eq!(next_event.event_timestamp, event_num / 10);
         }
 
         // The next epoch begins with another person etc.
@@ -302,7 +321,6 @@ pub mod tests {
         assert!(next_event.is_some());
         let next_event = next_event.unwrap();
 
-        assert_eq!(next_event.event_timestamp, 5);
         assert!(
             matches!(next_event.event, Event::Person(_)),
             "got: {:?}, want: Event::NewPerson(_)",

--- a/src/nexmark/mod.rs
+++ b/src/nexmark/mod.rs
@@ -253,6 +253,10 @@ pub mod tests {
         let (next_event_tx, next_event_rx) = mpsc::sync_channel(max_events as usize + 1);
         let mut generator = NexmarkGenerator::new(
             GeneratorConfig {
+                nexmark_config: NexmarkConfig {
+                    num_event_generators: 1,
+                    ..NexmarkConfig::default()
+                },
                 base_time: times.start,
                 ..GeneratorConfig::default()
             },


### PR DESCRIPTION
Before adding a small README or script for running the benchmarks, I wanted to update the defaults to be more useful. Initially I'd ensured we used defaults that were the same as the Java implementation defaults, but now that we have played and found sensible ones for DBSP, it makes sense to use those so it's easier to run the benchmark with sensible defaults (in particular, the rate of events).

As it turned out, this actually exposed a bug in the implementation: I'd used a `usize` for the inter_event_delay microseconds, which was fine for the previous defaults, but when using 10M events per second, the number of microseconds for the inter event delay was fractional - and so always zero :/ .  So this PR updates to use an `f64` (equivalent to the Java double in the original implementation) and adds tests to ensure the correct timestamps with a single generator or the default (2) generators.

I'm currently re-running the benchmark on the ec2 instance to see if it changes timings at all (it will affect windowed queries where previously we may have had all events with the same zero timestamp). Result: only q13 changes by more than a second, and it improves from 42 to 35 seconds:

```shell
┌───────┬─────────────┬───────┬──────────┬─────────────────┬──────────────────┬───────────────┬───────────────┬─────────────┬────────────┬────────────────┬─────────────┬─────────────┐
│ Query │ #Events     │ Cores │ Elapsed  │ Cores * Elapsed │ Throughput/Cores │ Total Usr CPU │ Total Sys CPU │ Current RSS │ Peak RSS   │ Current Commit │ Peak Commit │ Page Faults │
├───────┼─────────────┼───────┼──────────┼─────────────────┼──────────────────┼───────────────┼───────────────┼─────────────┼────────────┼────────────────┼─────────────┼─────────────┤
│ q0    │ 100,000,000 │ 8     │ 21.521s  │ 172.172s        │ 580.815 K/s      │ 227.979s      │ 1.846s        │ 720.79 MiB  │ 216.53 MiB │ 720.79 MiB     │ 720.80 MiB  │ 0           │
│ q1    │ 100,000,000 │ 8     │ 22.484s  │ 179.872s        │ 555.952 K/s      │ 249.398s      │ 2.149s        │ 800.00 KiB  │ 248.71 MiB │ 800.00 KiB     │ 836.00 KiB  │ 0           │
│ q2    │ 100,000,000 │ 8     │ 20.831s  │ 166.646s        │ 600.075 K/s      │ 224.496s      │ 2.025s        │ 9.66 MiB    │ 275.83 MiB │ 9.66 MiB       │ 9.70 MiB    │ 0           │
│ q3    │ 100,000,000 │ 8     │ 21.321s  │ 170.569s        │ 586.274 K/s      │ 233.864s      │ 2.508s        │ 12.21 MiB   │ 499.93 MiB │ 12.21 MiB      │ 12.25 MiB   │ 0           │
│ q4    │ 100,000,000 │ 8     │ 27.260s  │ 218.083s        │ 458.541 K/s      │ 302.616s      │ 8.957s        │ 4.51 GiB    │ 7.74 GiB   │ 4.51 GiB       │ 7.33 GiB    │ 0           │
│ q5    │ 100,000,000 │ 8     │ 21.763s  │ 174.103s        │ 574.374 K/s      │ 239.131s      │ 4.283s        │ 3.28 MiB    │ 7.74 GiB   │ 3.28 MiB       │ 3.31 MiB    │ 0           │
│ q6    │ 100,000,000 │ 8     │ 27.929s  │ 223.435s        │ 447.558 K/s      │ 317.848s      │ 6.862s        │ 521.66 MiB  │ 8.30 GiB   │ 521.66 MiB     │ 3.33 GiB    │ 0           │
│ q7    │ 100,000,000 │ 8     │ 40.020s  │ 320.161s        │ 312.343 K/s      │ 279.108s      │ 9.417s        │ 4.00 GiB    │ 12.83 GiB  │ 4.00 GiB       │ 7.52 GiB    │ 0           │
│ q8    │ 100,000,000 │ 8     │ 22.287s  │ 178.294s        │ 560.871 K/s      │ 238.839s      │ 3.781s        │ 4.97 MiB    │ 12.83 GiB  │ 4.97 MiB       │ 5.01 MiB    │ 0           │
│ q9    │ 100,000,000 │ 8     │ 116.960s │ 935.676s        │ 106.875 K/s      │ 578.242s      │ 16.888s       │ 6.26 GiB    │ 21.72 GiB  │ 6.26 GiB       │ 12.40 GiB   │ 0           │
│ q12   │ 100,000,000 │ 8     │ 24.123s  │ 192.982s        │ 518.182 K/s      │ 257.477s      │ 2.724s        │ 7.60 MiB    │ 21.72 GiB  │ 7.60 MiB       │ 7.67 MiB    │ 0           │
│ q13   │ 100,000,000 │ 8     │ 34.926s  │ 279.404s        │ 357.905 K/s      │ 351.461s      │ 8.299s        │ 3.15 MiB    │ 21.72 GiB  │ 3.15 MiB       │ 5.33 GiB    │ 0           │
│ q14   │ 100,000,000 │ 8     │ 21.246s  │ 169.966s        │ 588.354 K/s      │ 245.230s      │ 2.001s        │ 732.00 KiB  │ 21.72 GiB  │ 732.00 KiB     │ 808.00 KiB  │ 0           │
│ q15   │ 100,000,000 │ 8     │ 31.499s  │ 251.989s        │ 396.843 K/s      │ 318.184s      │ 13.095s       │ 4.28 MiB    │ 21.72 GiB  │ 4.28 MiB       │ 4.36 MiB    │ 0           │
│ q16   │ 100,000,000 │ 8     │ 94.630s  │ 757.042s        │ 132.093 K/s      │ 753.009s      │ 12.336s       │ 6.59 MiB    │ 21.72 GiB  │ 6.59 MiB       │ 6.67 MiB    │ 0           │
│ q17   │ 100,000,000 │ 8     │ 40.309s  │ 322.476s        │ 310.101 K/s      │ 432.518s      │ 10.911s       │ 1.75 GiB    │ 21.72 GiB  │ 1.75 GiB       │ 3.06 GiB    │ 0           │
│ q18   │ 100,000,000 │ 8     │ 73.103s  │ 584.820s        │ 170.993 K/s      │ 434.762s      │ 12.831s       │ 16.00 EiB   │ 24.03 GiB  │ 16.00 EiB      │ 6.55 GiB    │ 0           │
│ q19   │ 100,000,000 │ 8     │ 71.254s  │ 570.032s        │ 175.429 K/s      │ 537.604s      │ 23.832s       │ 16.00 EiB   │ 25.76 GiB  │ 16.00 EiB      │ 8.09 GiB    │ 0           │
│ q20   │ 100,000,000 │ 8     │ 54.033s  │ 432.265s        │ 231.340 K/s      │ 403.924s      │ 13.374s       │ 16.00 EiB   │ 25.76 GiB  │ 16.00 EiB      │ 7.19 GiB    │ 0           │
│ q21   │ 100,000,000 │ 8     │ 23.753s  │ 190.027s        │ 526.242 K/s      │ 253.041s      │ 2.344s        │ 16.00 EiB   │ 25.76 GiB  │ 16.00 EiB      │ 44.00 KiB   │ 0           │
│ q22   │ 100,000,000 │ 8     │ 21.734s  │ 173.870s        │ 575.143 K/s      │ 252.638s      │ 1.951s        │ 16.00 EiB   │ 25.76 GiB  │ 16.00 EiB      │ 40.00 KiB   │ 0           │
└───────┴─────────────┴───────┴──────────┴─────────────────┴──────────────────┴───────────────┴───────────────┴─────────────┴────────────┴────────────────┴─────────────┴─────────────┘

```

Note: On the assumption that not everyone has 16 cores, I've used a default of 2 and 2 for number of cores and number of generators respectively :)

Signed-off-by: Michael Nelson <minelson@vmware.com>