### PR TITLE
Remove `TraceReader` trait.

### DIFF
--- a/src/operator/join.rs
+++ b/src/operator/join.rs
@@ -10,7 +10,7 @@ use crate::{
     time::Timestamp,
     trace::{
         cursor::Cursor as TraceCursor, spine_fueled::Spine, Batch, BatchReader, Batcher, Builder,
-        Trace, TraceReader,
+        Trace,
     },
     OrdIndexedZSet, OrdZSet,
 };
@@ -549,7 +549,7 @@ impl JoinStats {
 
 pub struct JoinTrace<F, I, T, Z, It>
 where
-    T: TraceReader,
+    T: BatchReader,
     Z: IndexedZSet,
 {
     join_func: F,
@@ -569,7 +569,7 @@ where
 
 impl<F, I, T, Z, It> JoinTrace<F, I, T, Z, It>
 where
-    T: TraceReader,
+    T: BatchReader,
     Z: IndexedZSet,
 {
     pub fn new(join_func: F, location: &'static Location<'static>) -> Self {
@@ -590,7 +590,7 @@ impl<F, I, T, Z, It> Operator for JoinTrace<F, I, T, Z, It>
 where
     F: 'static,
     I: 'static,
-    T: TraceReader + 'static,
+    T: BatchReader + 'static,
     Z: IndexedZSet,
     Z::Batcher: SizeOf,
     It: 'static,

--- a/src/operator/trace.rs
+++ b/src/operator/trace.rs
@@ -5,7 +5,7 @@ use crate::{
         Circuit, ExportId, ExportStream, GlobalNodeId, OwnershipPreference, Scope, Stream,
     },
     circuit_cache_key,
-    trace::{cursor::Cursor, spine_fueled::Spine, Batch, BatchReader, Builder, Trace, TraceReader},
+    trace::{cursor::Cursor, spine_fueled::Spine, Batch, BatchReader, Builder, Trace},
     NumEntries, Timestamp,
 };
 use size_of::SizeOf;
@@ -154,7 +154,7 @@ where
 impl<P, T> Stream<Circuit<P>, T>
 where
     P: Clone + 'static,
-    T: TraceReader + 'static,
+    T: Trace + 'static,
 {
     pub fn delay_trace(&self) -> Stream<Circuit<P>, T> {
         self.circuit()
@@ -168,14 +168,14 @@ where
 
 pub struct UntimedTraceAppend<T>
 where
-    T: TraceReader,
+    T: Trace,
 {
     _phantom: PhantomData<T>,
 }
 
 impl<T> UntimedTraceAppend<T>
 where
-    T: TraceReader,
+    T: Trace,
 {
     pub fn new() -> Self {
         Self {
@@ -186,7 +186,7 @@ where
 
 impl<T> Default for UntimedTraceAppend<T>
 where
-    T: TraceReader,
+    T: Trace,
 {
     fn default() -> Self {
         Self::new()
@@ -195,7 +195,7 @@ where
 
 impl<T> Operator for UntimedTraceAppend<T>
 where
-    T: TraceReader + 'static,
+    T: Trace + 'static,
 {
     fn name(&self) -> Cow<'static, str> {
         Cow::from("UntimedTraceAppend")
@@ -241,7 +241,7 @@ where
 
 pub struct TraceAppend<T, B>
 where
-    T: TraceReader,
+    T: Trace,
 {
     time: T::Time,
     _phantom: PhantomData<B>,
@@ -249,7 +249,7 @@ where
 
 impl<T, B> TraceAppend<T, B>
 where
-    T: TraceReader,
+    T: Trace,
 {
     pub fn new() -> Self {
         Self {
@@ -261,7 +261,7 @@ where
 
 impl<T, B> Default for TraceAppend<T, B>
 where
-    T: TraceReader,
+    T: Trace,
 {
     fn default() -> Self {
         Self::new()
@@ -270,7 +270,7 @@ where
 
 impl<T, B> Operator for TraceAppend<T, B>
 where
-    T: TraceReader + 'static,
+    T: Trace + 'static,
     B: 'static,
 {
     fn name(&self) -> Cow<'static, str> {
@@ -325,7 +325,7 @@ where
     }
 }
 
-pub struct Z1Trace<T: TraceReader> {
+pub struct Z1Trace<T: Trace> {
     time: T::Time,
     trace: Option<T>,
     // `dirty[scope]` is `true` iff at least one non-empty update was added to the trace

--- a/src/operator/upsert.rs
+++ b/src/operator/upsert.rs
@@ -6,8 +6,8 @@ use crate::{
     },
     operator::trace::{DelayedTraceId, TraceAppend, TraceId, Z1Trace},
     trace::{
-        consolidation::consolidate, cursor::Cursor, spine_fueled::Spine, Batch, Builder, Trace,
-        TraceReader,
+        consolidation::consolidate, cursor::Cursor, spine_fueled::Spine, Batch, BatchReader,
+        Builder, Trace,
     },
     utils::VecExt,
     Circuit, Stream, Timestamp,
@@ -98,7 +98,7 @@ where
 
 pub struct Upsert<T, B>
 where
-    T: TraceReader,
+    T: BatchReader,
 {
     time: T::Time,
     phantom: PhantomData<B>,
@@ -106,7 +106,7 @@ where
 
 impl<T, B> Upsert<T, B>
 where
-    T: TraceReader,
+    T: BatchReader,
 {
     pub fn new() -> Self {
         Self {
@@ -118,7 +118,7 @@ where
 
 impl<T, B> Default for Upsert<T, B>
 where
-    T: TraceReader,
+    T: BatchReader,
 {
     fn default() -> Self {
         Self::new()
@@ -127,7 +127,7 @@ where
 
 impl<T, B> Operator for Upsert<T, B>
 where
-    T: TraceReader + 'static,
+    T: BatchReader + 'static,
     B: 'static,
 {
     fn name(&self) -> Cow<'static, str> {

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -25,40 +25,14 @@ use crate::{
 };
 use size_of::SizeOf;
 
-/// A trace whose contents may be read.
-///
-/// This is a restricted interface to the more general `Trace` trait, which
-/// extends this trait with further methods to update the contents of the trace.
-/// These methods are used to examine the contents, and to update the reader's
-/// capabilities (which may release restrictions on the mutations to the
-/// underlying trace and cause work to happen).
-pub trait TraceReader: BatchReader {
-    /// The type of an immutable collection of updates.
-    type Batch: Batch<Key = Self::Key, Val = Self::Val, Time = Self::Time, R = Self::R> + 'static;
-
-    // TODO: Do we want a version of `cursor` with an upper bound on time?  E.g., it
-    // could help in `distinct` to avoid iterating into the future (and then
-    // drop future timestamps anyway).
-    /*
-    /// Acquires a cursor to the restriction of the collection's contents to updates at times not greater or
-    /// equal to an element of `upper`.
-    ///
-    /// This method is expected to work if called with an `upper` that (i) was an observed bound in batches from
-    /// the trace, and (ii) the trace has not been advanced beyond `upper`. Practically, the implementation should
-    /// be expected to look for a "clean cut" using `upper`, and if it finds such a cut can return a cursor. This
-    /// should allow `upper` such as `&[]` as used by `self.cursor()`, though it is difficult to imagine other uses.
-    fn cursor_through(&self, upper: AntichainRef<Self::Time>) -> Option<(Self::Cursor, <Self::Cursor as Cursor<Self::Key, Self::Val, Self::Time, Self::R>>::Storage)>;
-    */
-
-    /// Maps logic across the non-empty sequence of batches in the trace.
-    fn map_batches<F: FnMut(&Self::Batch)>(&self, f: F);
-}
-
 /// An append-only collection of `(key, val, time, diff)` tuples.
 ///
 /// The trace must be constructable from, and navigable by the `Key`, `Val`,
 /// `Time` types, but does not need to return them.
-pub trait Trace: TraceReader {
+pub trait Trace: BatchReader {
+    /// The type of an immutable collection of updates.
+    type Batch: Batch<Key = Self::Key, Val = Self::Val, Time = Self::Time, R = Self::R> + 'static;
+
     /// Allocates a new empty trace.
     fn new(activator: Option<Activator>) -> Self;
 


### PR DESCRIPTION
`TraceReader` only defined a single method, `map_batches`.  Work on persistent traces showed that this is not a good design, as it exposes the internal structure of the trace.  We only used this API in one place in `distinct.rs`, and that code would have to be re-written anyway as we generalize `distinct` to work in arbitrary nested scopes.

We eliminate the `map_batches` method from the public API and downgrade it to a private method of `Spine`.  We also remove the no longer useful trait `TraceReader`.

Addresses a TODO in PR #124. 