### PR TITLE
Simplify trait bounds.

### DIFF
--- a/benches/ldbc-graphalytics/pagerank.rs
+++ b/benches/ldbc-graphalytics/pagerank.rs
@@ -1,15 +1,12 @@
 use crate::data::{Edges, Node, Rank, RankMap, Ranks, Streamed, Vertices};
 use dbsp::{
     algebra::HasOne,
-    circuit::operator_traits::Data,
     operator::{DelayedFeedback, FilterMap, Generator},
     trace::{Batch, BatchReader, Builder, Cursor},
-    OrdIndexedZSet, OrdZSet, Runtime,
+    DBData, OrdIndexedZSet, OrdZSet, Runtime,
 };
-use size_of::SizeOf;
 use std::{
     cmp::{min, Ordering},
-    hash::Hash,
     panic::Location,
 };
 
@@ -261,7 +258,7 @@ fn div_join_stream<S, K>(
 ) -> Streamed<S, OrdZSet<K, Rank>>
 where
     S: Clone + 'static,
-    K: Hash + Ord + Copy + Data + SizeOf + Send,
+    K: DBData + Send + Copy,
 {
     lhs.shard().apply2(&rhs.shard(), |lhs, rhs| {
         let capacity = min(lhs.len(), rhs.len());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,4 +28,4 @@ pub use circuit::{
 };
 pub use operator::{CollectionHandle, InputHandle, UpsertHandle};
 pub use trace::ord::{OrdIndexedZSet, OrdZSet};
-pub use trace::DBData;
+pub use trace::{DBData, DBTimestamp, DBWeight};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,3 +28,4 @@ pub use circuit::{
 };
 pub use operator::{CollectionHandle, InputHandle, UpsertHandle};
 pub use trace::ord::{OrdIndexedZSet, OrdZSet};
+pub use trace::DBData;

--- a/src/nexmark/queries/q14.rs
+++ b/src/nexmark/queries/q14.rs
@@ -3,6 +3,7 @@ use crate::{nexmark::model::Event, operator::FilterMap, Circuit, OrdZSet, Stream
 use arcstr::ArcStr;
 use rust_decimal::Decimal;
 use size_of::SizeOf;
+use std::hash::Hash;
 
 /// Query 14: Calculation (Not in original suite)
 ///
@@ -41,14 +42,14 @@ use size_of::SizeOf;
 /// WHERE 0.908 * price > 1000000 AND 0.908 * price < 50000000;
 /// ```
 
-#[derive(Eq, Clone, Debug, PartialEq, PartialOrd, Ord, SizeOf)]
+#[derive(Eq, Clone, Debug, Hash, PartialEq, PartialOrd, Ord, SizeOf)]
 enum BidTimeType {
     Day,
     Night,
     Other,
 }
 
-#[derive(Eq, Clone, Debug, PartialEq, PartialOrd, Ord, SizeOf)]
+#[derive(Eq, Clone, Debug, Hash, PartialEq, PartialOrd, Ord, SizeOf)]
 pub struct Q14Output(u64, u64, Decimal, BidTimeType, u64, ArcStr, usize);
 
 type Q14Stream = Stream<Circuit<()>, OrdZSet<Q14Output, isize>>;

--- a/src/nexmark/queries/q15.rs
+++ b/src/nexmark/queries/q15.rs
@@ -2,7 +2,7 @@ use super::NexmarkStream;
 use crate::{
     nexmark::{model::Event, queries::OrdinalDate},
     operator::FilterMap,
-    Circuit, OrdIndexedZSet, OrdZSet, Stream,
+    Circuit, DBData, OrdIndexedZSet, OrdZSet, Stream,
 };
 use size_of::SizeOf;
 use std::{
@@ -78,8 +78,8 @@ type Q15Stream = Stream<Circuit<()>, OrdZSet<Q15Output, isize>>;
 impl<P, K, V> Stream<Circuit<P>, OrdIndexedZSet<K, V, isize>>
 where
     P: Clone + 'static,
-    K: Default + SizeOf + Clone + Ord + Hash + Send + 'static,
-    V: Default + SizeOf + Clone + Ord + Hash + Send + 'static,
+    K: DBData + Default,
+    V: DBData + Default,
 {
     /// Outer join:
     /// - returns the output of `join_func` for common keys.
@@ -96,8 +96,8 @@ where
     ) -> Stream<Circuit<P>, OrdZSet<O, isize>>
     where
         Self: FilterMap<Circuit<P>, R = isize>,
-        V2: Default + SizeOf + Clone + Ord + Hash + Send + 'static,
-        O: Clone + Default + Ord + SizeOf + 'static,
+        V2: DBData + Default,
+        O: DBData + Default,
         F: Fn(&K, &V, &V2) -> O + Clone + 'static,
         for<'a> FL: Fn(<Self as FilterMap<Circuit<P>>>::ItemRef<'a>) -> O + Clone + 'static,
         for<'a> FR: Fn(
@@ -124,8 +124,8 @@ where
         join_func: F,
     ) -> Stream<Circuit<P>, OrdZSet<O, isize>>
     where
-        V2: Default + SizeOf + Clone + Ord + Hash + Send + 'static,
-        O: Clone + Default + Ord + SizeOf + 'static,
+        V2: DBData + Default,
+        O: DBData + Default,
         F: Fn(&K, &V, &V2) -> O + Clone + 'static,
     {
         let join_func_left = join_func.clone();

--- a/src/nexmark/queries/q9.rs
+++ b/src/nexmark/queries/q9.rs
@@ -56,7 +56,7 @@ use size_of::SizeOf;
 /// WHERE rownum <= 1;
 /// ```
 
-#[derive(Eq, Clone, Debug, PartialEq, PartialOrd, Ord, SizeOf)]
+#[derive(Eq, Clone, Debug, Hash, PartialEq, PartialOrd, Ord, SizeOf)]
 pub struct Q9Output(
     u64,
     ArcStr,

--- a/src/operator/aggregate/average.rs
+++ b/src/operator/aggregate/average.rs
@@ -2,7 +2,7 @@ use crate::{
     algebra::{AddAssignByRef, AddByRef, GroupValue, HasZero, IndexedZSet, MulByRef, NegByRef},
     trace::layers::{column_leaf::OrderedColumnLeaf, ordered::OrderedLayer},
     utils::VecExt,
-    Circuit, OrdIndexedZSet, Stream, Timestamp,
+    Circuit, DBData, OrdIndexedZSet, Stream, Timestamp,
 };
 use size_of::SizeOf;
 use std::{
@@ -11,7 +11,7 @@ use std::{
 };
 
 /// Intermediate representation of an average as a `(sum, count)` pair.
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, SizeOf)]
+#[derive(Debug, Clone, Eq, Hash, PartialEq, Ord, PartialOrd, SizeOf)]
 pub struct Avg<T> {
     sum: T,
     count: isize,
@@ -141,12 +141,10 @@ where
     #[track_caller]
     pub fn average<TS, A, F>(&self, f: F) -> Stream<Circuit<P>, OrdIndexedZSet<Z::Key, A, isize>>
     where
-        TS: Timestamp + SizeOf,
+        TS: DBData + Timestamp,
         Z: IndexedZSet,
-        Z::Key: PartialEq + Ord + Hash + SizeOf + Clone + Send,
-        Z::Val: Ord + SizeOf + Clone,
         Avg<A>: MulByRef<Z::R, Output = Avg<A>>,
-        A: Div<isize, Output = A> + Ord + GroupValue + SizeOf + Clone + Send,
+        A: DBData + Div<isize, Output = A> + GroupValue,
         isize: MulByRef<Z::R, Output = isize>,
         F: Fn(&Z::Key, &Z::Val) -> A + Clone + 'static,
     {

--- a/src/operator/aggregate/average.rs
+++ b/src/operator/aggregate/average.rs
@@ -2,7 +2,7 @@ use crate::{
     algebra::{AddAssignByRef, AddByRef, GroupValue, HasZero, IndexedZSet, MulByRef, NegByRef},
     trace::layers::{column_leaf::OrderedColumnLeaf, ordered::OrderedLayer},
     utils::VecExt,
-    Circuit, DBData, OrdIndexedZSet, Stream, Timestamp,
+    Circuit, DBData, DBTimestamp, OrdIndexedZSet, Stream,
 };
 use size_of::SizeOf;
 use std::{
@@ -141,7 +141,7 @@ where
     #[track_caller]
     pub fn average<TS, A, F>(&self, f: F) -> Stream<Circuit<P>, OrdIndexedZSet<Z::Key, A, isize>>
     where
-        TS: DBData + Timestamp,
+        TS: DBTimestamp,
         Z: IndexedZSet,
         Avg<A>: MulByRef<Z::R, Output = Avg<A>>,
         A: DBData + Div<isize, Output = A> + GroupValue,

--- a/src/operator/aggregate/fold.rs
+++ b/src/operator/aggregate/fold.rs
@@ -2,7 +2,7 @@ use crate::{
     algebra::{MonoidValue, Semigroup},
     operator::aggregate::Aggregator,
     trace::Cursor,
-    Timestamp,
+    DBData, Timestamp,
 };
 use std::{convert::identity, marker::PhantomData};
 
@@ -63,10 +63,11 @@ impl<V, T, R, A, S, O, SF, OF> Aggregator<V, T, R> for Fold<A, S, SF, OF>
 where
     T: Timestamp,
     R: MonoidValue,
-    A: Clone,
-    SF: Fn(&mut A, &V, R) + Clone,
-    OF: Fn(A) -> O + Clone,
-    S: Semigroup<O> + Clone,
+    A: Clone + 'static,
+    SF: Fn(&mut A, &V, R) + Clone + 'static,
+    OF: Fn(A) -> O + Clone + 'static,
+    S: Semigroup<O> + Clone + 'static,
+    O: DBData,
 {
     type Output = O;
     type Semigroup = S;

--- a/src/operator/aggregate/max.rs
+++ b/src/operator/aggregate/max.rs
@@ -2,7 +2,7 @@ use crate::{
     algebra::{MonoidValue, Semigroup},
     operator::aggregate::Aggregator,
     trace::Cursor,
-    Timestamp,
+    DBData, Timestamp,
 };
 use std::{cmp::max, marker::PhantomData};
 
@@ -24,7 +24,7 @@ where
 
 impl<V, T, R> Aggregator<V, T, R> for Max
 where
-    V: Ord + Clone,
+    V: DBData,
     T: Timestamp,
     R: MonoidValue,
 {

--- a/src/operator/aggregate/min.rs
+++ b/src/operator/aggregate/min.rs
@@ -2,7 +2,7 @@ use crate::{
     algebra::{MonoidValue, Semigroup},
     operator::aggregate::Aggregator,
     trace::Cursor,
-    Timestamp,
+    DBData, Timestamp,
 };
 use std::{cmp::min, marker::PhantomData};
 
@@ -26,7 +26,7 @@ where
 }
 impl<V, T, R> Aggregator<V, T, R> for Min
 where
-    V: Ord + Clone,
+    V: DBData,
     T: Timestamp,
     R: MonoidValue,
 {

--- a/src/operator/aggregate/mod.rs
+++ b/src/operator/aggregate/mod.rs
@@ -23,7 +23,7 @@ use crate::{
         spine_fueled::Spine,
         Batch, BatchReader, Builder,
     },
-    DBData, NumEntries, OrdIndexedZSet, OrdZSet,
+    DBData, DBTimestamp, DBWeight, NumEntries, OrdIndexedZSet, OrdZSet,
 };
 use size_of::SizeOf;
 
@@ -158,7 +158,7 @@ where
         aggregator: A,
     ) -> Stream<Circuit<P>, OrdIndexedZSet<Z::Key, A::Output, isize>>
     where
-        TS: DBData + Timestamp,
+        TS: DBTimestamp,
         Z: IndexedZSet + SizeOf + NumEntries + Send, /* + std::fmt::Display */
         A: Aggregator<Z::Val, TS, Z::R> + 'static,
         A::Output: DBData,
@@ -169,7 +169,7 @@ where
     /// Like [`Self::aggregate`], but can return any batch type.
     pub fn aggregate_generic<TS, A, O>(&self, aggregator: A) -> Stream<Circuit<P>, O>
     where
-        TS: DBData + Timestamp,
+        TS: DBTimestamp,
         Z: IndexedZSet + SizeOf + NumEntries + Send, /* + std::fmt::Display */
         Z::R: DBData,                                /* + std::fmt::Display */
         A: Aggregator<Z::Val, TS, Z::R> + 'static,
@@ -214,7 +214,7 @@ where
         f: F,
     ) -> Stream<Circuit<P>, OrdIndexedZSet<Z::Key, A, isize>>
     where
-        TS: DBData + Timestamp,
+        TS: DBTimestamp,
         Z: IndexedZSet,
         A: DBData + MulByRef<Z::R, Output = A> + GroupValue,
         F: Fn(&Z::Key, &Z::Val) -> A + Clone + 'static,
@@ -225,7 +225,7 @@ where
     /// Like [`Self::aggregate_linear`], but can return any batch type.
     pub fn aggregate_linear_generic<TS, F, O>(&self, f: F) -> Stream<Circuit<P>, O>
     where
-        TS: DBData + Timestamp,
+        TS: DBTimestamp,
         Z: IndexedZSet,
         F: Fn(&Z::Key, &Z::Val) -> O::Val + Clone + 'static,
         O: Clone + Batch<Key = Z::Key, Time = ()> + 'static,
@@ -251,7 +251,7 @@ where
     where
         Z: IndexedZSet,
         F: Fn(&Z::Key, &Z::Val) -> T + 'static,
-        T: DBData + MonoidValue + MulByRef<Z::R, Output = T>,
+        T: DBWeight + MulByRef<Z::R, Output = T>,
     {
         self.weigh_generic::<_, OrdZSet<_, _>>(f)
     }

--- a/src/operator/communication/shard.rs
+++ b/src/operator/communication/shard.rs
@@ -27,7 +27,7 @@ fn sharding_policy<P>(_circuit: &Circuit<P>) -> ShardingPolicy {
 impl<P, IB> Stream<Circuit<P>, IB>
 where
     P: Clone + 'static,
-    IB: BatchReader<Time = ()> + Clone + 'static,
+    IB: BatchReader<Time = ()> + Clone,
     IB::Key: Ord + Clone + Hash,
     IB::Val: Ord + Clone,
 {
@@ -105,7 +105,7 @@ where
     #[track_caller]
     pub fn shard_generic<OB>(&self) -> Option<Stream<Circuit<P>, OB>>
     where
-        OB: Batch<Key = IB::Key, Val = IB::Val, Time = (), R = IB::R> + Clone + Send + 'static,
+        OB: Batch<Key = IB::Key, Val = IB::Val, Time = (), R = IB::R> + Send,
     {
         let location = Location::caller();
 

--- a/src/operator/consolidate.rs
+++ b/src/operator/consolidate.rs
@@ -16,7 +16,7 @@ circuit_cache_key!(ConsolidateId<C, D>(GlobalNodeId => Stream<C, D>));
 impl<P, T> Stream<Circuit<P>, T>
 where
     P: Clone + 'static,
-    T: Clone + Trace<Time = ()> + 'static,
+    T: Trace<Time = ()> + Clone,
 {
     // TODO: drop the `Time = ()` requirement?
     /// Consolidate a trace into a single batch.
@@ -77,7 +77,7 @@ where
 
 impl<T> UnaryOperator<T, T::Batch> for Consolidate<T>
 where
-    T: Trace<Time = ()> + 'static,
+    T: Trace<Time = ()>,
 {
     fn eval(&mut self, _i: &T) -> T::Batch {
         unimplemented!()

--- a/src/operator/distinct.rs
+++ b/src/operator/distinct.rs
@@ -223,7 +223,7 @@ where
     Z::Key: Clone + PartialEq,
     Z::Val: Clone + PartialEq,
     Z::R: ZRingValue,
-    I: BatchReader<Key = Z::Key, Val = Z::Val, Time = (), R = Z::R> + 'static,
+    I: BatchReader<Key = Z::Key, Val = Z::Val, Time = (), R = Z::R>,
 {
     fn eval(&mut self, delta: &Z, delayed_integral: &I) -> Z {
         let mut builder = Z::Builder::with_capacity((), delta.len());
@@ -298,7 +298,7 @@ where
 pub struct DistinctTrace<Z, T>
 where
     Z: ZSet,
-    T: BatchReader<Key = Z::Key, Val = (), R = Z::R> + 'static,
+    T: BatchReader<Key = Z::Key, Val = (), R = Z::R>,
 {
     // Keeps track of keys that need to be considered at future times.
     // Specifically, `future_updates[i]` accumulates all keys observed during
@@ -314,7 +314,7 @@ where
 impl<Z, T> DistinctTrace<Z, T>
 where
     Z: ZSet,
-    T: BatchReader<Key = Z::Key, Val = (), R = Z::R> + 'static,
+    T: BatchReader<Key = Z::Key, Val = (), R = Z::R>,
 {
     fn new() -> Self {
         Self {
@@ -332,7 +332,7 @@ where
     Z: ZSet,
     Z::Key: Clone + Ord + PartialEq,
     Z::R: ZRingValue,
-    T: BatchReader<Key = Z::Key, Val = (), Time = NestedTimestamp32, R = Z::R> + 'static,
+    T: BatchReader<Key = Z::Key, Val = (), Time = NestedTimestamp32, R = Z::R>,
 {
     // Evaluate nested incremental distinct for a single value.
     //
@@ -459,7 +459,7 @@ impl<Z, T> Operator for DistinctTrace<Z, T>
 where
     Z: ZSet,
     Z::Key: SizeOf + Clone + Ord + PartialEq,
-    T: BatchReader<Key = Z::Key, Val = (), Time = NestedTimestamp32, R = Z::R> + 'static,
+    T: BatchReader<Key = Z::Key, Val = (), Time = NestedTimestamp32, R = Z::R>,
 {
     fn name(&self) -> Cow<'static, str> {
         Cow::Borrowed("DistinctTrace")
@@ -505,7 +505,7 @@ where
     Z: ZSet,
     Z::Key: Clone + Ord + PartialEq + SizeOf,
     Z::R: ZRingValue,
-    T: Trace<Key = Z::Key, Val = (), Time = NestedTimestamp32, R = Z::R> + 'static,
+    T: Trace<Key = Z::Key, Val = (), Time = NestedTimestamp32, R = Z::R>,
 {
     // Distinct does not have nice properties like linearity that help with
     // incremental evaluation: computing an update for each key requires inspecting

--- a/src/operator/distinct.rs
+++ b/src/operator/distinct.rs
@@ -10,7 +10,7 @@ use crate::{
     circuit_cache_key,
     time::NestedTimestamp32,
     trace::{ord::OrdKeySpine, BatchReader, Builder, Cursor as TraceCursor, Trace},
-    NumEntries, Timestamp,
+    NumEntries,
 };
 use size_of::SizeOf;
 use std::{
@@ -315,7 +315,6 @@ impl<Z, T> DistinctTrace<Z, T>
 where
     Z: ZSet,
     T: BatchReader<Key = Z::Key, Val = (), R = Z::R> + 'static,
-    T::Time: Timestamp,
 {
     fn new() -> Self {
         Self {

--- a/src/operator/filter_map.rs
+++ b/src/operator/filter_map.rs
@@ -1,13 +1,12 @@
 //! Filter and transform data record-by-record.
 
 use crate::{
-    algebra::MonoidValue,
     circuit::{
         operator_traits::{Operator, UnaryOperator},
         Circuit, OwnershipPreference, Scope, Stream,
     },
     trace::{Batch, BatchReader, Builder, Consumer, Cursor, ValueConsumer},
-    DBData, OrdIndexedZSet, OrdZSet,
+    DBData, DBWeight, OrdIndexedZSet, OrdZSet,
 };
 use std::{borrow::Cow, marker::PhantomData};
 
@@ -70,7 +69,7 @@ pub trait FilterMap<C> {
     type ItemRef<'a>;
 
     /// Type of the `weight` component of the `(key, value, weight)` tuple.
-    type R: DBData + MonoidValue;
+    type R: DBWeight;
 
     /// Filter input stream only retaining records that satisfy the
     /// `filter_func` predicate.
@@ -158,7 +157,7 @@ impl<P, K, R> FilterMap<Circuit<P>> for Stream<Circuit<P>, OrdZSet<K, R>>
 where
     P: Clone + 'static,
     K: DBData,
-    R: DBData + MonoidValue,
+    R: DBWeight,
 {
     type Item = K;
     type ItemRef<'a> = &'a K;
@@ -227,7 +226,7 @@ where
 impl<P, K, V, R> FilterMap<Circuit<P>> for Stream<Circuit<P>, OrdIndexedZSet<K, V, R>>
 where
     P: Clone + 'static,
-    R: DBData + MonoidValue,
+    R: DBWeight,
     K: DBData,
     V: DBData,
 {

--- a/src/operator/index.rs
+++ b/src/operator/index.rs
@@ -39,8 +39,8 @@ where
     /// not just `OrdIndexedZSet`.
     pub fn index_generic<CO>(&self) -> Stream<Circuit<P>, CO>
     where
-        CI: BatchReader<Key = (CO::Key, CO::Val), Val = (), Time = (), R = CO::R> + 'static,
-        CO: Batch<Time = ()> + Clone + 'static,
+        CI: BatchReader<Key = (CO::Key, CO::Val), Val = (), Time = (), R = CO::R>,
+        CO: Batch<Time = ()>,
     {
         self.circuit()
             .cache_get_or_insert_with(IndexId::new(self.origin_node_id().clone()), || {
@@ -63,7 +63,7 @@ where
         index_func: F,
     ) -> Stream<Circuit<P>, OrdIndexedZSet<K, V, CI::R>>
     where
-        CI: BatchReader<Time = (), Val = ()> + 'static,
+        CI: BatchReader<Time = (), Val = ()>,
         F: Fn(&CI::Key) -> (K, V) + Clone + 'static,
         K: DBData,
         V: DBData,
@@ -75,8 +75,8 @@ where
     /// Z-set type, not just `OrdIndexedZSet`.
     pub fn index_with_generic<CO, F>(&self, index_func: F) -> Stream<Circuit<P>, CO>
     where
-        CI: BatchReader<Time = (), Val = ()> + 'static,
-        CO: Batch<Time = (), R = CI::R> + Clone + 'static,
+        CI: BatchReader<Time = (), Val = ()>,
+        CO: Batch<Time = (), R = CI::R>,
         F: Fn(&CI::Key) -> (CO::Key, CO::Val) + Clone + 'static,
     {
         self.circuit()
@@ -125,8 +125,8 @@ where
 
 impl<CI, CO> UnaryOperator<CI, CO> for Index<CI, CO>
 where
-    CO: Batch<Time = ()> + Clone + 'static,
-    CI: BatchReader<Key = (CO::Key, CO::Val), Val = (), Time = (), R = CO::R> + 'static,
+    CO: Batch<Time = ()>,
+    CI: BatchReader<Key = (CO::Key, CO::Val), Val = (), Time = (), R = CO::R>,
 {
     fn eval(&mut self, input: &CI) -> CO {
         let mut builder = <CO as Batch>::Builder::with_capacity((), input.len());
@@ -209,8 +209,8 @@ where
 
 impl<CI, CO, F> UnaryOperator<CI, CO> for IndexWith<CI, CO, F>
 where
-    CO: Batch<Time = ()> + Clone + 'static,
-    CI: BatchReader<Val = (), Time = (), R = CO::R> + 'static,
+    CO: Batch<Time = ()>,
+    CI: BatchReader<Val = (), Time = (), R = CO::R>,
     F: Fn(&CI::Key) -> (CO::Key, CO::Val) + 'static,
 {
     fn eval(&mut self, i: &CI) -> CO {

--- a/src/operator/input.rs
+++ b/src/operator/input.rs
@@ -1,11 +1,11 @@
 use crate::{
-    algebra::{MonoidValue, ZRingValue},
+    algebra::ZRingValue,
     circuit::{
         operator_traits::{Operator, SourceOperator},
         LocalStoreMarker, Scope,
     },
     trace::Batch,
-    Circuit, DBData, OrdIndexedZSet, OrdZSet, Runtime, Stream,
+    Circuit, DBData, DBWeight, OrdIndexedZSet, OrdZSet, Runtime, Stream,
 };
 use fxhash::hash32;
 use size_of::SizeOf;
@@ -77,7 +77,7 @@ impl Circuit<()> {
     pub fn add_input_zset<K, R>(&self) -> (Stream<Self, OrdZSet<K, R>>, CollectionHandle<K, R>)
     where
         K: DBData,
-        R: DBData + MonoidValue,
+        R: DBWeight,
     {
         let (input, input_handle) = Input::new(|tuples| OrdZSet::from_keys((), tuples));
         let stream = self.add_source(input);
@@ -112,7 +112,7 @@ impl Circuit<()> {
     where
         K: DBData,
         V: DBData,
-        R: DBData + MonoidValue,
+        R: DBWeight,
     {
         let (input, input_handle) = Input::new(|tuples: Vec<(K, (V, R))>| {
             OrdIndexedZSet::from_tuples(

--- a/src/operator/input.rs
+++ b/src/operator/input.rs
@@ -8,7 +8,6 @@ use crate::{
     Circuit, DBData, DBWeight, OrdIndexedZSet, OrdZSet, Runtime, Stream,
 };
 use fxhash::hash32;
-use size_of::SizeOf;
 use std::{
     borrow::Cow,
     hash::{Hash, Hasher},
@@ -135,7 +134,7 @@ impl Circuit<()> {
     where
         K: DBData,
         F: Fn(VI) -> Option<V> + 'static,
-        B: Batch<Key = K, Val = V, Time = ()> + SizeOf + 'static,
+        B: Batch<Key = K, Val = V, Time = ()>,
         B::R: ZRingValue,
         V: DBData,
         VI: DBData,

--- a/src/operator/join.rs
+++ b/src/operator/join.rs
@@ -12,7 +12,7 @@ use crate::{
         cursor::Cursor as TraceCursor, spine_fueled::Spine, Batch, BatchReader, Batcher, Builder,
         Trace,
     },
-    DBData, OrdIndexedZSet, OrdZSet,
+    DBData, DBTimestamp, OrdIndexedZSet, OrdZSet,
 };
 use size_of::{Context, SizeOf};
 use std::{
@@ -189,7 +189,7 @@ where
         join_func: F,
     ) -> Stream<Circuit<P>, OrdZSet<V, I1::R>>
     where
-        TS: Timestamp + SizeOf,
+        TS: DBTimestamp,
         I2: IndexedZSet<Key = I1::Key, R = I1::R> + Send,
         F: Fn(&I1::Key, &I1::Val, &I2::Val) -> V + Clone + 'static,
         V: DBData + Default,
@@ -212,7 +212,7 @@ where
         join_func: F,
     ) -> Stream<Circuit<P>, OrdIndexedZSet<K, V, I1::R>>
     where
-        TS: Timestamp + SizeOf,
+        TS: DBTimestamp,
         I2: IndexedZSet<Key = I1::Key, R = I1::R> + Send,
         F: Fn(&I1::Key, &I1::Val, &I2::Val) -> It + Clone + 'static,
         K: DBData + Default,
@@ -230,7 +230,7 @@ where
         join_func: F,
     ) -> Stream<Circuit<P>, Z>
     where
-        TS: Timestamp + SizeOf,
+        TS: DBTimestamp,
         I2: IndexedZSet<Key = I1::Key, R = I1::R> + Send,
         Z: IndexedZSet<R = I1::R>,
         Z::Batcher: SizeOf,
@@ -311,7 +311,7 @@ where
     /// excluding keys that are not present in `other`.
     pub fn antijoin<TS, I2>(&self, other: &Stream<Circuit<P>, I2>) -> Stream<Circuit<P>, I1>
     where
-        TS: Timestamp + SizeOf,
+        TS: DBTimestamp,
         I1::Key: Default,
         I1::Val: Default,
         I1::Item: Default,
@@ -668,7 +668,7 @@ where
 
 impl<F, I, T, Z, It> BinaryOperator<I, T, Z> for JoinTrace<F, I, T, Z, It>
 where
-    I: IndexedZSet, /* + ::std::fmt::Display */
+    I: IndexedZSet,                             /* + ::std::fmt::Display */
     T: Trace<Key = I::Key, R = I::R> + 'static, /* + ::std::fmt::Display */
     //T::Time: ::std::fmt::Display,
     F: Clone + Fn(&I::Key, &I::Val, &T::Val) -> It + 'static,
@@ -820,12 +820,12 @@ mod test {
     use crate::{
         indexed_zset,
         operator::{DelayedFeedback, FilterMap, Generator},
-        time::{NestedTimestamp32, Product, Timestamp},
+        time::{NestedTimestamp32, Product},
         trace::{
             ord::{OrdIndexedZSet, OrdZSet},
             Batch,
         },
-        zset, Circuit, DBData, Runtime, Stream,
+        zset, Circuit, DBTimestamp, Runtime, Stream,
     };
     use size_of::SizeOf;
     use std::{
@@ -1091,7 +1091,7 @@ mod test {
     ) -> Stream<Circuit<P>, OrdZSet<Label, isize>>
     where
         P: Clone + 'static,
-        TS: DBData + Timestamp,
+        TS: DBTimestamp,
     {
         let computed_labels = circuit
             .fixedpoint(|child| {

--- a/src/operator/join_range.rs
+++ b/src/operator/join_range.rs
@@ -15,7 +15,7 @@
 //!   batch with weight `w1 * w2`.
 
 use crate::{
-    algebra::MulByRef,
+    algebra::{MulByRef, ZRingValue},
     circuit::{
         operator_traits::{BinaryOperator, Operator},
         Circuit, Scope, Stream,
@@ -43,9 +43,9 @@ where
         join_func: JF,
     ) -> Stream<Circuit<P>, OrdZSet<It::Item, I1::R>>
     where
-        I1: BatchReader<Time = ()> + Clone + 'static,
-        I1::R: MulByRef<Output = I1::R>,
-        I2: BatchReader<Time = (), R = I1::R> + Clone + 'static,
+        I1: BatchReader<Time = ()> + Clone,
+        I1::R: ZRingValue,
+        I2: BatchReader<Time = (), R = I1::R> + Clone,
         RF: Fn(&I1::Key) -> (I2::Key, I2::Key) + 'static,
         JF: Fn(&I1::Key, &I1::Val, &I2::Key, &I2::Val) -> It + 'static,
         It: IntoIterator + 'static,
@@ -74,9 +74,9 @@ where
         join_func: JF,
     ) -> Stream<Circuit<P>, OrdIndexedZSet<K, V, I1::R>>
     where
-        I1: BatchReader<Time = ()> + Clone + 'static,
-        I1::R: MulByRef<Output = I1::R>,
-        I2: BatchReader<Time = (), R = I1::R> + Clone + 'static,
+        I1: BatchReader<Time = ()> + Clone,
+        I1::R: ZRingValue,
+        I2: BatchReader<Time = (), R = I1::R> + Clone,
         RF: Fn(&I1::Key) -> (I2::Key, I2::Key) + 'static,
         JF: Fn(&I1::Key, &I1::Val, &I2::Key, &I2::Val) -> It + 'static,
         K: DBData,
@@ -94,10 +94,10 @@ where
         join_func: JF,
     ) -> Stream<Circuit<P>, O>
     where
-        I1: BatchReader<Time = (), R = O::R> + Clone + 'static,
-        I2: BatchReader<Time = (), R = O::R> + Clone + 'static,
-        O: Batch<Time = ()> + Clone + 'static,
-        O::R: MulByRef<Output = O::R>,
+        I1: BatchReader<Time = (), R = O::R> + Clone,
+        I2: BatchReader<Time = (), R = O::R> + Clone,
+        O: Batch<Time = ()>,
+        O::R: ZRingValue,
         RF: Fn(&I1::Key) -> (I2::Key, I2::Key) + 'static,
         JF: Fn(&I1::Key, &I1::Val, &I2::Key, &I2::Val) -> It + 'static,
         It: IntoIterator<Item = (O::Key, O::Val)> + 'static,
@@ -142,10 +142,10 @@ where
 
 impl<RF, JF, It, I1, I2, O> BinaryOperator<I1, I2, O> for StreamJoinRange<RF, JF, It, I1, I2, O>
 where
-    I1: BatchReader<Time = (), R = O::R> + Clone + 'static,
-    I2: BatchReader<Time = (), R = O::R> + Clone + 'static,
-    O: Batch<Time = ()> + 'static,
-    O::R: MulByRef<Output = O::R>,
+    I1: BatchReader<Time = (), R = O::R> + Clone,
+    I2: BatchReader<Time = (), R = O::R> + Clone,
+    O: Batch<Time = ()>,
+    O::R: ZRingValue,
     RF: Fn(&I1::Key) -> (I2::Key, I2::Key) + 'static,
     JF: Fn(&I1::Key, &I1::Val, &I2::Key, &I2::Val) -> It + 'static,
     It: IntoIterator<Item = (O::Key, O::Val)> + 'static,

--- a/src/operator/recursive.rs
+++ b/src/operator/recursive.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use impl_trait_for_tuples::impl_for_tuples;
 use size_of::SizeOf;
-use std::{hash::Hash, result::Result};
+use std::result::Result;
 
 /// Generalizes stream operators to groups of streams.
 ///
@@ -53,9 +53,8 @@ pub trait RecursiveStreams<C> {
 // batches, we can ditch the `B::Val = ()` constraint.
 impl<B> RecursiveStreams<Circuit<Circuit<()>>> for Stream<Circuit<Circuit<()>>, B>
 where
-    B: ZSet + SizeOf + Send + 'static,
-    B::Key: Clone + Ord + Hash + SizeOf,
-    B::R: SizeOf + ZRingValue,
+    B: ZSet + Send,
+    B::R: ZRingValue,
     Spine<B>: SizeOf,
 {
     type Feedback = DelayedFeedback<Circuit<()>, B>;

--- a/src/operator/time_series/radix_tree/mod.rs
+++ b/src/operator/time_series/radix_tree/mod.rs
@@ -87,6 +87,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     fmt,
     fmt::{Debug, Display, Formatter, Write},
+    hash::Hash,
     mem::size_of,
 };
 
@@ -341,7 +342,7 @@ where
 }
 
 /// Describes a range of timestamps that share a common prefix.
-#[derive(Clone, Debug, Default, SizeOf, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Default, SizeOf, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Prefix<TS> {
     /// Prefix bits.
     key: TS,
@@ -482,7 +483,7 @@ where
 }
 
 /// Pointer to a child node.
-#[derive(Clone, Debug, SizeOf, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, SizeOf, PartialEq, Eq, Hash, PartialOrd, Ord)]
 struct ChildPtr<TS, A> {
     /// Unique prefix of a child subtree, which serves as a pointer
     /// to the child node.  Given this prefix the child node can
@@ -524,7 +525,7 @@ where
 }
 
 /// Radix tree node.
-#[derive(Clone, Debug, Default, SizeOf, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, Default, SizeOf, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct TreeNode<TS, A> {
     /// Array of children.
     // `Option` doesn't introduce space overhead.

--- a/src/operator/time_series/radix_tree/partitioned_tree_aggregate.rs
+++ b/src/operator/time_series/radix_tree/partitioned_tree_aggregate.rs
@@ -462,7 +462,7 @@ mod test {
         algebra::{DefaultSemigroup, HasZero, Semigroup},
         operator::Fold,
         trace::BatchReader,
-        Circuit, DBData, CollectionHandle,
+        Circuit, CollectionHandle, DBData,
     };
     use num::PrimInt;
     use std::{

--- a/src/operator/time_series/radix_tree/partitioned_tree_aggregate.rs
+++ b/src/operator/time_series/radix_tree/partitioned_tree_aggregate.rs
@@ -120,9 +120,8 @@ where
         Z: PartitionedIndexedZSet<TS, V> + SizeOf,
         TS: DBData + PrimInt,
         V: DBData,
-        Z::R: ZRingValue,
-        Agg: Aggregator<V, (), Z::R> + 'static,
-        Agg::Output: Default + DBData,
+        Agg: Aggregator<V, (), Z::R>,
+        Agg::Output: Default,
     {
         self.partitioned_tree_aggregate_generic::<TS, V, Agg, OrdPartitionedRadixTree<Z::Key, TS, Agg::Output, isize>>(
             aggregator,
@@ -139,9 +138,8 @@ where
         Z: PartitionedIndexedZSet<TS, V> + SizeOf,
         TS: DBData + PrimInt,
         V: DBData,
-        Z::R: ZRingValue,
-        Agg: Aggregator<V, (), Z::R> + 'static,
-        Agg::Output: DBData + Default,
+        Agg: Aggregator<V, (), Z::R>,
+        Agg::Output: Default,
         O: PartitionedRadixTreeBatch<TS, Agg::Output, Key = Z::Key>,
         O::R: ZRingValue,
     {
@@ -336,11 +334,10 @@ where
     Z: PartitionedBatchReader<TS, V> + Clone,
     TS: DBData + PrimInt,
     V: DBData,
-    Z::R: ZRingValue,
     IT: PartitionedBatchReader<TS, V, Key = Z::Key, R = Z::R> + Clone,
     OT: PartitionedRadixTreeReader<TS, Agg::Output, Key = Z::Key, R = O::R> + Clone,
-    Agg: Aggregator<V, (), Z::R> + 'static,
-    Agg::Output: DBData + Default,
+    Agg: Aggregator<V, (), Z::R>,
+    Agg::Output: Default,
     O: PartitionedRadixTreeBatch<TS, Agg::Output, Key = Z::Key>,
     O::R: ZRingValue,
 {

--- a/src/operator/time_series/radix_tree/tree_aggregate.rs
+++ b/src/operator/time_series/radix_tree/tree_aggregate.rs
@@ -74,7 +74,7 @@ where
         Z::R: ZRingValue,
         Agg: Aggregator<Z::Val, (), Z::R> + 'static,
         Agg::Output: Default + DBData,
-        O: RadixTreeBatch<Z::Key, Agg::Output> + SizeOf + 'static,
+        O: RadixTreeBatch<Z::Key, Agg::Output>,
         O::R: ZRingValue,
     {
         self.circuit()
@@ -188,11 +188,11 @@ where
     Z: IndexedZSet,
     Z::Key: PrimInt,
     Z::R: ZRingValue,
-    IT: BatchReader<Key = Z::Key, Val = Z::Val, Time = (), R = Z::R> + Clone + 'static,
-    OT: RadixTreeReader<Z::Key, Agg::Output, R = O::R> + Clone + 'static,
+    IT: BatchReader<Key = Z::Key, Val = Z::Val, Time = (), R = Z::R> + Clone,
+    OT: RadixTreeReader<Z::Key, Agg::Output, R = O::R> + Clone,
     Agg: Aggregator<Z::Val, (), Z::R> + 'static,
     Agg::Output: DBData + Default,
-    O: RadixTreeBatch<Z::Key, Agg::Output> + 'static,
+    O: RadixTreeBatch<Z::Key, Agg::Output>,
     O::R: ZRingValue,
 {
     fn eval<'a>(

--- a/src/operator/time_series/radix_tree/tree_aggregate.rs
+++ b/src/operator/time_series/radix_tree/tree_aggregate.rs
@@ -11,7 +11,7 @@ use crate::{
         Aggregator,
     },
     trace::{spine_fueled::Spine, Batch, BatchReader, Builder},
-    Circuit, DBData, NumEntries, OrdIndexedZSet, Stream,
+    Circuit, NumEntries, OrdIndexedZSet, Stream,
 };
 use num::PrimInt;
 use size_of::SizeOf;
@@ -59,9 +59,8 @@ where
     where
         Z: IndexedZSet + SizeOf + NumEntries + Send,
         Z::Key: PrimInt,
-        Z::R: ZRingValue,
-        Agg: Aggregator<Z::Val, (), Z::R> + 'static,
-        Agg::Output: DBData + Default,
+        Agg: Aggregator<Z::Val, (), Z::R>,
+        Agg::Output: Default,
     {
         self.tree_aggregate_generic::<Agg, OrdRadixTree<Z::Key, Agg::Output, isize>>(aggregator)
     }
@@ -71,9 +70,8 @@ where
     where
         Z: IndexedZSet + SizeOf + NumEntries + Send,
         Z::Key: PrimInt,
-        Z::R: ZRingValue,
-        Agg: Aggregator<Z::Val, (), Z::R> + 'static,
-        Agg::Output: Default + DBData,
+        Agg: Aggregator<Z::Val, (), Z::R>,
+        Agg::Output: Default,
         O: RadixTreeBatch<Z::Key, Agg::Output>,
         O::R: ZRingValue,
     {
@@ -187,11 +185,10 @@ impl<Z, IT, OT, Agg, O> TernaryOperator<Z, IT, OT, O> for RadixTreeAggregate<Z, 
 where
     Z: IndexedZSet,
     Z::Key: PrimInt,
-    Z::R: ZRingValue,
     IT: BatchReader<Key = Z::Key, Val = Z::Val, Time = (), R = Z::R> + Clone,
     OT: RadixTreeReader<Z::Key, Agg::Output, R = O::R> + Clone,
-    Agg: Aggregator<Z::Val, (), Z::R> + 'static,
-    Agg::Output: DBData + Default,
+    Agg: Aggregator<Z::Val, (), Z::R>,
+    Agg::Output: Default,
     O: RadixTreeBatch<Z::Key, Agg::Output>,
     O::R: ZRingValue,
 {

--- a/src/operator/time_series/rolling_aggregate.rs
+++ b/src/operator/time_series/rolling_aggregate.rs
@@ -46,8 +46,8 @@ impl<B> Stream<Circuit<()>, B> {
     where
         B: PartitionedIndexedZSet<TS, V>,
         B::R: ZRingValue,
-        Agg: Aggregator<V, (), B::R> + 'static,
-        Agg::Output: DBData + Default,
+        Agg: Aggregator<V, (), B::R>,
+        Agg::Output: Default,
         TS: DBData + PrimInt,
         V: DBData,
     {
@@ -64,8 +64,8 @@ impl<B> Stream<Circuit<()>, B> {
     where
         B: PartitionedIndexedZSet<TS, V>,
         B::R: ZRingValue,
-        Agg: Aggregator<V, (), B::R> + 'static,
-        Agg::Output: DBData + Default,
+        Agg: Aggregator<V, (), B::R>,
+        Agg::Output: Default,
         O: PartitionedIndexedZSet<TS, (V, Option<Agg::Output>), Key = B::Key, R = B::R> + SizeOf,
         TS: DBData + PrimInt,
         V: DBData,

--- a/src/operator/trace.rs
+++ b/src/operator/trace.rs
@@ -353,7 +353,6 @@ where
 impl<T> Operator for Z1Trace<T>
 where
     T: Trace + SizeOf + NumEntries + 'static,
-    T::Time: Timestamp,
 {
     fn name(&self) -> Cow<'static, str> {
         Cow::from("Z1 (trace)")
@@ -407,7 +406,6 @@ where
 impl<T> StrictOperator<T> for Z1Trace<T>
 where
     T: SizeOf + NumEntries + Trace + 'static,
-    T::Time: Timestamp,
 {
     fn get_output(&mut self) -> T {
         let mut result = self.trace.take().unwrap();
@@ -427,7 +425,6 @@ where
 impl<T> StrictUnaryOperator<T, T> for Z1Trace<T>
 where
     T: SizeOf + NumEntries + Trace + 'static,
-    T::Time: Timestamp,
 {
     fn eval_strict(&mut self, _i: &T) {
         unimplemented!()

--- a/src/operator/upsert.rs
+++ b/src/operator/upsert.rs
@@ -10,9 +10,8 @@ use crate::{
         Builder, Trace,
     },
     utils::VecExt,
-    Circuit, Stream, Timestamp,
+    Circuit, DBData, Stream, Timestamp,
 };
-use size_of::SizeOf;
 use std::{borrow::Cow, marker::PhantomData, ops::Neg};
 
 impl<P, K, V> Stream<Circuit<P>, Vec<(K, Option<V>)>>
@@ -38,10 +37,10 @@ where
     // TODO: Derive TS from circuit.
     pub fn upsert<TS, B>(&self) -> Stream<Circuit<P>, B>
     where
-        K: Ord + Clone + Eq + SizeOf + 'static,
-        V: Ord + Clone + Ord + SizeOf + 'static,
-        B::R: ZRingValue + SizeOf,
-        TS: Timestamp + SizeOf,
+        K: DBData,
+        V: DBData,
+        B::R: DBData + ZRingValue,
+        TS: DBData + Timestamp,
         B: Batch<Key = K, Val = V, Time = ()> + 'static,
     {
         let circuit = self.circuit();
@@ -144,8 +143,6 @@ where
 impl<T, B> BinaryOperator<T, Vec<(T::Key, Option<T::Val>)>, B> for Upsert<T, B>
 where
     T: Trace + 'static,
-    T::Key: Clone + Ord + Eq,
-    T::Val: Clone + Ord,
     T::R: ZRingValue,
     B: Batch<Key = T::Key, Val = T::Val, Time = (), R = T::R> + 'static,
 {

--- a/src/operator/upsert.rs
+++ b/src/operator/upsert.rs
@@ -10,7 +10,7 @@ use crate::{
         Builder, Trace,
     },
     utils::VecExt,
-    Circuit, DBData, Stream, Timestamp,
+    Circuit, DBData, DBTimestamp, Stream, Timestamp,
 };
 use std::{borrow::Cow, marker::PhantomData, ops::Neg};
 
@@ -40,7 +40,7 @@ where
         K: DBData,
         V: DBData,
         B::R: DBData + ZRingValue,
-        TS: DBData + Timestamp,
+        TS: DBTimestamp,
         B: Batch<Key = K, Val = V, Time = ()> + 'static,
     {
         let circuit = self.circuit();

--- a/src/operator/upsert.rs
+++ b/src/operator/upsert.rs
@@ -41,7 +41,7 @@ where
         V: DBData,
         B::R: DBData + ZRingValue,
         TS: DBTimestamp,
-        B: Batch<Key = K, Val = V, Time = ()> + 'static,
+        B: Batch<Key = K, Val = V, Time = ()>,
     {
         let circuit = self.circuit();
 
@@ -126,7 +126,7 @@ where
 
 impl<T, B> Operator for Upsert<T, B>
 where
-    T: BatchReader + 'static,
+    T: BatchReader,
     B: 'static,
 {
     fn name(&self) -> Cow<'static, str> {
@@ -142,9 +142,9 @@ where
 
 impl<T, B> BinaryOperator<T, Vec<(T::Key, Option<T::Val>)>, B> for Upsert<T, B>
 where
-    T: Trace + 'static,
+    T: Trace,
     T::R: ZRingValue,
-    B: Batch<Key = T::Key, Val = T::Val, Time = (), R = T::R> + 'static,
+    B: Batch<Key = T::Key, Val = T::Val, Time = (), R = T::R>,
 {
     fn eval(&mut self, trace: &T, updates: &Vec<(T::Key, Option<T::Val>)>) -> B {
         // Inputs must be sorted by key

--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -5,10 +5,10 @@ mod nested_ts32;
 mod product;
 
 use crate::{
-    algebra::{Lattice, MonoidValue, PartialOrder},
+    algebra::{Lattice, PartialOrder},
     circuit::Scope,
     trace::{ord::OrdValBatch, Batch},
-    DBData, OrdIndexedZSet,
+    DBData, DBWeight, OrdIndexedZSet,
 };
 use size_of::SizeOf;
 use std::{fmt::Debug, hash::Hash};
@@ -89,7 +89,8 @@ pub trait Timestamp:
     /// We automate this choice by making it an associated type of
     /// `trait Timestamp` -- not a very elegant solution, but I couldn't
     /// think of a better one.
-    type OrdValBatch<K: DBData, V: DBData, R: DBData + MonoidValue>: Batch<Key=K, Val=V, Time=Self, R=R> + SizeOf;
+    type OrdValBatch<K: DBData, V: DBData, R: DBWeight>: Batch<Key = K, Val = V, Time = Self, R = R>
+        + SizeOf;
 
     fn minimum() -> Self;
 
@@ -155,7 +156,7 @@ pub trait Timestamp:
 }
 
 impl Timestamp for () {
-    type OrdValBatch<K: DBData, V: DBData, R: DBData + MonoidValue> = OrdIndexedZSet<K, V, R>;
+    type OrdValBatch<K: DBData, V: DBData, R: DBWeight> = OrdIndexedZSet<K, V, R>;
 
     fn minimum() -> Self {}
     fn advance(&self, _scope: Scope) -> Self {}
@@ -165,7 +166,7 @@ impl Timestamp for () {
 }
 
 impl Timestamp for u32 {
-    type OrdValBatch<K: DBData, V: DBData, R: DBData + MonoidValue> = OrdValBatch<K, V, Self, R>;
+    type OrdValBatch<K: DBData, V: DBData, R: DBWeight> = OrdValBatch<K, V, Self, R>;
 
     fn minimum() -> Self {
         0

--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     algebra::{Lattice, MonoidValue, PartialOrder},
     circuit::Scope,
     trace::{ord::OrdValBatch, Batch},
-    OrdIndexedZSet,
+    DBData, OrdIndexedZSet,
 };
 use size_of::SizeOf;
 use std::{fmt::Debug, hash::Hash};
@@ -89,11 +89,7 @@ pub trait Timestamp:
     /// We automate this choice by making it an associated type of
     /// `trait Timestamp` -- not a very elegant solution, but I couldn't
     /// think of a better one.
-    type OrdValBatch<
-        K: Ord + Clone + SizeOf + 'static,
-        V: Ord + Clone + SizeOf + 'static,
-        R: MonoidValue + SizeOf>
-            : Batch<Key=K, Val=V, Time=Self, R=R> + SizeOf;
+    type OrdValBatch<K: DBData, V: DBData, R: DBData + MonoidValue>: Batch<Key=K, Val=V, Time=Self, R=R> + SizeOf;
 
     fn minimum() -> Self;
 
@@ -159,11 +155,7 @@ pub trait Timestamp:
 }
 
 impl Timestamp for () {
-    type OrdValBatch<
-        K: Ord + Clone + SizeOf + 'static,
-        V: Ord + Clone + SizeOf + 'static,
-        R: MonoidValue + SizeOf,
-    > = OrdIndexedZSet<K, V, R>;
+    type OrdValBatch<K: DBData, V: DBData, R: DBData + MonoidValue> = OrdIndexedZSet<K, V, R>;
 
     fn minimum() -> Self {}
     fn advance(&self, _scope: Scope) -> Self {}
@@ -173,11 +165,7 @@ impl Timestamp for () {
 }
 
 impl Timestamp for u32 {
-    type OrdValBatch<
-        K: Ord + Clone + SizeOf + 'static,
-        V: Ord + Clone + SizeOf + 'static,
-        R: MonoidValue + SizeOf,
-    > = OrdValBatch<K, V, Self, R>;
+    type OrdValBatch<K: DBData, V: DBData, R: DBData + MonoidValue> = OrdValBatch<K, V, Self, R>;
 
     fn minimum() -> Self {
         0

--- a/src/time/mod.rs
+++ b/src/time/mod.rs
@@ -70,7 +70,6 @@ pub use product::Product;
 /// (i.e., the current parent clock cycle) from older values.  They therefore
 /// take advantage of the lossy timestamp representation implemented by the
 /// `NestedTimestamp32` type.
-// TODO: Eliminate timely dependency.
 // TODO: Conversion to/from the most general time representation (`[usize]`).
 // TODO: Model overflow by having `advance` return Option<Self>.
 pub trait Timestamp:
@@ -133,7 +132,7 @@ pub trait Timestamp:
     ///
     /// Push `self` back by one clock cycle by decrementing the clock at the
     /// specified nesting level by one.  `scope` identifies the nesting
-    /// level of the circuit whoce clock is ticking. `0` refers to the
+    /// level of the circuit whose clock is ticking. `0` refers to the
     /// innermost circuit.  `1` is its parent circuit, etc.
     ///
     /// While time does not normally flow backward in DBSP, it is sometimes

--- a/src/time/nested_ts32.rs
+++ b/src/time/nested_ts32.rs
@@ -3,6 +3,7 @@ use crate::{
     circuit::Scope,
     time::Timestamp,
     trace::ord::OrdValBatch,
+    DBData,
 };
 use size_of::SizeOf;
 use std::fmt::{Debug, Display, Formatter};
@@ -58,11 +59,7 @@ impl PartialOrder for NestedTimestamp32 {
 }
 
 impl Timestamp for NestedTimestamp32 {
-    type OrdValBatch<
-        K: Ord + Clone + SizeOf + 'static,
-        V: Ord + Clone + SizeOf + 'static,
-        R: MonoidValue + SizeOf,
-    > = OrdValBatch<K, V, Self, R>;
+    type OrdValBatch<K: DBData, V: DBData, R: DBData + MonoidValue> = OrdValBatch<K, V, Self, R>;
 
     fn minimum() -> Self {
         Self::new(false, 0)

--- a/src/time/nested_ts32.rs
+++ b/src/time/nested_ts32.rs
@@ -1,9 +1,9 @@
 use crate::{
-    algebra::{Lattice, MonoidValue, PartialOrder},
+    algebra::{Lattice, PartialOrder},
     circuit::Scope,
     time::Timestamp,
     trace::ord::OrdValBatch,
-    DBData,
+    DBData, DBWeight,
 };
 use size_of::SizeOf;
 use std::fmt::{Debug, Display, Formatter};
@@ -59,7 +59,7 @@ impl PartialOrder for NestedTimestamp32 {
 }
 
 impl Timestamp for NestedTimestamp32 {
-    type OrdValBatch<K: DBData, V: DBData, R: DBData + MonoidValue> = OrdValBatch<K, V, Self, R>;
+    type OrdValBatch<K: DBData, V: DBData, R: DBWeight> = OrdValBatch<K, V, Self, R>;
 
     fn minimum() -> Self {
         Self::new(false, 0)

--- a/src/time/product.rs
+++ b/src/time/product.rs
@@ -1,9 +1,9 @@
 use crate::{
-    algebra::{Lattice, MonoidValue, PartialOrder},
+    algebra::{Lattice, PartialOrder},
     circuit::Scope,
     time::Timestamp,
     trace::ord::OrdValBatch,
-    DBData,
+    DBData, DBTimestamp, DBWeight,
 };
 use size_of::SizeOf;
 use std::fmt::{Debug, Display, Formatter};
@@ -64,14 +64,10 @@ impl<TOuter: PartialOrder, TInner: PartialOrder> PartialOrder for Product<TOuter
 
 impl<TOuter, TInner> Timestamp for Product<TOuter, TInner>
 where
-    TOuter: DBData + Timestamp,
-    TInner: DBData + Timestamp,
+    TOuter: DBTimestamp,
+    TInner: DBTimestamp,
 {
-    type OrdValBatch<
-        K: DBData,
-        V: DBData,
-        R: DBData + MonoidValue,
-    > = OrdValBatch<K, V, Self, R>;
+    type OrdValBatch<K: DBData, V: DBData, R: DBWeight> = OrdValBatch<K, V, Self, R>;
 
     fn minimum() -> Self {
         Self::new(TOuter::minimum(), TInner::minimum())

--- a/src/time/product.rs
+++ b/src/time/product.rs
@@ -3,6 +3,7 @@ use crate::{
     circuit::Scope,
     time::Timestamp,
     trace::ord::OrdValBatch,
+    DBData,
 };
 use size_of::SizeOf;
 use std::fmt::{Debug, Display, Formatter};
@@ -63,13 +64,13 @@ impl<TOuter: PartialOrder, TInner: PartialOrder> PartialOrder for Product<TOuter
 
 impl<TOuter, TInner> Timestamp for Product<TOuter, TInner>
 where
-    TOuter: Timestamp + SizeOf,
-    TInner: Timestamp + SizeOf,
+    TOuter: DBData + Timestamp,
+    TInner: DBData + Timestamp,
 {
     type OrdValBatch<
-        K: Ord + Clone + SizeOf + 'static,
-        V: Ord + Clone + SizeOf + 'static,
-        R: MonoidValue + SizeOf,
+        K: DBData,
+        V: DBData,
+        R: DBData + MonoidValue,
     > = OrdValBatch<K, V, Self, R>;
 
     fn minimum() -> Self {

--- a/src/trace/layers/column_leaf/cursor.rs
+++ b/src/trace/layers/column_leaf/cursor.rs
@@ -1,7 +1,7 @@
 use crate::{
-    trace::{layers::{advance, column_leaf::OrderedColumnLeaf, Cursor}, MonoidValue},
+    trace::layers::{advance, column_leaf::OrderedColumnLeaf, Cursor},
     utils::cursor_position_oob,
-    DBData,
+    DBData, DBWeight,
 };
 use std::fmt::{self, Display};
 
@@ -153,7 +153,7 @@ where
 impl<'a, K, R> Display for ColumnLeafCursor<'a, K, R>
 where
     K: DBData,
-    R: DBData + MonoidValue,
+    R: DBWeight,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut cursor: ColumnLeafCursor<K, R> = self.clone();

--- a/src/trace/layers/column_leaf/cursor.rs
+++ b/src/trace/layers/column_leaf/cursor.rs
@@ -1,7 +1,7 @@
 use crate::{
-    algebra::{AddAssignByRef, HasZero},
-    trace::layers::{advance, column_leaf::OrderedColumnLeaf, Cursor},
+    trace::{layers::{advance, column_leaf::OrderedColumnLeaf, Cursor}, MonoidValue},
     utils::cursor_position_oob,
+    DBData,
 };
 use std::fmt::{self, Display};
 
@@ -152,15 +152,15 @@ where
 
 impl<'a, K, R> Display for ColumnLeafCursor<'a, K, R>
 where
-    K: Ord + Clone + Display,
-    R: Eq + HasZero + AddAssignByRef + Clone + Display,
+    K: DBData,
+    R: DBData + MonoidValue,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut cursor: ColumnLeafCursor<K, R> = self.clone();
 
         while cursor.valid() {
             let (key, val) = cursor.key();
-            writeln!(f, "{} -> {}", key, val)?;
+            writeln!(f, "{:?} -> {:?}", key, val)?;
             cursor.step();
         }
 

--- a/src/trace/layers/column_leaf/mod.rs
+++ b/src/trace/layers/column_leaf/mod.rs
@@ -12,9 +12,9 @@ pub use cursor::ColumnLeafCursor;
 
 use crate::{
     algebra::{AddAssignByRef, AddByRef, HasZero, NegByRef},
-    trace::{MonoidValue, layers::Trie},
     utils::{assume, cast_uninit_vec},
-    DBData, NumEntries,
+    trace::layers::Trie,
+    DBData, DBWeight, NumEntries,
 };
 use size_of::SizeOf;
 use std::{
@@ -174,7 +174,7 @@ where
 impl<K, R> Display for OrderedColumnLeaf<K, R>
 where
     K: DBData,
-    R: DBData + MonoidValue,
+    R: DBWeight,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.cursor().fmt(f)

--- a/src/trace/layers/column_leaf/mod.rs
+++ b/src/trace/layers/column_leaf/mod.rs
@@ -12,8 +12,8 @@ pub use cursor::ColumnLeafCursor;
 
 use crate::{
     algebra::{AddAssignByRef, AddByRef, HasZero, NegByRef},
-    utils::{assume, cast_uninit_vec},
     trace::layers::Trie,
+    utils::{assume, cast_uninit_vec},
     DBData, DBWeight, NumEntries,
 };
 use size_of::SizeOf;

--- a/src/trace/layers/column_leaf/mod.rs
+++ b/src/trace/layers/column_leaf/mod.rs
@@ -12,9 +12,9 @@ pub use cursor::ColumnLeafCursor;
 
 use crate::{
     algebra::{AddAssignByRef, AddByRef, HasZero, NegByRef},
-    trace::layers::Trie,
+    trace::{MonoidValue, layers::Trie},
     utils::{assume, cast_uninit_vec},
-    NumEntries,
+    DBData, NumEntries,
 };
 use size_of::SizeOf;
 use std::{
@@ -173,8 +173,8 @@ where
 
 impl<K, R> Display for OrderedColumnLeaf<K, R>
 where
-    K: Ord + Clone + Display,
-    R: Eq + HasZero + AddAssign + AddAssignByRef + Clone + Display,
+    K: DBData,
+    R: DBData + MonoidValue,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.cursor().fmt(f)

--- a/src/trace/layers/mod.rs
+++ b/src/trace/layers/mod.rs
@@ -181,6 +181,7 @@ pub trait OrdOffset:
     + HasZero
     + SizeOf
     + Sized
+    + 'static
 {
     fn from_usize(offset: usize) -> Self;
 
@@ -197,7 +198,8 @@ where
         + TryInto<usize>
         + HasZero
         + SizeOf
-        + Sized,
+        + Sized
+        + 'static,
     <O as TryInto<usize>>::Error: Debug,
     <O as TryFrom<usize>>::Error: Debug,
 {

--- a/src/trace/layers/ordered/mod.rs
+++ b/src/trace/layers/ordered/mod.rs
@@ -12,7 +12,7 @@ use crate::{
         TupleBuilder,
     },
     utils::{assume, cast_uninit_vec},
-    NumEntries,
+    DBData, NumEntries,
 };
 use size_of::SizeOf;
 use std::{
@@ -273,7 +273,7 @@ where
 
 impl<K, L, O> Display for OrderedLayer<K, L, O>
 where
-    K: Ord + Clone + Display,
+    K: DBData,
     L: Trie,
     for<'a> L::Cursor<'a>: Clone + Display,
     O: OrdOffset,
@@ -640,7 +640,7 @@ where
 
 impl<'a, K, L, O> Display for OrderedCursor<'a, K, O, L>
 where
-    K: Ord + Clone + Display,
+    K: DBData,
     L: Trie,
     L::Cursor<'a>: Clone + Display,
     O: OrdOffset,
@@ -650,7 +650,7 @@ where
 
         while cursor.valid() {
             let key = cursor.key();
-            writeln!(f, "{}:", key)?;
+            writeln!(f, "{:?}:", key)?;
             let val_str = cursor.values().to_string();
 
             f.write_str(&indent(&val_str, "    "))?;

--- a/src/trace/layers/ordered_leaf.rs
+++ b/src/trace/layers/ordered_leaf.rs
@@ -5,8 +5,9 @@ use crate::{
     trace::{
         consolidation::consolidate_from,
         layers::{advance, Builder, Cursor, MergeBuilder, Trie, TupleBuilder},
+        MonoidValue,
     },
-    NumEntries,
+    DBData, NumEntries,
 };
 use size_of::SizeOf;
 use std::{
@@ -54,8 +55,8 @@ where
 
 impl<K, R> Display for OrderedLeaf<K, R>
 where
-    K: Ord + Clone + Display,
-    R: Eq + HasZero + AddAssign + AddAssignByRef + Clone + Display,
+    K: DBData,
+    R: DBData + MonoidValue,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         self.cursor().fmt(f)
@@ -65,8 +66,8 @@ where
 // TODO: by-value merge
 impl<K, R> Add<Self> for OrderedLeaf<K, R>
 where
-    K: Ord + Clone,
-    R: Eq + HasZero + AddAssign + AddAssignByRef + Clone,
+    K: DBData,
+    R: DBData + MonoidValue,
 {
     type Output = Self;
 
@@ -362,15 +363,15 @@ where
 
 impl<'a, K, R> Display for OrderedLeafCursor<'a, K, R>
 where
-    K: Ord + Clone + Display,
-    R: Eq + HasZero + AddAssignByRef + Clone + Display,
+    K: DBData,
+    R: DBData + MonoidValue,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         let mut cursor: OrderedLeafCursor<K, R> = self.clone();
 
         while cursor.valid() {
             let (key, val) = cursor.key();
-            writeln!(f, "{} -> {}", key, val)?;
+            writeln!(f, "{:?} -> {:?}", key, val)?;
             cursor.step();
         }
 

--- a/src/trace/layers/ordered_leaf.rs
+++ b/src/trace/layers/ordered_leaf.rs
@@ -5,9 +5,8 @@ use crate::{
     trace::{
         consolidation::consolidate_from,
         layers::{advance, Builder, Cursor, MergeBuilder, Trie, TupleBuilder},
-        MonoidValue,
     },
-    DBData, NumEntries,
+    DBData, DBWeight, NumEntries,
 };
 use size_of::SizeOf;
 use std::{
@@ -56,7 +55,7 @@ where
 impl<K, R> Display for OrderedLeaf<K, R>
 where
     K: DBData,
-    R: DBData + MonoidValue,
+    R: DBWeight,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         self.cursor().fmt(f)
@@ -67,7 +66,7 @@ where
 impl<K, R> Add<Self> for OrderedLeaf<K, R>
 where
     K: DBData,
-    R: DBData + MonoidValue,
+    R: DBWeight,
 {
     type Output = Self;
 
@@ -364,7 +363,7 @@ where
 impl<'a, K, R> Display for OrderedLeafCursor<'a, K, R>
 where
     K: DBData,
-    R: DBData + MonoidValue,
+    R: DBWeight,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         let mut cursor: OrderedLeafCursor<K, R> = self.clone();

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -19,22 +19,21 @@ pub mod spine_fueled;
 pub use cursor::{Consumer, Cursor, ValueConsumer};
 
 use crate::{
-    algebra::{HasZero, Lattice, MonoidValue},
+    algebra::{HasZero, MonoidValue},
     circuit::Activator,
     time::{AntichainRef, Timestamp},
 };
-use std::{
-    fmt::Debug,
-    hash::Hash
-};
 use size_of::SizeOf;
+use std::{fmt::Debug, hash::Hash};
 
 pub trait DBData: Clone + Eq + Ord + Hash + SizeOf + Send + Debug + 'static {}
-impl<T> DBData for T
-where
-    T: Clone + Eq + Ord + Hash + SizeOf + Send + Debug + 'static
-{
-}
+impl<T> DBData for T where T: Clone + Eq + Ord + Hash + SizeOf + Send + Debug + 'static {}
+
+pub trait DBWeight: DBData + MonoidValue {}
+impl<T> DBWeight for T where T: DBData + MonoidValue {}
+
+pub trait DBTimestamp: DBData + Timestamp {}
+impl<T> DBTimestamp for T where T: DBData + Timestamp {}
 
 /// An append-only collection of `(key, val, time, diff)` tuples.
 ///
@@ -124,9 +123,9 @@ where
     /// Values associated with keys.
     type Val: DBData;
     /// Timestamps associated with updates
-    type Time: DBData + Timestamp + Lattice;
+    type Time: DBTimestamp;
     /// Associated update.
-    type R: DBData + MonoidValue;
+    type R: DBWeight;
 
     /// The type used to enumerate the batch's contents.
     type Cursor<'s>: Cursor<'s, Self::Key, Self::Val, Self::Time, Self::R>

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -23,7 +23,18 @@ use crate::{
     circuit::Activator,
     time::{AntichainRef, Timestamp},
 };
+use std::{
+    fmt::Debug,
+    hash::Hash
+};
 use size_of::SizeOf;
+
+pub trait DBData: Clone + Eq + Ord + Hash + SizeOf + Send + Debug + 'static {}
+impl<T> DBData for T
+where
+    T: Clone + Eq + Ord + Hash + SizeOf + Send + Debug + 'static
+{
+}
 
 /// An append-only collection of `(key, val, time, diff)` tuples.
 ///
@@ -109,13 +120,13 @@ where
     Self: Sized,
 {
     /// Key by which updates are indexed.
-    type Key;
+    type Key: DBData;
     /// Values associated with keys.
-    type Val;
+    type Val: DBData;
     /// Timestamps associated with updates
-    type Time: Timestamp + Lattice;
+    type Time: DBData + Timestamp + Lattice;
     /// Associated update.
-    type R: MonoidValue;
+    type R: DBData + MonoidValue;
 
     /// The type used to enumerate the batch's contents.
     type Cursor<'s>: Cursor<'s, Self::Key, Self::Val, Self::Time, Self::R>

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -22,6 +22,7 @@ use crate::{
     algebra::{HasZero, MonoidValue},
     circuit::Activator,
     time::{AntichainRef, Timestamp},
+    NumEntries,
 };
 use size_of::SizeOf;
 use std::{fmt::Debug, hash::Hash};
@@ -114,7 +115,7 @@ pub trait Trace: BatchReader {
 /// useful for views derived from other sources in ways that prevent the
 /// construction of batches from the type of data in the view (for example,
 /// filtered views, or views with extended time coordinates).
-pub trait BatchReader
+pub trait BatchReader: NumEntries + SizeOf + 'static
 where
     Self: Sized,
 {

--- a/src/trace/ord/indexed_zset_batch.rs
+++ b/src/trace/ord/indexed_zset_batch.rs
@@ -1,5 +1,5 @@
 use crate::{
-    algebra::{AddAssignByRef, AddByRef, HasZero, MonoidValue, NegByRef},
+    algebra::{AddAssignByRef, AddByRef, MonoidValue, NegByRef},
     time::AntichainRef,
     trace::{
         layers::{
@@ -14,7 +14,7 @@ use crate::{
         ord::merge_batcher::MergeBatcher,
         Batch, BatchReader, Builder, Consumer, Cursor, Merger, ValueConsumer,
     },
-    DBData, NumEntries,
+    DBData, DBWeight, NumEntries,
 };
 use size_of::SizeOf;
 use std::{
@@ -42,9 +42,9 @@ where
 
 impl<K, V, R, O> Display for OrdIndexedZSet<K, V, R, O>
 where
-    K: Ord + Clone + Display,
-    V: Ord + Clone + Display + 'static,
-    R: Eq + HasZero + AddAssign + AddAssignByRef + Clone + Display + 'static,
+    K: DBData,
+    V: DBData,
+    R: DBWeight,
     O: OrdOffset,
     Layers<K, V, R, O>: Display,
 {
@@ -61,7 +61,7 @@ impl<K, V, R, O> Default for OrdIndexedZSet<K, V, R, O>
 where
     K: DBData,
     V: DBData,
-    R: DBData + MonoidValue,
+    R: DBWeight,
     O: OrdOffset,
 {
     #[inline]
@@ -98,9 +98,9 @@ where
 
 impl<K, V, R, O> NumEntries for OrdIndexedZSet<K, V, R, O>
 where
-    K: Clone + Ord,
-    V: Clone + Ord,
-    R: Eq + HasZero + AddAssign + AddAssignByRef + Clone,
+    K: DBData,
+    V: DBData,
+    R: DBWeight,
     O: OrdOffset,
 {
     const CONST_NUM_ENTRIES: Option<usize> = Layers::<K, V, R, O>::CONST_NUM_ENTRIES;
@@ -211,7 +211,7 @@ impl<K, V, R, O> BatchReader for OrdIndexedZSet<K, V, R, O>
 where
     K: DBData,
     V: DBData,
-    R: DBData + MonoidValue,
+    R: DBWeight,
     O: OrdOffset,
 {
     type Key = K;
@@ -263,7 +263,7 @@ impl<K, V, R, O> Batch for OrdIndexedZSet<K, V, R, O>
 where
     K: DBData,
     V: DBData,
-    R: DBData + MonoidValue,
+    R: DBWeight,
     O: OrdOffset,
 {
     type Item = (K, V);
@@ -306,7 +306,7 @@ pub struct OrdIndexedZSetMerger<K, V, R, O>
 where
     K: DBData,
     V: DBData,
-    R: DBData + MonoidValue,
+    R: DBWeight,
     O: OrdOffset,
 {
     // result that we are currently assembling.
@@ -319,7 +319,7 @@ where
     Self: SizeOf,
     K: DBData,
     V: DBData,
-    R: DBData + MonoidValue,
+    R: DBWeight,
     O: OrdOffset,
 {
     #[inline]
@@ -477,7 +477,7 @@ where
     Self: SizeOf,
     K: DBData,
     V: DBData,
-    R: DBData + MonoidValue,
+    R: DBWeight,
     O: OrdOffset,
 {
     #[inline]

--- a/src/trace/ord/indexed_zset_batch.rs
+++ b/src/trace/ord/indexed_zset_batch.rs
@@ -14,7 +14,7 @@ use crate::{
         ord::merge_batcher::MergeBatcher,
         Batch, BatchReader, Builder, Consumer, Cursor, Merger, ValueConsumer,
     },
-    NumEntries,
+    DBData, NumEntries,
 };
 use size_of::SizeOf;
 use std::{
@@ -59,9 +59,9 @@ where
 
 impl<K, V, R, O> Default for OrdIndexedZSet<K, V, R, O>
 where
-    K: Ord + Clone + SizeOf + 'static,
-    V: Ord + Clone + SizeOf,
-    R: MonoidValue + SizeOf,
+    K: DBData,
+    V: DBData,
+    R: DBData + MonoidValue,
     O: OrdOffset,
 {
     #[inline]
@@ -209,9 +209,9 @@ where
 
 impl<K, V, R, O> BatchReader for OrdIndexedZSet<K, V, R, O>
 where
-    K: Ord + Clone + 'static,
-    V: Ord + Clone,
-    R: MonoidValue,
+    K: DBData,
+    V: DBData,
+    R: DBData + MonoidValue,
     O: OrdOffset,
 {
     type Key = K;
@@ -261,9 +261,9 @@ where
 
 impl<K, V, R, O> Batch for OrdIndexedZSet<K, V, R, O>
 where
-    K: Ord + Clone + SizeOf + 'static,
-    V: Ord + Clone + SizeOf,
-    R: MonoidValue + SizeOf,
+    K: DBData,
+    V: DBData,
+    R: DBData + MonoidValue,
     O: OrdOffset,
 {
     type Item = (K, V);
@@ -304,9 +304,9 @@ where
 #[derive(SizeOf)]
 pub struct OrdIndexedZSetMerger<K, V, R, O>
 where
-    K: Ord + Clone + 'static,
-    V: Ord + Clone,
-    R: MonoidValue,
+    K: DBData,
+    V: DBData,
+    R: DBData + MonoidValue,
     O: OrdOffset,
 {
     // result that we are currently assembling.
@@ -317,9 +317,9 @@ impl<K, V, R, O> Merger<K, V, (), R, OrdIndexedZSet<K, V, R, O>>
     for OrdIndexedZSetMerger<K, V, R, O>
 where
     Self: SizeOf,
-    K: Ord + Clone + SizeOf + 'static,
-    V: Ord + Clone + SizeOf,
-    R: MonoidValue + SizeOf,
+    K: DBData,
+    V: DBData,
+    R: DBData + MonoidValue,
     O: OrdOffset,
 {
     #[inline]
@@ -475,9 +475,9 @@ impl<K, V, R, O> Builder<(K, V), (), R, OrdIndexedZSet<K, V, R, O>>
     for OrdIndexedZSetBuilder<K, V, R, O>
 where
     Self: SizeOf,
-    K: Ord + Clone + SizeOf + 'static,
-    V: Ord + Clone + SizeOf,
-    R: MonoidValue + SizeOf,
+    K: DBData,
+    V: DBData,
+    R: DBData + MonoidValue,
     O: OrdOffset,
 {
     #[inline]

--- a/src/trace/ord/key_batch.rs
+++ b/src/trace/ord/key_batch.rs
@@ -14,7 +14,7 @@ use crate::{
         ord::merge_batcher::MergeBatcher,
         Batch, BatchReader, Builder, Consumer, Cursor, Merger, ValueConsumer,
     },
-    Timestamp,
+    DBData, Timestamp,
 };
 use size_of::SizeOf;
 use std::{fmt::Debug, marker::PhantomData};
@@ -33,9 +33,9 @@ pub struct OrdKeyBatch<K, T, R, O = usize> {
 
 impl<K, T, R, O> BatchReader for OrdKeyBatch<K, T, R, O>
 where
-    K: Ord + Clone + 'static,
-    T: Timestamp + Lattice,
-    R: MonoidValue,
+    K: DBData,
+    T: DBData + Timestamp,
+    R: DBData + MonoidValue,
     O: OrdOffset,
 {
     type Key = K;
@@ -75,9 +75,9 @@ where
 
 impl<K, T, R, O> Batch for OrdKeyBatch<K, T, R, O>
 where
-    K: Ord + Clone + SizeOf + 'static,
-    T: Lattice + Timestamp + Ord + Clone + SizeOf + 'static,
-    R: MonoidValue + SizeOf,
+    K: DBData,
+    T: DBData + Timestamp,
+    R: DBData + MonoidValue,
     O: OrdOffset,
 {
     type Item = K;
@@ -199,9 +199,9 @@ where
 impl<K, T, R, O> Merger<K, (), T, R, OrdKeyBatch<K, T, R, O>> for OrdKeyMerger<K, T, R, O>
 where
     Self: SizeOf,
-    K: Ord + Clone + SizeOf + 'static,
-    T: Lattice + Timestamp + Ord + Clone + SizeOf + 'static,
-    R: MonoidValue + SizeOf,
+    K: DBData,
+    T: DBData + Timestamp,
+    R: DBData + MonoidValue,
     O: OrdOffset,
 {
     fn new_merger(batch1: &OrdKeyBatch<K, T, R, O>, batch2: &OrdKeyBatch<K, T, R, O>) -> Self {
@@ -419,9 +419,9 @@ where
 impl<K, T, R, O> Builder<K, T, R, OrdKeyBatch<K, T, R, O>> for OrdKeyBuilder<K, T, R, O>
 where
     Self: SizeOf,
-    K: Ord + Clone + SizeOf + 'static,
-    T: Lattice + Timestamp + Ord + Clone + SizeOf + 'static,
-    R: MonoidValue + SizeOf,
+    K: DBData,
+    T: DBData + Timestamp,
+    R: DBData + MonoidValue,
     O: OrdOffset,
 {
     #[inline]

--- a/src/trace/ord/merge_batcher/mod.rs
+++ b/src/trace/ord/merge_batcher/mod.rs
@@ -1,10 +1,10 @@
 //! A general purpose `Batcher` implementation based on radix sort.
 
 use crate::{
-    algebra::{Lattice, MonoidValue},
+    algebra::MonoidValue,
     trace::{consolidation, Batch, Batcher, Builder},
     utils::VecExt,
-    Timestamp,
+    DBTimestamp,
 };
 use size_of::SizeOf;
 use std::{
@@ -29,7 +29,7 @@ impl<I, T, R, B> Batcher<I, T, R, B> for MergeBatcher<I, T, R, B>
 where
     Self: SizeOf,
     I: Ord + Clone,
-    T: Lattice + Timestamp + Ord + Clone,
+    T: DBTimestamp,
     R: MonoidValue,
     B: Batch<Item = I, Time = T, R = R>,
 {

--- a/src/trace/ord/val_batch.rs
+++ b/src/trace/ord/val_batch.rs
@@ -65,7 +65,7 @@ where
     V: DBData,
     T: DBTimestamp,
     R: DBWeight,
-    O: OrdOffset + 'static,
+    O: OrdOffset,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         writeln!(

--- a/src/trace/ord/val_batch.rs
+++ b/src/trace/ord/val_batch.rs
@@ -11,7 +11,7 @@ use crate::{
         ord::merge_batcher::MergeBatcher,
         Batch, BatchReader, Builder, Consumer, Cursor, Merger, ValueConsumer,
     },
-    DBData, Timestamp,
+    DBData, DBTimestamp, DBWeight, NumEntries,
 };
 use size_of::SizeOf;
 use std::{
@@ -38,12 +38,33 @@ where
     pub upper: Antichain<T>,
 }
 
+impl<K, V, T, R, O> NumEntries for OrdValBatch<K, V, T, R, O>
+where
+    K: DBData,
+    V: DBData,
+    T: DBTimestamp,
+    R: DBWeight,
+    O: OrdOffset,
+{
+    const CONST_NUM_ENTRIES: Option<usize> = <OrdValBatchLayer<K, V, R, R, O>>::CONST_NUM_ENTRIES;
+
+    #[inline]
+    fn num_entries_shallow(&self) -> usize {
+        self.layer.num_entries_shallow()
+    }
+
+    #[inline]
+    fn num_entries_deep(&self) -> usize {
+        self.layer.num_entries_deep()
+    }
+}
+
 impl<K, V, T, R, O> Display for OrdValBatch<K, V, T, R, O>
 where
     K: DBData,
     V: DBData,
-    T: DBData + Timestamp,
-    R: DBData + MonoidValue,
+    T: DBTimestamp,
+    R: DBWeight,
     O: OrdOffset + 'static,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
@@ -61,8 +82,8 @@ impl<K, V, T, R, O> BatchReader for OrdValBatch<K, V, T, R, O>
 where
     K: DBData,
     V: DBData,
-    T: DBData + Timestamp,
-    R: DBData + MonoidValue,
+    T: DBTimestamp,
+    R: DBWeight,
     O: OrdOffset,
 {
     type Key = K;
@@ -107,8 +128,8 @@ impl<K, V, T, R, O> Batch for OrdValBatch<K, V, T, R, O>
 where
     K: DBData,
     V: DBData,
-    T: DBData + Timestamp,
-    R: DBData + MonoidValue,
+    T: DBTimestamp,
+    R: DBWeight,
     O: OrdOffset,
 {
     type Item = (K, V);
@@ -270,8 +291,8 @@ where
     Self: SizeOf,
     K: DBData,
     V: DBData,
-    T: DBData + Timestamp,
-    R: DBData + MonoidValue,
+    T: DBTimestamp,
+    R: DBWeight,
     O: OrdOffset,
 {
     fn new_merger(
@@ -479,8 +500,8 @@ where
     Self: SizeOf,
     K: DBData,
     V: DBData,
-    T: DBData + Timestamp,
-    R: DBData + MonoidValue,
+    T: DBTimestamp,
+    R: DBWeight,
     O: OrdOffset,
 {
     #[inline]

--- a/src/trace/ord/val_batch.rs
+++ b/src/trace/ord/val_batch.rs
@@ -1,5 +1,5 @@
 use crate::{
-    algebra::{AddAssignByRef, HasZero, Lattice, MonoidValue},
+    algebra::{Lattice, MonoidValue},
     time::{Antichain, AntichainRef},
     trace::{
         layers::{
@@ -11,13 +11,12 @@ use crate::{
         ord::merge_batcher::MergeBatcher,
         Batch, BatchReader, Builder, Consumer, Cursor, Merger, ValueConsumer,
     },
-    Timestamp,
+    DBData, Timestamp,
 };
 use size_of::SizeOf;
 use std::{
     fmt::{Debug, Display, Formatter},
     marker::PhantomData,
-    ops::AddAssign,
 };
 
 pub type OrdValBatchLayer<K, V, T, R, O> =
@@ -41,10 +40,10 @@ where
 
 impl<K, V, T, R, O> Display for OrdValBatch<K, V, T, R, O>
 where
-    K: Ord + Clone + Display,
-    V: Ord + Clone + Display + 'static,
-    T: Lattice + Clone + Ord + Display + Debug + 'static,
-    R: Eq + HasZero + AddAssign + AddAssignByRef + Clone + Display + 'static,
+    K: DBData,
+    V: DBData,
+    T: DBData + Timestamp,
+    R: DBData + MonoidValue,
     O: OrdOffset + 'static,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
@@ -60,10 +59,10 @@ where
 
 impl<K, V, T, R, O> BatchReader for OrdValBatch<K, V, T, R, O>
 where
-    K: Ord + Clone + 'static,
-    V: Ord + Clone + 'static,
-    T: Timestamp + Lattice,
-    R: MonoidValue,
+    K: DBData,
+    V: DBData,
+    T: DBData + Timestamp,
+    R: DBData + MonoidValue,
     O: OrdOffset,
 {
     type Key = K;
@@ -106,10 +105,10 @@ where
 
 impl<K, V, T, R, O> Batch for OrdValBatch<K, V, T, R, O>
 where
-    K: Ord + Clone + SizeOf + 'static,
-    V: Ord + Clone + SizeOf + 'static,
-    T: Lattice + Timestamp + Ord + Clone + SizeOf + 'static,
-    R: MonoidValue + SizeOf,
+    K: DBData,
+    V: DBData,
+    T: DBData + Timestamp,
+    R: DBData + MonoidValue,
     O: OrdOffset,
 {
     type Item = (K, V);
@@ -269,10 +268,10 @@ where
 impl<K, V, T, R, O> Merger<K, V, T, R, OrdValBatch<K, V, T, R, O>> for OrdValMerger<K, V, T, R, O>
 where
     Self: SizeOf,
-    K: Ord + Clone + SizeOf + 'static,
-    V: Ord + Clone + SizeOf + 'static,
-    T: Lattice + Timestamp + SizeOf + Ord + Clone + 'static,
-    R: MonoidValue + SizeOf,
+    K: DBData,
+    V: DBData,
+    T: DBData + Timestamp,
+    R: DBData + MonoidValue,
     O: OrdOffset,
 {
     fn new_merger(
@@ -478,10 +477,10 @@ impl<K, V, T, R, O> Builder<(K, V), T, R, OrdValBatch<K, V, T, R, O>>
     for OrdValBuilder<K, V, T, R, O>
 where
     Self: SizeOf,
-    K: Ord + Clone + SizeOf + 'static,
-    V: Ord + Clone + SizeOf + 'static,
-    T: Lattice + Timestamp + Ord + Clone + SizeOf + 'static,
-    R: MonoidValue + SizeOf,
+    K: DBData,
+    V: DBData,
+    T: DBData + Timestamp,
+    R: DBData + MonoidValue,
     O: OrdOffset,
 {
     #[inline]

--- a/src/trace/ord/zset_batch.rs
+++ b/src/trace/ord/zset_batch.rs
@@ -12,7 +12,7 @@ use crate::{
         ord::merge_batcher::MergeBatcher,
         Batch, BatchReader, Builder, Consumer, Cursor, Merger, ValueConsumer,
     },
-    DBData, NumEntries,
+    DBData, DBWeight, NumEntries,
 };
 use size_of::SizeOf;
 use std::{
@@ -32,7 +32,7 @@ pub struct OrdZSet<K, R> {
 impl<K, R> Display for OrdZSet<K, R>
 where
     K: DBData,
-    R: DBData + MonoidValue,
+    R: DBWeight,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(
@@ -58,7 +58,7 @@ impl<K, R> From<OrderedColumnLeaf<K, R>> for Rc<OrdZSet<K, R>> {
 impl<K, R> NumEntries for OrdZSet<K, R>
 where
     K: DBData,
-    R: DBData + MonoidValue,
+    R: DBWeight,
 {
     const CONST_NUM_ENTRIES: Option<usize> = <OrderedColumnLeaf<K, R>>::CONST_NUM_ENTRIES;
 
@@ -155,7 +155,7 @@ where
 impl<K, R> BatchReader for OrdZSet<K, R>
 where
     K: DBData,
-    R: DBData + MonoidValue,
+    R: DBWeight,
 {
     type Key = K;
     type Val = ();
@@ -203,7 +203,7 @@ where
 impl<K, R> Batch for OrdZSet<K, R>
 where
     K: DBData,
-    R: DBData + MonoidValue,
+    R: DBWeight,
 {
     type Item = K;
     type Batcher = MergeBatcher<K, (), R, Self>;
@@ -236,7 +236,7 @@ where
 pub struct OrdZSetMerger<K, R>
 where
     K: DBData,
-    R: MonoidValue,
+    R: DBWeight,
 {
     // result that we are currently assembling.
     result: <OrderedColumnLeaf<K, R> as Trie>::MergeBuilder,
@@ -246,7 +246,7 @@ impl<K, R> Merger<K, (), (), R, OrdZSet<K, R>> for OrdZSetMerger<K, R>
 where
     Self: SizeOf,
     K: DBData,
-    R: DBData + MonoidValue,
+    R: DBWeight,
 {
     fn new_merger(batch1: &OrdZSet<K, R>, batch2: &OrdZSet<K, R>) -> Self {
         Self {
@@ -277,7 +277,7 @@ where
 pub struct OrdZSetCursor<'s, K, R>
 where
     K: DBData,
-    R: MonoidValue,
+    R: DBWeight,
 {
     valid: bool,
     cursor: ColumnLeafCursor<'s, K, R>,
@@ -286,7 +286,7 @@ where
 impl<'s, K, R> Cursor<'s, K, (), (), R> for OrdZSetCursor<'s, K, R>
 where
     K: DBData,
-    R: MonoidValue,
+    R: DBWeight,
 {
     #[inline]
     fn key(&self) -> &K {
@@ -378,7 +378,7 @@ where
 pub struct OrdZSetBuilder<K, R>
 where
     K: Ord,
-    R: MonoidValue,
+    R: DBWeight,
 {
     builder: OrderedColumnLeafBuilder<K, R>,
 }
@@ -387,7 +387,7 @@ impl<K, R> Builder<K, (), R, OrdZSet<K, R>> for OrdZSetBuilder<K, R>
 where
     Self: SizeOf,
     K: DBData,
-    R: DBData + MonoidValue,
+    R: DBWeight,
 {
     #[inline]
     fn new_builder(_time: ()) -> Self {

--- a/src/trace/spine_fueled.rs
+++ b/src/trace/spine_fueled.rs
@@ -119,7 +119,7 @@ where
 
 impl<B> Display for Spine<B>
 where
-    B: Batch + Display + 'static,
+    B: Batch + Display,
     B::Key: Ord,
     B::Val: Ord,
 {
@@ -148,7 +148,7 @@ where
 
 impl<B> NumEntries for Spine<B>
 where
-    B: Batch + SizeOf + 'static,
+    B: Batch,
     B::Key: Ord,
     B::Val: Ord,
 {
@@ -167,7 +167,7 @@ where
 
 impl<B> BatchReader for Spine<B>
 where
-    B: Batch + 'static,
+    B: Batch,
     B::Key: Ord,
     B::Val: Ord,
 {
@@ -240,7 +240,7 @@ where
 
 impl<B> Spine<B>
 where
-    B: Batch + 'static,
+    B: Batch,
 {
     fn map_batches<F: FnMut(&B)>(&self, mut f: F) {
         for batch in self.merging.iter().rev() {
@@ -419,7 +419,7 @@ where
 
 impl<B> Default for Spine<B>
 where
-    B: Batch + Clone + 'static,
+    B: Batch,
     B::Key: Ord,
     B::Val: Ord,
 {
@@ -430,7 +430,7 @@ where
 
 impl<B> Trace for Spine<B>
 where
-    B: Batch + 'static,
+    B: Batch,
     B::Key: Ord,
     B::Val: Ord,
 {
@@ -541,7 +541,7 @@ where
 
 impl<B> Spine<B>
 where
-    B: Batch + 'static,
+    B: Batch,
     B::Key: Ord,
     B::Val: Ord,
 {


### PR DESCRIPTION
Introduce trait bounds that capture common features of relational data:
 
`DBData` - trait bound on `BatchReader::Key`, `BatchReader::Val`
`DBWeight: DBData + MonoidValue` - trait bound on `BatchReader::R`
`DBTime: DBData + Timestamp` - trait bound on `BatchReader::Time`

This simplifies trait bounds throughput the code base thanks to: (1) implied bounds, (2) shorted bounds when type inference doesn't apply.

This also simplifies future refactoring as we adjust the bounds, e.g., to support persistence.

@gz: It should now be sufficient to add `encode/decode` bounds to `DBData`.