### PR TITLE
Reversed polarity in `seek_val_with`.

### DIFF
--- a/src/operator/time_series/partitioned.rs
+++ b/src/operator/time_series/partitioned.rs
@@ -100,7 +100,7 @@ where
     }
 
     fn seek_key(&mut self, key: &K) {
-        self.cursor.seek_val_with(|(k, _)| k < key);
+        self.cursor.seek_val_with(|(k, _)| k >= key);
         if self.cursor.val_valid() {
             self.key = self.cursor.val().0.clone();
         }

--- a/src/trace/ord/indexed_zset_batch.rs
+++ b/src/trace/ord/indexed_zset_batch.rs
@@ -443,7 +443,7 @@ where
     where
         P: Fn(&V) -> bool + Clone,
     {
-        self.cursor.child.seek_key_with(predicate);
+        self.cursor.child.seek_key_with(|v| !predicate(v));
     }
 
     #[inline]

--- a/src/trace/ord/val_batch.rs
+++ b/src/trace/ord/val_batch.rs
@@ -447,7 +447,7 @@ where
     where
         P: Fn(&V) -> bool + Clone,
     {
-        self.cursor.child.seek_with(predicate);
+        self.cursor.child.seek_with(|v| !predicate(v));
     }
     fn rewind_keys(&mut self) {
         self.cursor.rewind();


### PR DESCRIPTION
I used the seek_val_with API incorrectly, providing predicate with the wrong polariy, in `partitioned.rs`.  This did not cause test failures because the implementation used similarly inverted polarity.

Thanks, @gz, for finding the bug.