### PR TITLE
require serde for floats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,6 +1386,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "129d36517b53c461acc6e1580aeb919c8ae6708a4b1eae61c4463a615d4f0411"
 dependencies = [
  "num-traits",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ serde = { version = "1.0", optional = true }
 impl-trait-for-tuples = "0.2"
 textwrap = "0.15.0"
 fxhash = "0.2"
-ordered-float = "3.0.0"
+ordered-float = { version = "3.0.0", features = ["serde"] }
 arcstr = { version = "1.1.4", optional = true }
 rust_decimal = { version = "1.26.1", optional = true }
 regex = { version = "1.6.0", optional = true }

--- a/src/algebra/floats.rs
+++ b/src/algebra/floats.rs
@@ -1,5 +1,6 @@
 use crate::algebra::{HasOne, HasZero};
 use ordered_float::OrderedFloat;
+use serde::{Deserialize, Serialize};
 use size_of::SizeOf;
 use std::{
     fmt::{self, Debug, Display},
@@ -11,7 +12,7 @@ macro_rules! float {
     ($($outer:ident($inner:ident)),* $(,)?) => {
         $(
             #[doc = concat!("A wrapper around [`", stringify!($inner), "`] that allows using it as a DBSP weight")]
-            #[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, SizeOf)]
+            #[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, SizeOf, Serialize, Deserialize)]
             #[repr(transparent)]
             #[size_of(skip_all)]
             pub struct $outer(OrderedFloat<$inner>);


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>

This change allows dbsp to run all tests fine.
However, clippy is unhappy:
```
Checking Rust rules prior to push.  To run this check by hand invoke 'tools/pre-push'
+ cargo fmt -- --check
+ cargo clippy -- -D warnings
    Checking dbsp v0.1.0 (/home/mbudiu/git/database-stream-processor)
error: cannot find derive macro `Serialize` in this scope
   --> src/algebra/floats.rs:15:90
    |
15  |               #[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, SizeOf, Serialize, Deserialize)]
    |                                                                                            ^^^^^^^^^
...
383 | / float! {
384 | |     F32(f32),
385 | |     F64(f64),
386 | | }
    | |_- in this macro invocation
    |
note: `Serialize` is imported here, but it is only a trait, without a derive macro
   --> src/algebra/floats.rs:3:26
    |
3   | use serde::{Deserialize, Serialize};
    |                          ^^^^^^^^^
    = note: this error originates in the macro `float` (in Nightly builds, run with -Z macro-backtrace for more info)
```

I would appreciate help fixing this problem.
The SQL layer will need support for float serde.