### PR TITLE
Rudimentary, but easy-to-use profiler.

### DIFF
--- a/benches/nexmark/run_queries.rs
+++ b/benches/nexmark/run_queries.rs
@@ -15,7 +15,7 @@ macro_rules! run_queries {
         // so. The DBSP processing happens in its own thread where the resource usage
         // calculation can also happen.
         let (dbsp_step_tx, dbsp_step_rx) = mpsc::sync_channel(1);
-        let dbsp_join_handle = spawn_dbsp_consumer(dbsp, dbsp_step_rx, step_done_tx.clone());
+        let dbsp_join_handle = spawn_dbsp_consumer(stringify!($query), $nexmark_config.profile_path.as_deref(), dbsp, dbsp_step_rx, step_done_tx.clone());
 
         // Start the generator inputting the specified number of batches to the circuit
         // whenever it receives a message.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,34 @@
 use crate::{RuntimeError, SchedulerError};
+use std::io::Error as IOError;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug)]
 pub enum Error {
     Scheduler(SchedulerError),
     Runtime(RuntimeError),
+    IO(IOError),
     Custom(String),
+}
+
+impl From<IOError> for Error {
+    fn from(error: IOError) -> Self {
+        Self::IO(error)
+    }
+}
+
+impl From<SchedulerError> for Error {
+    fn from(error: SchedulerError) -> Self {
+        Self::Scheduler(error)
+    }
+}
+
+impl From<RuntimeError> for Error {
+    fn from(error: RuntimeError) -> Self {
+        Self::Runtime(error)
+    }
+}
+
+impl From<String> for Error {
+    fn from(error: String) -> Self {
+        Self::Custom(error)
+    }
 }

--- a/src/nexmark/config.rs
+++ b/src/nexmark/config.rs
@@ -91,6 +91,10 @@ pub struct Config {
     #[clap(long, default_value = "1", env = "NEXMARK_PERSON_PROPORTION")]
     pub person_proportion: usize,
 
+    /// Dump DBSP profiles for all executed queries to the specified directory.
+    #[clap(long, env = "NEXMARK_PROFILE_PATH")]
+    pub profile_path: Option<String>,
+
     /// Queries to run, all by default.
     #[clap(long, env = "NEXMARK_QUERIES", value_enum)]
     pub query: Vec<Query>,
@@ -133,6 +137,7 @@ impl Default for Config {
             num_in_flight_auctions: 100,
             out_of_order_group_size: 1,
             person_proportion: 1,
+            profile_path: None,
             query: Vec::new(),
             source_buffer_size: 10_000,
             input_batch_size: 40_000,

--- a/src/nexmark/queries/q16.rs
+++ b/src/nexmark/queries/q16.rs
@@ -793,9 +793,11 @@ mod tests {
         })
         .unwrap();
 
+        dbsp.enable_cpu_profiler().unwrap();
         for mut vec in input_vecs {
             input_handle.append(&mut vec);
             dbsp.step().unwrap();
         }
+        dbsp.dump_profile(std::env::temp_dir().join("q16")).unwrap();
     }
 }

--- a/src/profile/mod.rs
+++ b/src/profile/mod.rs
@@ -1,4 +1,95 @@
 //! Built-in profiling capabilities.
 
+use crate::{
+    circuit::{
+        circuit_builder::Node,
+        metadata::{MetaItem, OperatorMeta},
+        GlobalNodeId,
+    },
+    monitor::TraceMonitor,
+    Circuit,
+};
+use std::{borrow::Cow, collections::HashMap, fmt::Write};
+
 mod cpu;
 pub use cpu::CPUProfiler;
+
+/// Rudimentary circuit profiler.
+///
+/// Records circuit topology, operator metadata, and optionally CPU usage, and
+/// dumps them in graphviz (dot) format.
+pub struct Profiler {
+    cpu_profiler: CPUProfiler,
+    monitor: TraceMonitor,
+    circuit: Circuit<()>,
+}
+
+impl Profiler {
+    /// Create profiler; attach it to `circuit`.
+    ///
+    /// Profiler is created with CPU profiling disabled.
+    pub fn new(circuit: &Circuit<()>) -> Self {
+        let cpu_profiler = CPUProfiler::new();
+
+        let monitor = TraceMonitor::new_panic_on_error();
+        monitor.attach_circuit_events(circuit, "monitor");
+
+        Self {
+            cpu_profiler,
+            monitor,
+            circuit: circuit.clone(),
+        }
+    }
+
+    /// Enable CPU profiling.
+    pub fn enable_cpu_profiler(&self) {
+        self.cpu_profiler.attach(&self.circuit, "cpu_profiler");
+    }
+
+    /// Dump profile in graphviz format.
+    pub fn dump_profile(&self) -> String {
+        let mut metadata = HashMap::<GlobalNodeId, OperatorMeta>::new();
+
+        // Collect node metadata.
+        self.circuit.map_nodes_recursive(&mut |node: &dyn Node| {
+            let mut meta = OperatorMeta::new();
+            node.metadata(&mut meta);
+            metadata.insert(node.global_id().clone(), meta);
+        });
+
+        // Add CPU profiling info.
+        for (node_id, meta) in metadata.iter_mut() {
+            if let Some(profile) = self.cpu_profiler.operator_profile(node_id) {
+                let default_meta = [
+                    (
+                        Cow::Borrowed("invocations"),
+                        MetaItem::Int(profile.invocations()),
+                    ),
+                    (
+                        Cow::Borrowed("time"),
+                        MetaItem::Duration(profile.total_time()),
+                    ),
+                ];
+
+                for item in default_meta {
+                    meta.insert(0, item);
+                }
+            }
+        }
+
+        let graph = self.monitor.visualize_circuit_annotate(|node_id| {
+            let mut output = String::with_capacity(1024);
+            let meta = metadata.get(node_id).cloned().unwrap_or_default();
+
+            for (label, item) in meta.iter() {
+                write!(output, "{label}: ").unwrap();
+                item.format(&mut output).unwrap();
+                output.push_str("\\l");
+            }
+
+            output
+        });
+
+        graph.to_dot()
+    }
+}


### PR DESCRIPTION
Simple profiler that doesn't require pasting a ton of code in each benchmark.  See commit message for details.

Pros:
- Easy to use: Enable profiling with a single API call (`DBSPHandle::enable_cpu_profiler`), dump profiles across all workers with another call (`DBSPHandle::dump_profile`)
- Low profiling overhead (doesn't interpose on each operator invocation)

Cons:
- Doesn't support dumping profiles after individual iterations of a nested circuit.
- Still uses graphviz for visualization.

@gz, this may help with your performance debugging.