### PR TITLE
Update contribution guidelines.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ This is a rough outline of what a contributor's workflow looks like:
 - Create a topic branch from where you want to base your work
 - Make commits of logical units
 - Make sure your commit messages are in the proper format (see below)
-- Push your changes to a topic branch in your fork of the repository
+- Push your changes to a topic branch in the vmware repository or a fork if you don't have commit access to vmware (the reason that pushing directly to the vmware repo is preferred is because then CI will be able to add benchmark results to the PR in the comments).
 - Submit a pull request
 
 Example:
@@ -60,6 +60,19 @@ git push --force-with-lease origin my-new-feature
 
 Be sure to add a comment to the PR indicating your new changes are ready to review, as GitHub does not generate a
 notification when you git push.
+
+### Closing a pull request
+
+Since we run benchmarks as part of CI it's good practice to preserve the commit IDs of the feature branch 
+we've worked on (and benchmarked). Unfortunately, [the github UI does not have support for this](https://github.com/community/community/discussions/4618) 
+(it only allows rebase, squash and merge commits to close PRs).
+Therefore, it's recommended to close and merge PRs using the following git CLI invocation:
+
+```shell
+git checkout main
+git merge --ff-only feature-branch-name
+git push vmware main
+```
 
 ### Code Style
 

--- a/scripts/ci.bash
+++ b/scripts/ci.bash
@@ -67,8 +67,8 @@ pip3 install -r gh-pages/requirements.txt
 
 # If you change this, adjust the command also in the append_csv function in utils.py:
 DATE_PREFIX=`date +"%Y-%m-%d-%H-%M"`
-if [ ! -v PR_COMMIT_SHA ]; then
-    # So we can run the script in non-runner environments:
+if [ -z "${PR_COMMIT_SHA}" ]; then
+    # So we can run the script in non-runner environments and not pull request events
     PR_COMMIT_SHA=`git rev-parse HEAD`
 fi
 


### PR DESCRIPTION
This clarifies some workflow changes to ensure that the benchmark framework is effective.
- fast-forward merging so we don't lose the mapping of commit ids to results
- use feature branches on vmware so we get comments for benchmark regressions