### PR TITLE
Go back to stable Rust.

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           default: true
 
       - name: Restore cache

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           components: llvm-tools-preview
           override: true
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,32 +38,31 @@ jobs:
 
       matrix:
         # We test the following targets:
-        # - 64bit Linux nightly
+        # - 64bit Linux stable
         # - 64bit Linux beta
         # - 64bit Linux nightly
-        # - 64bit MacOS nightly
-        # - 64bit Windows nightly
-        # - 32bit Windows nightly
+        # - 64bit MacOS stable
+        # - 64bit Windows stable
+        # - 32bit Windows stable
         include:
           - {
-              rust: nightly,
+              rust: stable,
               target: x86_64-unknown-linux-gnu,
               os: [self-hosted, Linux, skylake-2x],
             }
-          - { rust: nightly, target: x86_64-apple-darwin, os: macos-latest }
+          - { rust: stable, target: x86_64-apple-darwin, os: macos-latest }
           - {
-              rust: nightly,
+              rust: stable,
               target: x86_64-pc-windows-msvc,
               os: windows-latest,
             }
-          - { rust: nightly, target: i686-pc-windows-msvc, os: windows-latest }
-            # TODO: uncomment when we're back to stable Rust.
-            #- { rust: beta, target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
-            #- {
-            #  rust: nightly,
-            #  target: x86_64-unknown-linux-gnu,
-            #  os: ubuntu-latest,
-            #}
+          - { rust: stable, target: i686-pc-windows-msvc, os: windows-latest }
+          - { rust: beta, target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
+          - {
+              rust: nightly,
+              target: x86_64-unknown-linux-gnu,
+              os: ubuntu-latest,
+            }
 
     steps:
       - name: Checkout
@@ -234,6 +233,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
+          # Run nightly clippy, which often finds additional issues.
           toolchain: nightly
           components: clippy
           default: true
@@ -261,6 +261,8 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
+          # We use unstable rustfmt features: `wrap_comments` and
+          # `format_code_in_doc_comments`.
           toolchain: nightly
           components: rustfmt
           default: true
@@ -285,7 +287,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           default: true
 
       - name: Restore cache

--- a/adapters/src/controller/mod.rs
+++ b/adapters/src/controller/mod.rs
@@ -442,7 +442,7 @@ impl ControllerInner {
         let parser = format.new_parser(&endpoint_config.format.config, &self.catalog)?;
 
         // Create probe.
-        let endpoint_id = inputs.last_key_value().map(|(k, _)| k + 1).unwrap_or(0);
+        let endpoint_id = inputs.iter().rev().next().map(|(k, _)| k + 1).unwrap_or(0);
         let probe = Box::new(InputProbe::new(
             endpoint_id,
             endpoint_name,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"

--- a/tools/pre-push
+++ b/tools/pre-push
@@ -7,7 +7,8 @@ echo "Checking Rust rules prior to push.  To run this check by hand invoke 'tool
 
 set -ex
 
-cargo fmt --all -- --check
+# We use unstable `rustfmt` features: `wrap_comments` and `format_code_in_doc_comments`
+RUSTUP_TOOLCHAIN=nightly cargo fmt --all -- --check
 cargo clippy --workspace -- -D warnings
 
 RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace


### PR DESCRIPTION
The Generic Associated Types (GAT) feature of Rust is now stable since 1.65, so we no longer need to rely on nightly Rust.