### PR TITLE
Kafka input adapter

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,10 +42,12 @@ jobs:
       - name: Restore cache
         uses: Swatinem/rust-cache@v1
 
-      - name: Start redpanda
-        uses: redpanda-data/github-action@v0.1.3
-        with:
-          version: "latest"
+      - name: Install redpanda
+        if: runner.os == 'Linux'
+        run: |
+          curl -1sLf 'https://dl.redpanda.com/nzc4ZYQK3WRGd9sy/redpanda/cfg/setup/bash.deb.sh' | sudo -E bash && \
+          sudo apt install redpanda -y && \
+          sudo systemctl start redpanda
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,6 +42,11 @@ jobs:
       - name: Restore cache
         uses: Swatinem/rust-cache@v1
 
+      - name: Start redpanda
+        uses: redpanda-data/github-action@v0.1.3
+        with:
+          version: "latest"
+
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,6 @@ jobs:
         # - 64bit Linux nightly
         # - 64bit MacOS stable
         # - 64bit Windows stable
-        # - 32bit Windows stable
         include:
           - {
               rust: stable,
@@ -62,7 +61,8 @@ jobs:
               os: windows-latest,
               test_flags: --skip kafka
             }
-          - { rust: stable, target: i686-pc-windows-msvc, os: windows-latest }
+          # `rdkafka` doesn't compile on 32-bit Windows.
+          # - { rust: stable, target: i686-pc-windows-msvc, os: windows-latest }
           - { rust: beta, target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
           - {
               rust: nightly-2022-11-10,

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       max-parallel: 4
 
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,11 +50,17 @@ jobs:
               target: x86_64-unknown-linux-gnu,
               os: [self-hosted, Linux, skylake-2x],
             }
-          - { rust: stable, target: x86_64-apple-darwin, os: macos-latest }
+          - {
+              rust: stable,
+              target: x86_64-apple-darwin,
+              os: macos-latest,
+              test_flags: --skip kafka
+            }
           - {
               rust: stable,
               target: x86_64-pc-windows-msvc,
               os: windows-latest,
+              test_flags: --skip kafka
             }
           - { rust: stable, target: i686-pc-windows-msvc, os: windows-latest }
           - { rust: beta, target: x86_64-unknown-linux-gnu, os: ubuntu-latest }
@@ -81,6 +87,12 @@ jobs:
         # Don't cache on Windows due to low disk space
         if: runner.os != 'Windows'
 
+      - name: Start redpanda
+        if: runner.os == 'Linux'
+        uses: redpanda-data/github-action@v0.1.3
+        with:
+          version: "latest"
+
       # We split building the tests into a separate step
       # so that we can easily distinguish between build
       # errors and failing tests
@@ -100,7 +112,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace ${{ env.ALMOST_ALL_FEATURES }} --target ${{ matrix.target }}
+          args: --workspace ${{ env.ALMOST_ALL_FEATURES }} --target ${{ matrix.target }} -- ${{ matrix.test_flags }}
 
   #   miri:
   #     name: Miri

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,11 +87,12 @@ jobs:
         # Don't cache on Windows due to low disk space
         if: runner.os != 'Windows'
 
-      - name: Start redpanda
+      - name: Install redpanda
         if: runner.os == 'Linux'
-        uses: redpanda-data/github-action@v0.1.3
-        with:
-          version: "latest"
+        run: |
+          curl -1sLf 'https://dl.redpanda.com/nzc4ZYQK3WRGd9sy/redpanda/cfg/setup/bash.deb.sh' | sudo -E bash && \
+          sudo apt install redpanda -y && \
+          sudo systemctl start redpanda
 
       # We split building the tests into a separate step
       # so that we can easily distinguish between build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -83,13 +83,13 @@ checksum = "75054ce561491263d7b80dc2f6f6c6f8cdfd0c7a7c17c5cf3b8117829fa72ae1"
 
 [[package]]
 name = "async-trait"
-version = "0.1.58"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
+checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.103",
+ "syn 1.0.104",
 ]
 
 [[package]]
@@ -208,6 +208,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15bf3650200d8bffa99015595e10f1fbd17de07abbc25bb067da79e769939bfa"
+dependencies = [
+ "borsh-derive",
+ "hashbrown 0.11.2",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6441c552f230375d18e3cc377677914d2ca2b0d36e52129fe15450a2dce46775"
+dependencies = [
+ "borsh-derive-internal",
+ "borsh-schema-derive-internal",
+ "proc-macro-crate 0.1.5",
+ "proc-macro2 1.0.47",
+ "syn 1.0.104",
+]
+
+[[package]]
+name = "borsh-derive-internal"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
+dependencies = [
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.104",
+]
+
+[[package]]
+name = "borsh-schema-derive-internal"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
+dependencies = [
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.104",
+]
+
+[[package]]
 name = "bstr"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -226,6 +271,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
+name = "bytecheck"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d11cac2c12b5adc6570dad2ee1b87eff4955dac476fe12d81e5fdd352e52406f"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13e576ebe98e605500b3c8041bb888e966653577172df6dd97398714eb30b9bf"
+dependencies = [
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.104",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,9 +299,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "bzip2"
@@ -269,7 +335,7 @@ dependencies = [
  "cached_proc_macro",
  "cached_proc_macro_types",
  "futures",
- "hashbrown",
+ "hashbrown 0.12.3",
  "instant",
  "lazy_static",
  "once_cell",
@@ -286,7 +352,7 @@ dependencies = [
  "cached_proc_macro_types",
  "darling 0.13.4",
  "quote 1.0.21",
- "syn 1.0.103",
+ "syn 1.0.104",
 ]
 
 [[package]]
@@ -303,9 +369,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.76"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
+checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
 dependencies = [
  "jobserver",
 ]
@@ -412,7 +478,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.103",
+ "syn 1.0.104",
 ]
 
 [[package]]
@@ -422,6 +488,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -561,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.11"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -574,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -584,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if",
 ]
@@ -629,9 +704,9 @@ checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "cxx"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97abf9f0eca9e52b7f81b945524e76710e6cb2366aead23b7d4fbf72e281f888"
+checksum = "d4a41a86530d0fe7f5d9ea779916b7cadd2d4f9add748b99c2c029cbbdfaf453"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -641,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc32cc5fea1d894b77d269ddb9f192110069a8a9c1f1d441195fba90553dea3"
+checksum = "06416d667ff3e3ad2df1cd8cd8afae5da26cf9cec4d0825040f88b5ca659a2f0"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -651,24 +726,24 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "scratch",
- "syn 1.0.103",
+ "syn 1.0.104",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca220e4794c934dc6b1207c3b42856ad4c302f2df1712e9f8d2eec5afaacf1f"
+checksum = "820a9a2af1669deeef27cb271f476ffd196a2c4b6731336011e0ba63e2c7cf71"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b846f081361125bfc8dc9d3940c84e1fd83ba54bbca7b17cd29483c828be0704"
+checksum = "a08a6e2fcc370a089ad3b4aaf54db3b1b4cee38ddabce5896b33eb693275f470"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.103",
+ "syn 1.0.104",
 ]
 
 [[package]]
@@ -702,7 +777,7 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "strsim",
- "syn 1.0.103",
+ "syn 1.0.104",
 ]
 
 [[package]]
@@ -716,7 +791,7 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "strsim",
- "syn 1.0.103",
+ "syn 1.0.104",
 ]
 
 [[package]]
@@ -727,7 +802,7 @@ checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core 0.13.4",
  "quote 1.0.21",
- "syn 1.0.103",
+ "syn 1.0.104",
 ]
 
 [[package]]
@@ -738,7 +813,7 @@ checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
  "darling_core 0.14.2",
  "quote 1.0.21",
- "syn 1.0.103",
+ "syn 1.0.104",
 ]
 
 [[package]]
@@ -748,7 +823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -769,7 +844,7 @@ dependencies = [
  "crossbeam",
  "crossbeam-utils",
  "csv",
- "hashbrown",
+ "hashbrown 0.12.3",
  "impl-trait-for-tuples",
  "indicatif",
  "itertools",
@@ -814,11 +889,14 @@ dependencies = [
  "csv",
  "dbsp",
  "erased-serde",
+ "futures",
+ "log",
  "num-derive",
  "num-traits",
  "once_cell",
  "proptest",
  "proptest-derive",
+ "rdkafka",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -828,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -896,9 +974,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -996,7 +1074,7 @@ checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.103",
+ "syn 1.0.104",
 ]
 
 [[package]]
@@ -1086,6 +1164,15 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1245,17 +1332,17 @@ checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.103",
+ "syn 1.0.104",
 ]
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
  "serde",
 ]
 
@@ -1368,6 +1455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
 dependencies = [
  "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -1408,9 +1496,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
@@ -1439,9 +1527,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.4"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
 ]
@@ -1528,7 +1616,7 @@ checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.103",
+ "syn 1.0.104",
 ]
 
 [[package]]
@@ -1594,6 +1682,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
+dependencies = [
+ "proc-macro-crate 1.2.1",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.104",
+]
+
+[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1619,9 +1728,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.42"
+version = "0.10.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12fc0523e3bd51a692c8850d075d74dc062ccf251c0110668cbd921917118a13"
+checksum = "020433887e44c27ff16365eaa2d380547a94544ad509aff6eb5b6e3e0b27b376"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1640,7 +1749,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.103",
+ "syn 1.0.104",
 ]
 
 [[package]]
@@ -1651,9 +1760,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.77"
+version = "0.9.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
+checksum = "07d5c8cb6e57b3a3612064d7b18b117912b4ce70955c2504d4b741c9e244b132"
 dependencies = [
  "autocfg",
  "cc",
@@ -1674,15 +1783,15 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.0"
+version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc9e0dc2adc1c69d09143aff38d3d30c5c3f0df0dad82e6d25547af174ebec0"
+checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1811,6 +1920,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+dependencies = [
+ "toml",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9"
+dependencies = [
+ "once_cell",
+ "thiserror",
+ "toml",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,7 +1948,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.103",
+ "syn 1.0.104",
  "version_check",
 ]
 
@@ -1881,6 +2010,26 @@ dependencies = [
  "proc-macro2 0.4.30",
  "quote 0.6.13",
  "syn 0.15.44",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.104",
 ]
 
 [[package]]
@@ -1969,11 +2118,10 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+checksum = "1e060280438193c554f654141c9ea9417886713b7acd75974c85b18a69a88e0b"
 dependencies = [
- "autocfg",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -1981,14 +2129,45 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.3"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
+]
+
+[[package]]
+name = "rdkafka"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd7c5d6d17442bcb9f943aae96d67d98c6d36af60442dd5da62aaa7fcbb25c48"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "libc",
+ "log",
+ "rdkafka-sys",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "slab",
+ "tokio",
+]
+
+[[package]]
+name = "rdkafka-sys"
+version = "4.3.0+1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d222a401698c7f2010e3967353eae566d9934dcda49c29910da922414ab4e3f4"
+dependencies = [
+ "cmake",
+ "libc",
+ "libz-sys",
+ "num_enum",
+ "pkg-config",
 ]
 
 [[package]]
@@ -2033,10 +2212,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.11.12"
+name = "rend"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
+checksum = "79af64b4b6362ffba04eef3a4e10829718a4896dac19daa741851c86781edf95"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
  "base64",
  "bytes",
@@ -2067,6 +2255,31 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "rkyv"
+version = "0.7.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cec2b3485b07d96ddfd3134767b8a447b45ea4eb91448d0a35180ec0ffd5ed15"
+dependencies = [
+ "bytecheck",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eaedadc88b53e36dd32d940ed21ae4d850d5916f2581526921f553a72ac34c4"
+dependencies = [
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.104",
 ]
 
 [[package]]
@@ -2101,18 +2314,25 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "rustc_version",
- "syn 1.0.103",
+ "syn 1.0.104",
 ]
 
 [[package]]
 name = "rust_decimal"
-version = "1.26.1"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee9164faf726e4f3ece4978b25ca877ddc6802fa77f38cdccb32c7f805ecd70c"
+checksum = "33c321ee4e17d2b7abe12b5d20c1231db708dd36185c8a21e9de5fed6da4dbe9"
 dependencies = [
  "arrayvec",
+ "borsh",
+ "bytecheck",
+ "byteorder",
+ "bytes",
  "num-traits",
+ "rand",
+ "rkyv",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2180,6 +2400,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 
 [[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
 name = "security-framework"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2210,29 +2436,29 @@ checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
-version = "1.0.147"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
+checksum = "e53f64bb4ba0191d6d0676e1b141ca55047d83b74f5607e6d8eb88126c52c2dc"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.147"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.103",
+ "syn 1.0.104",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
  "itoa",
  "ryu",
@@ -2253,9 +2479,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f2d60d049ea019a84dcd6687b0d1e0030fe663ae105039bdf967ed5e6a9a7"
+checksum = "25bf4a5a814902cd1014dbccfa4d4560fb8432c779471e96e035602519f82eef"
 dependencies = [
  "base64",
  "chrono",
@@ -2269,14 +2495,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ccadfacf6cf10faad22bbadf55986bdd0856edfb5d9210aa1dcf1f516e84e93"
+checksum = "e3452b4c0f6c1e357f73fdb87cd1efabaa12acf328c7a528e252893baeb3f4aa"
 dependencies = [
  "darling 0.14.2",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.103",
+ "syn 1.0.104",
 ]
 
 [[package]]
@@ -2327,7 +2553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce8228c03a78ad52baf655fd57103097f598e029fc75e697f1d6fbe0160420aa"
 dependencies = [
  "arcstr",
- "hashbrown",
+ "hashbrown 0.12.3",
  "rust_decimal",
  "size-of-derive",
  "time",
@@ -2342,7 +2568,7 @@ checksum = "eefff4890f5308d477f3da563af8bdb8fbb6fabaec4c974bd211896fa7945e68"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.103",
+ "syn 1.0.104",
 ]
 
 [[package]]
@@ -2401,9 +2627,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "4ae548ec36cf198c0ef7710d3c230987c2d6d7bd98ad6edc0274462724c585ce"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
@@ -2494,7 +2720,7 @@ checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.103",
+ "syn 1.0.104",
 ]
 
 [[package]]
@@ -2551,9 +2777,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.2"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
+checksum = "d76ce4a75fb488c605c54bf610f221cea8b0dafb53333c1a67e8ee199dcd2ae3"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2569,13 +2795,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "5ec8ecbbb74d42a8dd0ce8ea9bfc38ad13e2ed5203c4f272dbe144f4e17d70ac"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.103",
+ "syn 1.0.104",
 ]
 
 [[package]]
@@ -2600,6 +2826,15 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2667,7 +2902,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5faade31a542b8b35855fff6e8def199853b2da8da256da52f52f1316ee3137"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.12.3",
  "regex",
 ]
 
@@ -2711,9 +2946,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
+checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
 dependencies = [
  "getrandom",
 ]
@@ -2793,7 +3028,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.103",
+ "syn 1.0.104",
  "wasm-bindgen-shared",
 ]
 
@@ -2827,7 +3062,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.103",
+ "syn 1.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2990,9 +3225,9 @@ dependencies = [
 
 [[package]]
 name = "wyz"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]

--- a/adapters/Cargo.toml
+++ b/adapters/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
+[features]
+default = ["with-kafka"]
+with-kafka = ["rdkafka"]
+
 [dependencies]
 num-traits = "0.2.15"
 num-derive = "0.3.3"
@@ -16,6 +20,8 @@ once_cell = "1.9.0"
 serde_yaml = "0.9.14"
 csv = { git = "https://github.com/ryzhyk/rust-csv.git" }
 bincode = { version = "2.0.0-rc.2", features = ["serde"] }
+# cmake-build is required on Windows.
+rdkafka = { version = "0.29.0", features = ["cmake-build"], optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.87"
@@ -23,3 +29,5 @@ size-of = { version = "0.1.2", features = ["time-std"]}
 tempfile = "3.3.0"
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
+futures = "0.3.25"
+log = "0.4.17"

--- a/adapters/src/test/data.rs
+++ b/adapters/src/test/data.rs
@@ -1,0 +1,31 @@
+use bincode::{Decode, Encode};
+use proptest::{collection, prelude::*};
+use proptest_derive::Arbitrary;
+use serde::{Deserialize, Serialize};
+use size_of::SizeOf;
+
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    Clone,
+    Hash,
+    SizeOf,
+    Encode,
+    Decode,
+    Arbitrary,
+)]
+pub struct TestStruct {
+    pub id: u32,
+    pub b: bool,
+    pub i: Option<i64>,
+    pub s: String,
+}
+
+pub fn generate_test_data(size: usize) -> impl Strategy<Value = Vec<TestStruct>> {
+    collection::vec(any::<TestStruct>(), 0..=size)
+}

--- a/adapters/src/test/mod.rs
+++ b/adapters/src/test/mod.rs
@@ -8,9 +8,11 @@ use std::{
     time::{Duration, Instant},
 };
 
+mod data;
 mod mock_dezset;
 mod mock_input_consumer;
 
+pub use data::{generate_test_data, TestStruct};
 pub use mock_dezset::MockDeZSet;
 pub use mock_input_consumer::MockInputConsumer;
 

--- a/adapters/src/transport/file.rs
+++ b/adapters/src/transport/file.rs
@@ -103,7 +103,6 @@ impl FileInputEndpoint {
         status: Arc<AtomicU32>,
         follow: bool,
     ) {
-        println!("file reader worker");
         loop {
             match PipelineState::from_u32(status.load(Ordering::Acquire)) {
                 Some(PipelineState::Paused) => parker.park(),

--- a/adapters/src/transport/kafka.rs
+++ b/adapters/src/transport/kafka.rs
@@ -1,0 +1,649 @@
+use crate::{InputConsumer, InputEndpoint, InputTransport, PipelineState};
+use anyhow::{Error as AnyError, Result as AnyResult};
+use num_traits::FromPrimitive;
+use rdkafka::{
+    config::{FromClientConfigAndContext, RDKafkaLogLevel},
+    consumer::{BaseConsumer, Consumer, ConsumerContext, Rebalance, RebalanceProtocol},
+    ClientConfig, ClientContext, Message,
+};
+use serde::Deserialize;
+use serde_yaml::Value as YamlValue;
+use std::{
+    borrow::Cow,
+    collections::BTreeMap,
+    sync::{
+        atomic::{AtomicU32, Ordering},
+        Arc, Mutex, Weak,
+    },
+    thread::spawn,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+const POLL_TIMEOUT: Duration = Duration::from_millis(100);
+
+/// On startup, the endpoint waits to join the consumer group.
+/// This constant defines the default wait timeout.
+const fn default_group_join_timeout_secs() -> u32 {
+    10
+}
+
+/// `InputTransport` implementation that reads data from one or more
+/// Kafka topics.
+pub struct KafkaInputTransport;
+
+impl InputTransport for KafkaInputTransport {
+    fn name(&self) -> Cow<'static, str> {
+        Cow::Borrowed("kafka")
+    }
+
+    fn new_endpoint(
+        &self,
+        config: &YamlValue,
+        consumer: Box<dyn InputConsumer>,
+    ) -> AnyResult<Box<dyn InputEndpoint>> {
+        let config = KafkaInputConfig::deserialize(config)?;
+        let ep = KafkaInputEndpoint::new(config, consumer)?;
+        Ok(Box::new(ep))
+    }
+}
+
+/// Kafka logging levels.
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum KafkaLogLevel {
+    #[serde(rename = "emerg")]
+    Emerg,
+    #[serde(rename = "alert")]
+    Alert,
+    #[serde(rename = "critical")]
+    Critical,
+    #[serde(rename = "error")]
+    Error,
+    #[serde(rename = "warning")]
+    Warning,
+    #[serde(rename = "notice")]
+    Notice,
+    #[serde(rename = "info")]
+    Info,
+    #[serde(rename = "debug")]
+    Debug,
+}
+
+impl From<RDKafkaLogLevel> for KafkaLogLevel {
+    fn from(level: RDKafkaLogLevel) -> Self {
+        match level {
+            RDKafkaLogLevel::Emerg => Self::Emerg,
+            RDKafkaLogLevel::Alert => Self::Alert,
+            RDKafkaLogLevel::Critical => Self::Critical,
+            RDKafkaLogLevel::Error => Self::Error,
+            RDKafkaLogLevel::Warning => Self::Warning,
+            RDKafkaLogLevel::Notice => Self::Notice,
+            RDKafkaLogLevel::Info => Self::Info,
+            RDKafkaLogLevel::Debug => Self::Debug,
+        }
+    }
+}
+
+impl From<KafkaLogLevel> for RDKafkaLogLevel {
+    fn from(level: KafkaLogLevel) -> Self {
+        match level {
+            KafkaLogLevel::Emerg => RDKafkaLogLevel::Emerg,
+            KafkaLogLevel::Alert => RDKafkaLogLevel::Alert,
+            KafkaLogLevel::Critical => RDKafkaLogLevel::Critical,
+            KafkaLogLevel::Error => RDKafkaLogLevel::Error,
+            KafkaLogLevel::Warning => RDKafkaLogLevel::Warning,
+            KafkaLogLevel::Notice => RDKafkaLogLevel::Notice,
+            KafkaLogLevel::Info => RDKafkaLogLevel::Info,
+            KafkaLogLevel::Debug => RDKafkaLogLevel::Debug,
+        }
+    }
+}
+
+/// Input endpoint configuration.
+#[derive(Deserialize)]
+pub struct KafkaInputConfig {
+    /// Options passed directly to `rdkafka`.
+    ///
+    /// [`librdkafka` options](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)
+    /// used to configure the Kafka consumer.  Not all options are valid with
+    /// this Kafka adapter:
+    ///
+    /// * "enable.auto.commit", if present, must be set to "false",
+    /// * "enable.auto.offset.store", if present, must be set to "false"
+    #[serde(flatten)]
+    kafka_options: BTreeMap<String, String>,
+
+    /// List of topics to subscribe to.
+    topics: Vec<String>,
+
+    /// The log level of the client.
+    ///
+    /// If not specified, the log level will be calculated based on the global
+    /// log level of the `log` crate.
+    log_level: Option<KafkaLogLevel>,
+
+    /// Maximum timeout in seconds to wait for the endpoint to join the Kafka
+    /// consumer group during initialization.
+    #[serde(default = "default_group_join_timeout_secs")]
+    group_join_timeout_secs: u32,
+}
+
+impl KafkaInputConfig {
+    /// Set `option` to `val`; return an error if `option` is set to a different
+    /// value.
+    fn enforce_option(&mut self, option: &str, val: &str) -> AnyResult<()> {
+        let option_val = self
+            .kafka_options
+            .entry(option.to_string())
+            .or_insert_with(|| val.to_string());
+        if option_val != val {
+            Err(AnyError::msg("cannot override '{option}' option: the Kafka transport adapter sets this option to '{val}'"))?;
+        }
+        Ok(())
+    }
+
+    /// Set `option` to `val`, if missing.
+    fn set_option_if_missing(&mut self, option: &str, val: &str) {
+        self.kafka_options
+            .entry(option.to_string())
+            .or_insert_with(|| val.to_string());
+    }
+
+    /// Validate configuration, set default option values required by this
+    /// adapter.
+    fn validate(&mut self) -> AnyResult<()> {
+        // Commit automatically.
+        // See https://docs.confluent.io/platform/current/clients/consumer.html#offset-management
+        self.enforce_option("enable.auto.commit", "true")?;
+        self.enforce_option("enable.auto.offset.store", "true")?;
+
+        let group_id = format!(
+            "{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_millis()
+        );
+        self.set_option_if_missing("group.id", &group_id);
+        self.set_option_if_missing("enable.partition.eof", "false");
+
+        Ok(())
+    }
+}
+
+struct KafkaInputEndpoint(Arc<KafkaInputEndpointInner>);
+
+impl KafkaInputEndpoint {
+    fn new(config: KafkaInputConfig, consumer: Box<dyn InputConsumer>) -> AnyResult<Self> {
+        Ok(Self(KafkaInputEndpointInner::new(config, consumer)?))
+    }
+}
+
+/// Client context used to intercept rebalancing events.
+///
+/// `rdkafka` allows consumers to register callbacks invoked on various
+/// Kafka events.  We need to intercept rebalancing events, when the
+/// consumer gets assigned new partitions, since these new partitions are
+/// may not be in the paused/unpaused state required by the endpoint,
+/// so we may need to pause or unpause them as appropriate.
+///
+/// See https://github.com/edenhill/librdkafka/issues/1849 for a discussion
+/// of the pause/unpause behavior.
+struct KafkaEndpointContext {
+    // We keep a weak reference to the endpoint to avoid a reference cycle:
+    // endpoint->BaseConsumer->context->endpoint.
+    endpoint: Mutex<Weak<KafkaInputEndpointInner>>,
+}
+
+impl KafkaEndpointContext {
+    fn new() -> Self {
+        Self {
+            endpoint: Mutex::new(Weak::new()),
+        }
+    }
+}
+
+impl ClientContext for KafkaEndpointContext {}
+
+impl ConsumerContext for KafkaEndpointContext {
+    fn post_rebalance(&self, rebalance: &Rebalance<'_>) {
+        // println!("Rebalance: {rebalance:?}");
+        if matches!(rebalance, Rebalance::Assign(_)) {
+            if let Some(endpoint) = self.endpoint.lock().unwrap().upgrade() {
+                if endpoint.state() == PipelineState::Running {
+                    // TODO: handle errors by storing them inside `endpoint`
+                    // for later processing in `poll`.
+                    let _ = endpoint.resume_partitions();
+                } else {
+                    let _ = endpoint.pause_partitions();
+                }
+            }
+        }
+
+        // println!("Rebalance complete");
+    }
+}
+
+struct KafkaInputEndpointInner {
+    state: AtomicU32,
+    kafka_consumer: BaseConsumer<KafkaEndpointContext>,
+}
+
+impl KafkaInputEndpointInner {
+    fn new(mut config: KafkaInputConfig, consumer: Box<dyn InputConsumer>) -> AnyResult<Arc<Self>> {
+        // Create Kafka consumer configuration.
+        config.validate()?;
+
+        let mut client_config = ClientConfig::new();
+
+        for (key, value) in config.kafka_options.iter() {
+            client_config.set(key, value);
+        }
+
+        if let Some(log_level) = config.log_level {
+            client_config.set_log_level(RDKafkaLogLevel::from(log_level));
+        }
+
+        // Context object to intercept rebalancing events.
+        let context = KafkaEndpointContext::new();
+
+        // Create Kafka consumer.
+        let kafka_consumer = BaseConsumer::from_config_and_context(&client_config, context)?;
+
+        let endpoint = Arc::new(Self {
+            state: AtomicU32::new(PipelineState::Paused as u32),
+            kafka_consumer,
+        });
+
+        *endpoint.kafka_consumer.context().endpoint.lock().unwrap() = Arc::downgrade(&endpoint);
+
+        // Subscibe consumer to `topics`.
+        endpoint
+            .kafka_consumer
+            .subscribe(&config.topics.iter().map(String::as_str).collect::<Vec<_>>())?;
+
+        // Wait for the consumer to join the group by waiting for the group
+        // rebalance protocol to be set.
+        for attempt in 0..=config.group_join_timeout_secs {
+            if matches!(
+                endpoint.kafka_consumer.rebalance_protocol(),
+                RebalanceProtocol::None
+            ) {
+                if attempt == config.group_join_timeout_secs {
+                    return Err(AnyError::msg(format!(
+                        "failed to join consumer group '{}', giving up after {}s",
+                        config.kafka_options.get("group.id").unwrap(),
+                        config.group_join_timeout_secs
+                    )));
+                }
+                std::thread::sleep(std::time::Duration::from_millis(1000));
+                // kafka_consumer.poll(POLL_TIMEOUT);
+                // println!("waiting to join the group");
+            } else {
+                break;
+            }
+        }
+
+        let endpoint_clone = endpoint.clone();
+        spawn(move || Self::worker_thread(endpoint_clone, consumer));
+
+        Ok(endpoint)
+    }
+
+    #[allow(dead_code)]
+    fn debug_consumer(&self) {
+        /*let topic_metadata = self.kafka_consumer.fetch_metadata(None, Duration::from_millis(1000)).unwrap();
+        for topic in topic_metadata.topics() {
+            println!("topic: {}", topic.name());
+            for partition in topic.partitions() {
+                println!("  partition: {}, leader: {}, error: {:?}, replicas: {:?}, isr: {:?}", partition.id(), partition.leader(), partition.error(), partition.replicas(), partition.isr());
+            }
+        }*/
+        // println!("Subscription: {:?}", self.kafka_consumer.subscription());
+        println!("Assignment: {:?}", self.kafka_consumer.assignment());
+    }
+
+    fn state(&self) -> PipelineState {
+        PipelineState::from_u32(self.state.load(Ordering::Acquire)).unwrap()
+    }
+
+    fn set_state(&self, state: PipelineState) {
+        self.state.store(state as u32, Ordering::Release);
+    }
+
+    /// Pause all partitions assigned to the consumer.
+    fn pause_partitions(&self) -> AnyResult<()> {
+        // println!("pause");
+        // self.debug_consumer();
+
+        self.kafka_consumer
+            .pause(&self.kafka_consumer.assignment()?)?;
+        Ok(())
+    }
+
+    /// Resume all partitions assigned to the consumer.
+    fn resume_partitions(&self) -> AnyResult<()> {
+        self.kafka_consumer
+            .resume(&self.kafka_consumer.assignment()?)?;
+        Ok(())
+    }
+
+    fn worker_thread(endpoint: Arc<KafkaInputEndpointInner>, mut consumer: Box<dyn InputConsumer>) {
+        let mut actual_state = PipelineState::Paused;
+        loop {
+            // endpoint.debug_consumer();
+            match endpoint.state() {
+                PipelineState::Paused if actual_state != PipelineState::Paused => {
+                    actual_state = PipelineState::Paused;
+                    if let Err(e) = endpoint.pause_partitions() {
+                        consumer.error(e);
+                        return;
+                    }
+                }
+                PipelineState::Running if actual_state != PipelineState::Running => {
+                    actual_state = PipelineState::Running;
+                    if let Err(e) = endpoint.resume_partitions() {
+                        consumer.error(e);
+                        return;
+                    };
+                }
+                PipelineState::Terminated => return,
+                _ => {}
+            }
+
+            // According to `rdkafka` docs, we must keep polling even while
+            // the consumer is paused as `BaseConsumer` processes control
+            // messages (including rebalancing) within the polling thread.
+            //
+            // `POLL_TIMEOUT` makes sure that the thread will periodically
+            // check for termination and pause commands.
+            match endpoint.kafka_consumer.poll(POLL_TIMEOUT) {
+                None => {
+                    // println!("poll returned None");
+                }
+                Some(Err(e)) => {
+                    // println!("poll returned error");
+                    consumer.error(AnyError::from(e));
+                    if endpoint.kafka_consumer.client().fatal_error().is_some() {
+                        return;
+                    }
+                }
+                Some(Ok(message)) => {
+                    // println!("received {} bytes", message.payload().unwrap().len());
+                    // message.payload().map(|payload| consumer.input(payload));
+
+                    if let Some(payload) = message.payload() {
+                        consumer.input(payload);
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl InputEndpoint for KafkaInputEndpoint {
+    fn pause(&self) -> AnyResult<()> {
+        // Notify worker thread via the state flag.  The worker may
+        // send another buffer downstream before the flag takes effect.
+        self.0.set_state(PipelineState::Paused);
+        Ok(())
+    }
+
+    fn start(&self) -> AnyResult<()> {
+        self.0.set_state(PipelineState::Running);
+        Ok(())
+    }
+
+    fn disconnect(&self) {
+        self.0.set_state(PipelineState::Terminated);
+    }
+}
+
+impl Drop for KafkaInputEndpoint {
+    fn drop(&mut self) {
+        self.disconnect();
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use crate::test::{generate_test_data, mock_input_pipeline, wait, MockDeZSet, TestStruct};
+    use csv::WriterBuilder as CsvWriterBuilder;
+    use futures::executor::block_on;
+    use log::{LevelFilter, Log, Metadata, Record};
+    use proptest::{collection, prelude::*};
+    use rdkafka::{
+        admin::{AdminClient, AdminOptions, NewPartitions, NewTopic, TopicReplication},
+        client::DefaultClientContext,
+        config::{FromClientConfig, RDKafkaLogLevel},
+        producer::{BaseRecord, DefaultProducerContext, ThreadedProducer},
+        ClientConfig,
+    };
+    use std::{thread::sleep, time::Duration};
+
+    struct TestLogger;
+    static TEST_LOGGER: TestLogger = TestLogger;
+
+    impl Log for TestLogger {
+        fn enabled(&self, _metadata: &Metadata) -> bool {
+            true
+        }
+
+        fn log(&self, record: &Record) {
+            println!("{} - {}", record.level(), record.args());
+        }
+
+        fn flush(&self) {}
+    }
+
+    struct KafkaResources {
+        admin_client: AdminClient<DefaultClientContext>,
+    }
+
+    /// An object that creates a couple of topics on startup and deletes them
+    /// on drop.  Helps make sure that test runs don't leave garbage behind.
+    impl KafkaResources {
+        fn create_topics() -> Self {
+            let mut admin_config = ClientConfig::new();
+            admin_config
+                .set("bootstrap.servers", "localhost")
+                .set_log_level(RDKafkaLogLevel::Debug);
+            let admin_client = AdminClient::from_config(&admin_config).unwrap();
+
+            let input_topic1 = NewTopic::new("input_topic1", 1, TopicReplication::Fixed(1));
+            let input_topic2 = NewTopic::new("input_topic2", 2, TopicReplication::Fixed(1));
+
+            // Delete topics if they exist from previous failed runs that crashed before
+            // cleaning up.  Otherwise, it may take a long time to re-join a
+            // group whose members are dead, plus the old topics may contain
+            // messages that will mess up our tests.
+            let _ = block_on(
+                admin_client.delete_topics(&["input_topic1", "input_topic2"], &AdminOptions::new()),
+            );
+
+            block_on(
+                admin_client.create_topics([&input_topic1, &input_topic2], &AdminOptions::new()),
+            )
+            .unwrap();
+
+            Self { admin_client }
+        }
+
+        fn add_partition(&self, topic: &str) {
+            block_on(
+                self.admin_client
+                    .create_partitions(&[NewPartitions::new(topic, 1)], &AdminOptions::new()),
+            )
+            .unwrap();
+        }
+    }
+
+    impl Drop for KafkaResources {
+        fn drop(&mut self) {
+            let _ = block_on(
+                self.admin_client
+                    .delete_topics(&["input_topic1", "input_topic2"], &AdminOptions::new()),
+            );
+        }
+    }
+
+    fn send_to_topic(
+        producer: &ThreadedProducer<DefaultProducerContext>,
+        data: &[Vec<TestStruct>],
+        topic: &str,
+    ) {
+        for batch in data {
+            let mut writer = CsvWriterBuilder::new()
+                .has_headers(false)
+                .from_writer(Vec::with_capacity(batch.len() * 32));
+
+            for val in batch.iter().cloned() {
+                writer.serialize(val).unwrap();
+            }
+            writer.flush().unwrap();
+            let bytes = writer.into_inner().unwrap();
+
+            let record = <BaseRecord<(), [u8], ()>>::to(topic).payload(&bytes);
+            producer.send(record).unwrap();
+            // println!("sent {} bytes", bytes.len());
+        }
+        // producer.flush(Timeout::Never).unwrap();
+        println!("Data written to '{topic}'");
+    }
+
+    /// Wait to receive all records in `data` in the same order.
+    fn wait_for_output_ordered(zset: &MockDeZSet<TestStruct>, data: &[Vec<TestStruct>]) {
+        let num_records: usize = data.iter().map(Vec::len).sum();
+
+        wait(|| zset.state().flushed.len() == num_records, None);
+
+        for (i, val) in data.iter().flat_map(|data| data.iter()).enumerate() {
+            assert_eq!(&zset.state().flushed[i].0, val);
+        }
+    }
+
+    /// Wait to receive all records in `data` in some order.
+    fn wait_for_output_unordered(zset: &MockDeZSet<TestStruct>, data: &[Vec<TestStruct>]) {
+        let num_records: usize = data.iter().map(Vec::len).sum();
+
+        wait(|| zset.state().flushed.len() == num_records, None);
+
+        let mut data_sorted = data
+            .iter()
+            .flat_map(|data| data.clone().into_iter())
+            .collect::<Vec<_>>();
+        data_sorted.sort();
+
+        let mut zset_sorted = zset
+            .state()
+            .flushed
+            .iter()
+            .map(|(val, polarity)| {
+                assert_eq!(*polarity, true);
+                val.clone()
+            })
+            .collect::<Vec<_>>();
+        zset_sorted.sort();
+
+        assert_eq!(zset_sorted, data_sorted);
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(2))]
+
+        #[test]
+        fn proptest_kafka_input(data in collection::vec(generate_test_data(1000), 0..=100)) {
+
+            let _ = log::set_logger(&TEST_LOGGER);
+            log::set_max_level(LevelFilter::Debug);
+
+            let kafka_resources = KafkaResources::create_topics();
+
+            // auto.offset.reset: "earliest" - guarantees that on startup the
+            // consumer will observe all messages sent by the producer even if
+            // the producer starts earlier (the consumer won't start until the
+            // rebalancing protocol kicks in).
+            let config_str = format!(
+                r#"
+transport:
+    name: kafka
+    config:
+        bootstrap.servers: "localhost"
+        auto.offset.reset: "earliest"
+        topics: [input_topic1, input_topic2]
+        log_level: debug
+format:
+    name: csv
+    config:
+        input_stream: test_input
+"#);
+
+            println!("Building input pipeline");
+
+            let (endpoint, _consumer, zset) = mock_input_pipeline::<TestStruct>(
+                "test_input",
+                serde_yaml::from_str(&config_str).unwrap(),
+            );
+
+            endpoint.start().unwrap();
+
+            let mut producer_config = ClientConfig::new();
+            producer_config
+                .set("bootstrap.servers", "localhost")
+                .set("message.timeout.ms", "0") // infinite timeout
+                .set_log_level(RDKafkaLogLevel::Debug);
+            let producer = ThreadedProducer::from_config(&producer_config)?;
+
+            println!("Test: Receive from a topic with a single partition");
+
+            // Send data to a topic with a single partition;
+            // Make sure all records arrive in the original order.
+            send_to_topic(&producer, &data, "input_topic1");
+
+            wait_for_output_ordered(&zset, &data);
+            zset.reset();
+
+            println!("Test: Receive from a topic with multiple partitions");
+
+            // Send data to a topic with multiple partitions.
+            // Make sure all records are delivered, but not necessarily in the original order.
+            send_to_topic(&producer, &data, "input_topic2");
+
+            wait_for_output_unordered(&zset, &data);
+            zset.reset();
+
+            println!("Test: pause/resume");
+            //println!("records before pause: {}", zset.state().flushed.len());
+
+            // Paused endpoint shouldn't receive any data.
+            endpoint.pause().unwrap();
+            sleep(Duration::from_millis(1000));
+
+            kafka_resources.add_partition("input_topic2");
+
+            send_to_topic(&producer, &data, "input_topic2");
+            sleep(Duration::from_millis(1000));
+            assert_eq!(zset.state().flushed.len(), 0);
+
+            // Receive everything after unpause.
+            endpoint.start().unwrap();
+            wait_for_output_unordered(&zset, &data);
+
+            zset.reset();
+
+            println!("Test: Disconnect");
+            // Disconnected endpoint should not receive any data.
+            endpoint.disconnect();
+            sleep(Duration::from_millis(1000));
+
+            send_to_topic(&producer, &data, "input_topic2");
+            sleep(Duration::from_millis(1000));
+            assert_eq!(zset.state().flushed.len(), 0);
+
+            sleep(2 * super::POLL_TIMEOUT);
+
+            println!("Delete Kafka resources");
+            drop(kafka_resources);
+        }
+    }
+}

--- a/adapters/src/transport/mod.rs
+++ b/adapters/src/transport/mod.rs
@@ -6,16 +6,29 @@ use std::collections::BTreeMap;
 
 mod file;
 
+#[cfg(feature = "with-kafka")]
+mod kafka;
+
 pub use file::{FileInputTransport, FileOutputTransport};
+
+#[cfg(feature = "with-kafka")]
+pub use kafka::KafkaInputTransport;
 
 /// Static map of supported input transports.
 // TODO: support for registering new transports at runtime in order to allow
 // external crates to implement new transports.
 static INPUT_TRANSPORT: Lazy<BTreeMap<&'static str, Box<dyn InputTransport>>> = Lazy::new(|| {
-    BTreeMap::from([(
-        "file",
-        Box::new(FileInputTransport) as Box<dyn InputTransport>,
-    )])
+    BTreeMap::from([
+        (
+            "file",
+            Box::new(FileInputTransport) as Box<dyn InputTransport>,
+        ),
+        #[cfg(feature = "with-kafka")]
+        (
+            "kafka",
+            Box::new(KafkaInputTransport) as Box<dyn InputTransport>,
+        ),
+    ])
 });
 
 /// Static map of supported output transports.


### PR DESCRIPTION
Simple adapter that reads data from Kafka into DBSP and doesn't do
anything clever for transactions or reliable delivery.  It is suitable
for streaming data in scenarios where atomic transactions are not
required and at least once delivery is acceptable (i.e., occasional
duplicates can be tolerated).