### PR TITLE
Minimal DBSP server

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -232,9 +232,11 @@ jobs:
           # https://github.com/llvm-mirror/compiler-rt/blob/69445f095c22aac2388f939bedebf224a6efcdaf/lib/sanitizer_common/sanitizer_thread_registry.h#L104.
           # So we run tests one at a time to mitigate this.
           THREADS: "${{ matrix.sanitizer == 'leak' && '--test-threads=1' || '' }}"
+          # Memory sanitizer reports uninitialized reads in `librdkafka`.
+          SKIP_KAFKA: "${{ (matrix.sanitizer == 'memory' || matrix.sanitizer == 'thread') && '--skip kafka' || '' }}"
         with:
           command: test
-          args: --workspace ${{ env.ALMOST_ALL_FEATURES }} --target ${{ matrix.target }} -Z build-std -- --skip 'proptest' --skip 'persistent' ${{ env.THREADS }}
+          args: --workspace ${{ env.ALMOST_ALL_FEATURES }} --target ${{ matrix.target }} -Z build-std -- --skip 'proptest' --skip 'persistent' ${{ env.SKIP_KAFKA }} ${{ env.THREADS }}
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,208 @@
 version = 3
 
 [[package]]
+name = "actix-codec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a7559404a7f3573127aab53c08ce37a6c6a315c374a31070f3c91cd1b4a7fe"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "actix-files"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d832782fac6ca7369a70c9ee9a20554623c5e51c76e190ad151780ebea1cf689"
+dependencies = [
+ "actix-http",
+ "actix-service",
+ "actix-utils",
+ "actix-web",
+ "askama_escape",
+ "bitflags",
+ "bytes",
+ "derive_more",
+ "futures-core",
+ "http-range",
+ "log",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-http"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c83abf9903e1f0ad9973cc4f7b9767fd5a03a583f51a5b7a339e07987cd2724"
+dependencies = [
+ "actix-codec",
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "ahash",
+ "base64",
+ "bitflags",
+ "brotli",
+ "bytes",
+ "bytestring",
+ "derive_more",
+ "encoding_rs",
+ "flate2",
+ "futures-core",
+ "h2",
+ "http",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "language-tags",
+ "local-channel",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rand",
+ "sha1",
+ "smallvec",
+ "tracing",
+ "zstd 0.11.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "actix-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465a6172cf69b960917811022d8f29bc0b7fa1398bc4f78b3c466673db1213b6"
+dependencies = [
+ "quote 1.0.21",
+ "syn 1.0.105",
+]
+
+[[package]]
+name = "actix-router"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66ff4d247d2b160861fa2866457e85706833527840e4133f8f49aa423a38799"
+dependencies = [
+ "bytestring",
+ "http",
+ "regex",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "actix-rt"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ea16c295198e958ef31930a6ef37d0fb64e9ca3b6116e6b93a8bdae96ee1000"
+dependencies = [
+ "futures-core",
+ "tokio",
+]
+
+[[package]]
+name = "actix-server"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0da34f8e659ea1b077bb4637948b815cd3768ad5a188fdcd74ff4d84240cd824"
+dependencies = [
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "futures-util",
+ "mio",
+ "num_cpus",
+ "socket2",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "actix-service"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b894941f818cfdc7ccc4b9e60fa7e53b5042a2e8567270f9147d5591893373a"
+dependencies = [
+ "futures-core",
+ "paste",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-utils"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
+dependencies = [
+ "local-waker",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "actix-web"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d48f7b6534e06c7bfc72ee91db7917d4af6afe23e7d223b51e68fffbb21e96b9"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-macros",
+ "actix-router",
+ "actix-rt",
+ "actix-server",
+ "actix-service",
+ "actix-utils",
+ "actix-web-codegen",
+ "ahash",
+ "bytes",
+ "bytestring",
+ "cfg-if",
+ "cookie",
+ "derive_more",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "itoa",
+ "language-tags",
+ "log",
+ "mime",
+ "once_cell",
+ "pin-project-lite",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "socket2",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "actix-web-codegen"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa9362663c8643d67b2d5eafba49e4cb2c8a053a29ed00a0bea121f17c76b13"
+dependencies = [
+ "actix-router",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.105",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,6 +240,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -82,6 +299,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75054ce561491263d7b80dc2f6f6c6f8cdfd0c7a7c17c5cf3b8117829fa72ae1"
 
 [[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
+
+[[package]]
 name = "async-trait"
 version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,7 +312,7 @@ checksum = "31e6e93155431f3931513b243d371981bb2770112b370c82745a1d19d2f99364"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -123,9 +346,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64ct"
-version = "1.0.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a32fd6af2b5827bce66c29053ba0e7c42b9dcab01835835058558c10851a46b"
+checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
 
 [[package]]
 name = "bincode"
@@ -227,7 +450,7 @@ dependencies = [
  "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
  "proc-macro2 1.0.47",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -238,7 +461,7 @@ checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -249,7 +472,28 @@ checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
+]
+
+[[package]]
+name = "brotli"
+version = "3.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -288,7 +532,7 @@ checksum = "13e576ebe98e605500b3c8041bb888e966653577172df6dd97398714eb30b9bf"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -302,6 +546,15 @@ name = "bytes"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+
+[[package]]
+name = "bytestring"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7f83e57d9154148e355404702e2694463241880b939570d7c97c014da7a69a1"
+dependencies = [
+ "bytes",
+]
 
 [[package]]
 name = "bzip2"
@@ -352,7 +605,7 @@ dependencies = [
  "cached_proc_macro_types",
  "darling 0.13.4",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -478,7 +731,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -528,6 +781,23 @@ name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "cookie"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "344adc371239ef32293cb1c4fe519592fcf21206c79c02854320afcdf3ab4917"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
 
 [[package]]
 name = "core-foundation"
@@ -704,9 +974,9 @@ checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "cxx"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a41a86530d0fe7f5d9ea779916b7cadd2d4f9add748b99c2c029cbbdfaf453"
+checksum = "bdf07d07d6531bfcdbe9b8b739b104610c6508dcc4d63b410585faf338241daf"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -716,9 +986,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06416d667ff3e3ad2df1cd8cd8afae5da26cf9cec4d0825040f88b5ca659a2f0"
+checksum = "d2eb5b96ecdc99f72657332953d4d9c50135af1bac34277801cc3937906ebd39"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -726,24 +996,24 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "scratch",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "820a9a2af1669deeef27cb271f476ffd196a2c4b6731336011e0ba63e2c7cf71"
+checksum = "ac040a39517fd1674e0f32177648334b0f4074625b5588a64519804ba0553b12"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08a6e2fcc370a089ad3b4aaf54db3b1b4cee38ddabce5896b33eb693275f470"
+checksum = "1362b0ddcfc4eb0a1f57b68bd77dd99f0e826958a96abd0ae9bd092e114ffed6"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -777,7 +1047,7 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "strsim",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -791,7 +1061,7 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "strsim",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -802,7 +1072,7 @@ checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
  "darling_core 0.13.4",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -813,7 +1083,7 @@ checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
  "darling_core 0.14.2",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -876,13 +1146,15 @@ dependencies = [
  "uuid",
  "xxhash-rust",
  "zip",
- "zstd",
+ "zstd 0.12.1+zstd.1.5.2",
 ]
 
 [[package]]
 name = "dbsp_adapters"
 version = "0.1.0"
 dependencies = [
+ "actix-files",
+ "actix-web",
  "anyhow",
  "bincode",
  "crossbeam",
@@ -902,6 +1174,19 @@ dependencies = [
  "serde_yaml",
  "size-of",
  "tempfile",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "rustc_version",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1074,7 +1359,7 @@ checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1236,6 +1521,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,7 +1623,7 @@ checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1407,6 +1698,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "language-tags"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1420,9 +1717,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 
 [[package]]
 name = "libloading"
@@ -1468,6 +1765,24 @@ checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "local-channel"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f303ec0e94c6c54447f84f3b0ef7af769858a9c4ef56ef2a986d3dcd4c3fc9c"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "local-waker",
+]
+
+[[package]]
+name = "local-waker"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34f76eb3611940e0e7d53a9aaa4e6a3151f69541a282fd0dad5571420c53ff1"
 
 [[package]]
 name = "lock_api"
@@ -1518,6 +1833,16 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -1616,14 +1941,14 @@ checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
 name = "num-format"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b862ff8df690cf089058c98b183676a7ed0f974cc08b426800093227cbff3b"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
  "arrayvec",
  "itoa",
@@ -1699,7 +2024,7 @@ dependencies = [
  "proc-macro-crate 1.2.1",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1749,7 +2074,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -1788,6 +2113,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1802,9 +2137,9 @@ dependencies = [
 
 [[package]]
 name = "password-hash"
-version = "0.3.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d791538a6dcc1e7cb7fe6f6b58aca40e7f79403c45b2bc274008b5e647af1d8"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
  "base64ct",
  "rand_core",
@@ -1819,9 +2154,9 @@ checksum = "b1de2e551fb905ac83f73f7aedf2f0cb4a0da7e35efa24a202a936269f1f18e1"
 
 [[package]]
 name = "pbkdf2"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest",
  "hmac",
@@ -1948,7 +2283,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
  "version_check",
 ]
 
@@ -2029,7 +2364,7 @@ checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -2279,7 +2614,7 @@ checksum = "6eaedadc88b53e36dd32d940ed21ae4d850d5916f2581526921f553a72ac34c4"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -2314,7 +2649,7 @@ dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
  "rustc_version",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -2451,7 +2786,7 @@ checksum = "a55492425aa53521babf6137309e7d34c20bbfbbfcfe2c7f3a047fd1f6b92c0c"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -2502,7 +2837,7 @@ dependencies = [
  "darling 0.14.2",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -2547,6 +2882,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "size-of"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2568,7 +2912,7 @@ checksum = "eefff4890f5308d477f3da563af8bdb8fbb6fabaec4c974bd211896fa7945e68"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -2627,9 +2971,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.104"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae548ec36cf198c0ef7710d3c230987c2d6d7bd98ad6edc0274462724c585ce"
+checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
@@ -2720,7 +3064,7 @@ checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -2787,7 +3131,9 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "winapi",
@@ -2795,13 +3141,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec8ecbbb74d42a8dd0ce8ea9bfc38ad13e2ed5203c4f272dbe144f4e17d70ac"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -2850,6 +3196,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-core",
 ]
@@ -2883,6 +3230,15 @@ name = "typenum"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -3028,7 +3384,7 @@ dependencies = [
  "once_cell",
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
  "wasm-bindgen-shared",
 ]
 
@@ -3062,7 +3418,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
- "syn 1.0.104",
+ "syn 1.0.105",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3249,9 +3605,9 @@ checksum = "735a71d46c4d68d71d4b24d03fdc2b98e38cea81730595801db779c04fe80d70"
 
 [[package]]
 name = "zip"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf225bcf73bb52cbb496e70475c7bd7a3f769df699c0020f6c7bd9a96dcf0b8d"
+checksum = "537ce7411d25e54e8ae21a7ce0b15840e7bfcff15b51d697ec3266cc76bdf080"
 dependencies = [
  "aes",
  "byteorder",
@@ -3264,23 +3620,42 @@ dependencies = [
  "pbkdf2",
  "sha1",
  "time",
- "zstd",
+ "zstd 0.11.2+zstd.1.5.2",
 ]
 
 [[package]]
 name = "zstd"
-version = "0.10.2+zstd.1.5.2"
+version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4a6bd64f22b5e3e94b4e238669ff9f10815c27a5180108b849d24174a83847"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 5.0.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
+version = "0.12.1+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c947d2adc84ff9a59f2e3c03b81aa4128acf28d6ad7d56273f7e8af14e47bea"
+dependencies = [
+ "zstd-safe 6.0.2+zstd.1.5.2",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "4.1.6+zstd.1.5.2"
+version = "5.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b61c51bb270702d6167b8ce67340d2754b088d0c091b06e593aa772c3ee9bb"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "6.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cf39f730b440bab43da8fb5faf5f254574462f73f260f85f7987f32154ff17"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -3288,9 +3663,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.6.3+zstd.1.5.2"
+version = "2.0.4+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
+checksum = "4fa202f2ef00074143e219d15b62ffc317d17cc33909feac471c044087cad7b0"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ cached = { version = "0.38.0", optional = true }
 zip = "0.6.2"
 tar = "0.4.38"
 rand = "0.8.5"
-zstd = "0.10.0"
+zstd = "0.12.0"
 paste = "1.0.9"
 rstest = "0.15"
 cached = "0.38.0"

--- a/adapters/Cargo.toml
+++ b/adapters/Cargo.toml
@@ -5,8 +5,10 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [features]
-default = ["with-kafka"]
+default = ["with-kafka", "server"]
 with-kafka = ["rdkafka"]
+server = ["actix-files", "actix-web", "with-kafka"]
+test-utils = ["size-of", "futures", "proptest", "proptest-derive"]
 
 [dependencies]
 num-traits = "0.2.15"
@@ -22,6 +24,13 @@ csv = { git = "https://github.com/ryzhyk/rust-csv.git" }
 bincode = { version = "2.0.0-rc.2", features = ["serde"] }
 # cmake-build is required on Windows.
 rdkafka = { version = "0.29.0", features = ["cmake-build"], optional = true }
+actix-files = { version = "0.6.2", optional = true }
+actix-web = { version = "4.2", optional = true }
+log = "0.4.17"
+size-of = { version = "0.1.2", features = ["time-std"], optional = true}
+futures = { version = "0.3.25", optional = true}
+proptest = { version = "1.0.0", optional = true} 
+proptest-derive = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0.87"
@@ -30,4 +39,8 @@ tempfile = "3.3.0"
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
 futures = "0.3.25"
-log = "0.4.17"
+
+[[example]]
+
+name = "server"
+required-features = ["with-kafka", "test-utils", "server"]

--- a/adapters/examples/server.rs
+++ b/adapters/examples/server.rs
@@ -1,0 +1,91 @@
+//! This example creates a DBSP server on port 8080 and feeds
+//! an infinite stream of Kafka messages to it.
+
+use dbsp_adapters::{
+    server,
+    test::{
+        generate_test_batches,
+        kafka::{BufferConsumer, KafkaResources, TestProducer},
+        test_circuit, TEST_LOGGER,
+    },
+};
+use log::LevelFilter;
+use proptest::{
+    strategy::{Strategy, ValueTree},
+    test_runner::TestRunner,
+};
+use std::{
+    io::{stdout, Write},
+    thread::spawn,
+};
+
+fn main() {
+    let _ = log::set_logger(&TEST_LOGGER);
+    log::set_max_level(LevelFilter::Debug);
+
+    // Create topics.
+    let kafka_resources = KafkaResources::create_topics(&[
+        ("server_example_input_topic", 1),
+        ("server_example_output_topic", 1),
+    ]);
+
+    // Config string
+    let config_str = format!(
+        r#"
+inputs:
+    test_input1:
+        transport:
+            name: kafka
+            config:
+                bootstrap.servers: "localhost"
+                auto.offset.reset: "earliest"
+                topics: [server_example_input_topic]
+                log_level: debug
+        format:
+            name: csv
+            config:
+                input_stream: test_input1
+outputs:
+    test_output2:
+        stream: test_output1
+        transport:
+            name: kafka
+            config:
+                bootstrap.servers: "localhost"
+                topic: server_example_output_topic
+                max_inflight_messages: 0
+        format:
+            name: csv
+"#
+    );
+
+    spawn(move || {
+        let producer = TestProducer::new();
+        let buffer_consumer = BufferConsumer::new("server_example_output_topic");
+
+        let mut runner = TestRunner::default();
+
+        loop {
+            // Generate some data, send it to the circuit, wait for it to
+            // appear in the output topic before sending more.
+            let data = generate_test_batches(5, 100)
+                .new_tree(&mut runner)
+                .unwrap()
+                .current();
+
+            producer.send_to_topic(&data, "server_example_input_topic");
+            buffer_consumer.wait_for_output_unordered(&data);
+            buffer_consumer.clear();
+            print!(".");
+            stdout().flush().unwrap();
+        }
+    });
+
+    // Create circuit
+    let (circuit, catalog) = test_circuit(4);
+
+    println!("Starting HTTP server on port 8080");
+    let _server = server::run(circuit, catalog, &config_str, 8080);
+
+    drop(kafka_resources);
+}

--- a/adapters/src/controller/mod.rs
+++ b/adapters/src/controller/mod.rs
@@ -63,8 +63,8 @@ pub use config::{
     ControllerConfig, ControllerInnerConfig, FormatConfig, GlobalControllerConfig,
     InputEndpointConfig, OutputEndpointConfig,
 };
-use error::ControllerError;
-use stats::ControllerStats;
+pub use error::ControllerError;
+pub use stats::ControllerStats;
 
 type EndpointId = u64;
 

--- a/adapters/src/lib.rs
+++ b/adapters/src/lib.rs
@@ -113,10 +113,12 @@ mod controller;
 mod deinput;
 mod format;
 mod seroutput;
+#[cfg(feature = "server")]
+pub mod server;
 mod transport;
 
-#[cfg(test)]
-mod test;
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test;
 
 #[derive(Copy, Clone, PartialEq, Eq, FromPrimitive)]
 pub enum PipelineState {
@@ -137,7 +139,7 @@ pub use deinput::{
 pub use format::{Encoder, InputFormat, OutputConsumer, OutputFormat, Parser};
 pub use seroutput::{SerBatch, SerCursor, SerOutputBatchHandle};
 
-pub use controller::{Controller, ControllerConfig};
+pub use controller::{Controller, ControllerConfig, ControllerError};
 pub use transport::{
     FileInputTransport, InputConsumer, InputEndpoint, InputTransport, OutputEndpoint,
     OutputTransport,

--- a/adapters/src/server/mod.rs
+++ b/adapters/src/server/mod.rs
@@ -1,0 +1,263 @@
+use crate::{Catalog, Controller, ControllerConfig, ControllerError};
+use actix_files as fs;
+use actix_files::NamedFile;
+use actix_web::{
+    dev::{ServiceFactory, ServiceRequest},
+    get,
+    middleware::Logger,
+    rt, web,
+    web::Data as WebData,
+    App, Error as ActixError, HttpResponse, HttpServer, Responder, Result as ActixResult,
+};
+use anyhow::Result as AnyResult;
+use dbsp::DBSPHandle;
+use log::error;
+use std::sync::Mutex;
+
+// TODO:
+//
+// - Config
+// - Stats: return per-endpoint statistics + status (ok/failed)
+// - grafana
+
+struct ServerState {
+    controller: Mutex<Option<Controller>>,
+}
+
+impl ServerState {
+    fn new(controller: Controller) -> Self {
+        Self {
+            controller: Mutex::new(Some(controller)),
+        }
+    }
+}
+
+pub fn run(circuit: DBSPHandle, catalog: Catalog, yaml_config: &str, port: u16) -> AnyResult<()> {
+    let config: ControllerConfig = serde_yaml::from_str(yaml_config)?;
+    let controller = Controller::with_config(
+        circuit,
+        catalog,
+        &config,
+        Box::new(|e| error!("{e}")) as Box<dyn Fn(ControllerError) + Send + Sync>,
+    )?;
+
+    let state = WebData::new(ServerState::new(controller));
+
+    rt::System::new().block_on(
+        HttpServer::new(move || build_app(App::new().wrap(Logger::default()), state.clone()))
+            .bind(("127.0.0.1", port))?
+            .run(),
+    )?;
+
+    Ok(())
+}
+
+fn build_app<T>(app: App<T>, state: WebData<ServerState>) -> App<T>
+where
+    T: ServiceFactory<ServiceRequest, Config = (), Error = ActixError, InitError = ()>,
+{
+    app.app_data(state)
+        .route("/", web::get().to(index))
+        .route("/index.html", web::get().to(index))
+        .service(fs::Files::new("/static", "static").show_files_listing())
+        .service(start)
+        .service(pause)
+        .service(shutdown)
+}
+
+async fn index() -> ActixResult<NamedFile> {
+    Ok(NamedFile::open("static/index.html")?)
+}
+
+#[get("/start")]
+async fn start(state: WebData<ServerState>) -> impl Responder {
+    match &*state.controller.lock().unwrap() {
+        Some(controller) => {
+            controller.start();
+            HttpResponse::Ok().body("The pipeline is running")
+        }
+        None => HttpResponse::Conflict().body("The pipeline has been terminated"),
+    }
+}
+
+#[get("/pause")]
+async fn pause(state: WebData<ServerState>) -> impl Responder {
+    match &*state.controller.lock().unwrap() {
+        Some(controller) => {
+            controller.pause();
+            HttpResponse::Ok().body("Pipeline paused")
+        }
+        None => HttpResponse::Conflict().body("The pipeline has been terminated"),
+    }
+}
+
+#[get("/shutdown")]
+async fn shutdown(state: WebData<ServerState>) -> impl Responder {
+    let controller = state.controller.lock().unwrap().take();
+    if let Some(controller) = controller {
+        match controller.stop() {
+            Ok(()) => HttpResponse::Ok().body("Pipeline terminated"),
+            Err(e) => HttpResponse::InternalServerError()
+                .body(format!("Failed to terminate the pipeline: {e}")),
+        }
+    } else {
+        HttpResponse::Ok().body("Pipeline already terminated")
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "with-kafka")]
+mod test {
+    use super::{build_app, ServerState};
+    use crate::{
+        test::{
+            generate_test_batches,
+            kafka::{BufferConsumer, KafkaResources, TestProducer},
+            test_circuit, wait, TEST_LOGGER,
+        },
+        Controller, ControllerConfig, ControllerError,
+    };
+    use actix_web::{http::StatusCode, middleware::Logger, test, web::Data as WebData, App};
+    use crossbeam::queue::SegQueue;
+    use log::{error, LevelFilter};
+    use proptest::{
+        strategy::{Strategy, ValueTree},
+        test_runner::TestRunner,
+    };
+    use std::{sync::Arc, thread::sleep, time::Duration};
+
+    #[actix_web::test]
+    async fn test_server() {
+        // We cannot use proptest macros in `async` context, so generate
+        // some random data manually.
+        let mut runner = TestRunner::default();
+        let data = generate_test_batches(100, 1000)
+            .new_tree(&mut runner)
+            .unwrap()
+            .current();
+
+        let _ = log::set_logger(&TEST_LOGGER);
+        log::set_max_level(LevelFilter::Debug);
+
+        // Create topics.
+        let kafka_resources = KafkaResources::create_topics(&[
+            ("test_server_input_topic", 1),
+            ("test_server_output_topic", 1),
+        ]);
+
+        // Create buffer consumer
+        let buffer_consumer = BufferConsumer::new("test_server_output_topic");
+
+        // Config string
+        let config_str = format!(
+            r#"
+inputs:
+    test_input1:
+        transport:
+            name: kafka
+            config:
+                bootstrap.servers: "localhost"
+                auto.offset.reset: "earliest"
+                topics: [test_server_input_topic]
+                log_level: debug
+        format:
+            name: csv
+            config:
+                input_stream: test_input1
+outputs:
+    test_output2:
+        stream: test_output1
+        transport:
+            name: kafka
+            config:
+                bootstrap.servers: "localhost"
+                topic: test_server_output_topic
+                max_inflight_messages: 0
+        format:
+            name: csv
+"#
+        );
+
+        // Create circuit
+        println!("Creating circuit");
+        let (circuit, catalog) = test_circuit(4);
+
+        let errors = Arc::new(SegQueue::new());
+        let errors_clone = errors.clone();
+
+        let config: ControllerConfig = serde_yaml::from_str(&config_str).unwrap();
+        let controller = Controller::with_config(
+            circuit,
+            catalog,
+            &config,
+            Box::new(move |e| {
+                error!("{e}");
+                errors_clone.push(e);
+            }) as Box<dyn Fn(ControllerError) + Send + Sync>,
+        )
+        .unwrap();
+
+        // Create service
+        println!("Creating HTTP server");
+        let state = WebData::new(ServerState::new(controller));
+        let app =
+            test::init_service(build_app(App::new().wrap(Logger::default()), state.clone())).await;
+
+        // Write data to Kafka.
+        println!("Send test data");
+        let producer = TestProducer::new();
+        producer.send_to_topic(&data, "test_server_input_topic");
+
+        sleep(Duration::from_millis(2000));
+        assert!(buffer_consumer.is_empty());
+
+        // Start command; wait for data.
+        println!("/start");
+        let req = test::TestRequest::get().uri("/start").to_request();
+        let resp = test::call_service(&app, req).await;
+        assert!(resp.status().is_success());
+
+        buffer_consumer.wait_for_output_unordered(&data);
+        buffer_consumer.clear();
+
+        // Pause command; send more data, receive none.
+        println!("/pause");
+        let req = test::TestRequest::get().uri("/pause").to_request();
+        let resp = test::call_service(&app, req).await;
+        assert!(resp.status().is_success());
+        sleep(Duration::from_millis(1000));
+
+        producer.send_to_topic(&data, "test_server_input_topic");
+        sleep(Duration::from_millis(2000));
+        assert_eq!(buffer_consumer.len(), 0);
+
+        // Start; wait for data
+        println!("/start");
+        let req = test::TestRequest::get().uri("/start").to_request();
+        let resp = test::call_service(&app, req).await;
+        assert!(resp.status().is_success());
+
+        buffer_consumer.wait_for_output_unordered(&data);
+        buffer_consumer.clear();
+
+        println!("Testing invalid input");
+        producer.send_string("invalid\n", "test_server_input_topic");
+        wait(|| errors.len() == 1, None);
+
+        // Shutdown
+        println!("/shutdown");
+        let req = test::TestRequest::get().uri("/shutdown").to_request();
+        let resp = test::call_service(&app, req).await;
+        // println!("Response: {resp:?}");
+        assert!(resp.status().is_success());
+
+        // Start after shutdown must fail.
+        println!("/start");
+        let req = test::TestRequest::get().uri("/start").to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+
+        drop(buffer_consumer);
+        drop(kafka_resources);
+    }
+}

--- a/adapters/src/server/mod.rs
+++ b/adapters/src/server/mod.rs
@@ -107,7 +107,7 @@ async fn shutdown(state: WebData<ServerState>) -> impl Responder {
 
 #[cfg(test)]
 #[cfg(feature = "with-kafka")]
-mod test {
+mod test_with_kafka {
     use super::{build_app, ServerState};
     use crate::{
         test::{

--- a/adapters/src/test/kafka.rs
+++ b/adapters/src/test/kafka.rs
@@ -1,0 +1,261 @@
+use crate::test::{wait, TestStruct};
+use csv::{ReaderBuilder as CsvReaderBuilder, WriterBuilder as CsvWriterBuilder};
+use futures::executor::block_on;
+use rdkafka::{
+    admin::{AdminClient, AdminOptions, NewPartitions, NewTopic, TopicReplication},
+    client::DefaultClientContext,
+    config::{FromClientConfig, RDKafkaLogLevel},
+    consumer::{BaseConsumer, Consumer},
+    producer::{BaseRecord, DefaultProducerContext, Producer, ThreadedProducer},
+    util::Timeout,
+    ClientConfig, Message,
+};
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
+    thread,
+    thread::JoinHandle,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+pub struct KafkaResources {
+    admin_client: AdminClient<DefaultClientContext>,
+    topics: Vec<String>,
+}
+
+/// An object that creates a couple of topics on startup and deletes them
+/// on drop.  Helps make sure that test runs don't leave garbage behind.
+impl KafkaResources {
+    pub fn create_topics(topics: &[(&str, i32)]) -> Self {
+        let mut admin_config = ClientConfig::new();
+        admin_config
+            .set("bootstrap.servers", "localhost")
+            .set_log_level(RDKafkaLogLevel::Debug);
+        let admin_client = AdminClient::from_config(&admin_config).unwrap();
+
+        let new_topics = topics
+            .iter()
+            .map(|(topic_name, partitions)| {
+                NewTopic::new(topic_name, *partitions, TopicReplication::Fixed(1))
+            })
+            .collect::<Vec<_>>();
+        let topic_names = topics
+            .iter()
+            .map(|(topic_name, _partitions)| &**topic_name)
+            .collect::<Vec<_>>();
+
+        // Delete topics if they exist from previous failed runs that crashed before
+        // cleaning up.  Otherwise, it may take a long time to re-join a
+        // group whose members are dead, plus the old topics may contain
+        // messages that will mess up our tests.
+        let _ = block_on(admin_client.delete_topics(&topic_names, &AdminOptions::new()));
+
+        block_on(admin_client.create_topics(&new_topics, &AdminOptions::new())).unwrap();
+
+        Self {
+            admin_client,
+            topics: topics
+                .iter()
+                .map(|(topic_name, _)| topic_name.to_string())
+                .collect::<Vec<_>>(),
+        }
+    }
+
+    pub fn add_partition(&self, topic: &str) {
+        block_on(
+            self.admin_client
+                .create_partitions(&[NewPartitions::new(topic, 1)], &AdminOptions::new()),
+        )
+        .unwrap();
+    }
+}
+
+impl Drop for KafkaResources {
+    fn drop(&mut self) {
+        let topic_names = self
+            .topics
+            .iter()
+            .map(|topic_name| &**topic_name)
+            .collect::<Vec<_>>();
+        let _ = block_on(
+            self.admin_client
+                .delete_topics(&topic_names, &AdminOptions::new()),
+        );
+    }
+}
+
+pub struct TestProducer {
+    producer: ThreadedProducer<DefaultProducerContext>,
+}
+
+impl Default for TestProducer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TestProducer {
+    pub fn new() -> Self {
+        let mut producer_config = ClientConfig::new();
+        producer_config
+            .set("bootstrap.servers", "localhost")
+            .set("message.timeout.ms", "0") // infinite timeout
+            .set_log_level(RDKafkaLogLevel::Debug);
+        let producer = ThreadedProducer::from_config(&producer_config).unwrap();
+
+        Self { producer }
+    }
+
+    pub fn send_to_topic(&self, data: &[Vec<TestStruct>], topic: &str) {
+        for batch in data {
+            let mut writer = CsvWriterBuilder::new()
+                .has_headers(false)
+                .from_writer(Vec::with_capacity(batch.len() * 32));
+
+            for val in batch.iter().cloned() {
+                writer.serialize(val).unwrap();
+            }
+            writer.flush().unwrap();
+            let bytes = writer.into_inner().unwrap();
+
+            let record = <BaseRecord<(), [u8], ()>>::to(topic).payload(&bytes);
+            self.producer.send(record).unwrap();
+        }
+        // producer.flush(Timeout::Never).unwrap();
+        // println!("Data written to '{topic}'");
+    }
+
+    pub fn send_string(&self, string: &str, topic: &str) {
+        let record = <BaseRecord<(), str, ()>>::to(topic).payload(string);
+        self.producer.send(record).unwrap();
+        self.producer.flush(Timeout::Never).unwrap();
+    }
+}
+
+/// Consumer thread: read from output topic, deserialize to a shared buffer.
+pub struct BufferConsumer {
+    thread_handle: Option<JoinHandle<()>>,
+    buffer: Arc<Mutex<Vec<TestStruct>>>,
+    shutdown_flag: Arc<AtomicBool>,
+}
+
+impl Drop for BufferConsumer {
+    fn drop(&mut self) {
+        self.shutdown_flag.store(true, Ordering::Release);
+        self.thread_handle.take().unwrap().join().unwrap();
+    }
+}
+
+impl BufferConsumer {
+    pub fn new(topic: &str) -> Self {
+        let buffer: Arc<Mutex<Vec<TestStruct>>> = Arc::new(Mutex::new(Vec::new()));
+        let buffer_clone = buffer.clone();
+
+        let shutdown_flag = Arc::new(AtomicBool::new(false));
+        let shutdown_flag_clone = shutdown_flag.clone();
+
+        let topic = topic.to_string();
+
+        // Consumer thread: read from output topic, deserialize to a shared buffer.
+        let thread_handle = thread::Builder::new()
+            .name("test consumer".to_string())
+            .spawn(move || {
+                let group_id = format!(
+                    "test_group_{}",
+                    SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap()
+                        .as_millis()
+                );
+
+                let kafka_consumer = ClientConfig::new()
+                    .set("bootstrap.servers", "localhost")
+                    .set("enable.auto.commit", "true")
+                    .set("enable.auto.offset.store", "true")
+                    .set("auto.offset.reset", "earliest")
+                    .set("group.id", &group_id)
+                    .create::<BaseConsumer>()
+                    .unwrap();
+
+                kafka_consumer.subscribe(&[&topic]).unwrap();
+
+                loop {
+                    if shutdown_flag_clone.load(Ordering::Acquire) {
+                        return;
+                    }
+
+                    match kafka_consumer.poll(Duration::from_millis(100)) {
+                        None => {
+                            // println!("poll returned None");
+                        }
+                        Some(Err(e)) => {
+                            panic!("poll returned error: {e}");
+                        }
+                        Some(Ok(message)) => {
+                            // println!("received {} bytes", message.payload().unwrap().len());
+                            // message.payload().map(|payload| consumer.input(payload));
+
+                            if let Some(payload) = message.payload() {
+                                let mut builder = CsvReaderBuilder::new();
+                                builder.has_headers(false);
+                                let mut reader = builder.from_reader(payload);
+                                let mut buffer = buffer_clone.lock().unwrap();
+                                // let mut num_received = 0;
+                                for (record, w) in reader
+                                    .deserialize::<(TestStruct, i32)>()
+                                    .map(Result::unwrap)
+                                {
+                                    // num_received += 1;
+                                    assert_eq!(w, 1);
+                                    // println!("received record: {:?}", record);
+                                    buffer.push(record);
+                                }
+                                // println!("received {num_received} records");
+                            }
+                        }
+                    }
+                }
+            })
+            .unwrap();
+
+        Self {
+            thread_handle: Some(thread_handle),
+            buffer,
+            shutdown_flag,
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn len(&self) -> usize {
+        self.buffer.lock().unwrap().len()
+    }
+
+    pub fn clear(&self) {
+        self.buffer.lock().unwrap().clear()
+    }
+
+    pub fn wait_for_output_unordered(&self, data: &[Vec<TestStruct>]) {
+        let num_records: usize = data.iter().map(Vec::len).sum();
+
+        // println!("waiting for {num_records} records");
+        wait(|| self.len() == num_records, None);
+        //println!("{num_records} records received: {:?}",
+        // received_data.lock().unwrap().iter().map(|r| r.id).collect::<Vec<_>>());
+
+        let mut expected = data
+            .iter()
+            .flat_map(|data| data.iter())
+            .cloned()
+            .collect::<Vec<_>>();
+        expected.sort();
+
+        let mut received = self.buffer.lock().unwrap().clone();
+        received.sort();
+        assert_eq!(expected, received);
+    }
+}

--- a/adapters/src/test/mock_dezset.rs
+++ b/adapters/src/test/mock_dezset.rs
@@ -15,6 +15,12 @@ pub struct MockDeZSetState<T> {
     pub flushed: Vec<(T, bool)>,
 }
 
+impl<T> Default for MockDeZSetState<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T> MockDeZSetState<T> {
     pub fn new() -> Self {
         Self {
@@ -31,6 +37,12 @@ impl<T> MockDeZSetState<T> {
 }
 
 pub struct MockDeZSet<T>(Arc<Mutex<MockDeZSetState<T>>>);
+
+impl<T> Default for MockDeZSet<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 /// Mock implementation of `DeCollectionHandle`.
 impl<T> Clone for MockDeZSet<T> {

--- a/adapters/src/test/mod.rs
+++ b/adapters/src/test/mod.rs
@@ -2,6 +2,7 @@
 
 use crate::{controller::InputEndpointConfig, Catalog, InputEndpoint, InputTransport};
 use dbsp::{DBSPHandle, Runtime};
+use log::{Log, Metadata, Record};
 use serde::Deserialize;
 use std::{
     sync::{Arc, Mutex},
@@ -10,12 +11,30 @@ use std::{
 };
 
 mod data;
+
+#[cfg(feature = "with-kafka")]
+pub mod kafka;
 mod mock_dezset;
 mod mock_input_consumer;
 
 pub use data::{generate_test_batch, generate_test_batches, TestStruct};
 pub use mock_dezset::MockDeZSet;
 pub use mock_input_consumer::MockInputConsumer;
+
+pub struct TestLogger;
+pub static TEST_LOGGER: TestLogger = TestLogger;
+
+impl Log for TestLogger {
+    fn enabled(&self, _metadata: &Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record) {
+        println!("{} - {}", record.level(), record.args());
+    }
+
+    fn flush(&self) {}
+}
 
 /// Wait for `predicate` to become `true`.
 ///

--- a/adapters/src/transport/kafka/mod.rs
+++ b/adapters/src/transport/kafka/mod.rs
@@ -5,7 +5,7 @@ mod input;
 mod output;
 
 #[cfg(test)]
-mod test;
+pub mod test;
 
 pub use input::KafkaInputTransport;
 pub use output::KafkaOutputTransport;

--- a/adapters/src/transport/kafka/test.rs
+++ b/adapters/src/transport/kafka/test.rs
@@ -1,134 +1,14 @@
 use crate::{
     test::{
-        generate_test_batches, mock_input_pipeline, test_circuit, wait, MockDeZSet, TestStruct,
+        generate_test_batches,
+        kafka::{BufferConsumer, KafkaResources, TestProducer},
+        mock_input_pipeline, test_circuit, wait, MockDeZSet, TestStruct, TEST_LOGGER,
     },
     Controller, ControllerConfig,
 };
-use csv::{ReaderBuilder as CsvReaderBuilder, WriterBuilder as CsvWriterBuilder};
-use futures::executor::block_on;
-use log::{LevelFilter, Log, Metadata, Record};
+use log::LevelFilter;
 use proptest::prelude::*;
-use rdkafka::{
-    admin::{AdminClient, AdminOptions, NewPartitions, NewTopic, TopicReplication},
-    client::DefaultClientContext,
-    config::{FromClientConfig, RDKafkaLogLevel},
-    consumer::{BaseConsumer, Consumer},
-    producer::{BaseRecord, DefaultProducerContext, ThreadedProducer},
-    ClientConfig, Message,
-};
-use std::{
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc, Mutex,
-    },
-    thread,
-    thread::sleep,
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
-
-struct TestLogger;
-static TEST_LOGGER: TestLogger = TestLogger;
-
-impl Log for TestLogger {
-    fn enabled(&self, _metadata: &Metadata) -> bool {
-        true
-    }
-
-    fn log(&self, record: &Record) {
-        println!("{} - {}", record.level(), record.args());
-    }
-
-    fn flush(&self) {}
-}
-
-struct KafkaResources {
-    admin_client: AdminClient<DefaultClientContext>,
-    topics: Vec<String>,
-}
-
-/// An object that creates a couple of topics on startup and deletes them
-/// on drop.  Helps make sure that test runs don't leave garbage behind.
-impl KafkaResources {
-    fn create_topics(topics: &[(&str, i32)]) -> Self {
-        let mut admin_config = ClientConfig::new();
-        admin_config
-            .set("bootstrap.servers", "localhost")
-            .set_log_level(RDKafkaLogLevel::Debug);
-        let admin_client = AdminClient::from_config(&admin_config).unwrap();
-
-        let new_topics = topics
-            .iter()
-            .map(|(topic_name, partitions)| {
-                NewTopic::new(topic_name, *partitions, TopicReplication::Fixed(1))
-            })
-            .collect::<Vec<_>>();
-        let topic_names = topics
-            .iter()
-            .map(|(topic_name, _partitions)| &**topic_name)
-            .collect::<Vec<_>>();
-
-        // Delete topics if they exist from previous failed runs that crashed before
-        // cleaning up.  Otherwise, it may take a long time to re-join a
-        // group whose members are dead, plus the old topics may contain
-        // messages that will mess up our tests.
-        let _ = block_on(admin_client.delete_topics(&topic_names, &AdminOptions::new()));
-
-        block_on(admin_client.create_topics(&new_topics, &AdminOptions::new())).unwrap();
-
-        Self {
-            admin_client,
-            topics: topics
-                .iter()
-                .map(|(topic_name, _)| topic_name.to_string())
-                .collect::<Vec<_>>(),
-        }
-    }
-
-    fn add_partition(&self, topic: &str) {
-        block_on(
-            self.admin_client
-                .create_partitions(&[NewPartitions::new(topic, 1)], &AdminOptions::new()),
-        )
-        .unwrap();
-    }
-}
-
-impl Drop for KafkaResources {
-    fn drop(&mut self) {
-        let topic_names = self
-            .topics
-            .iter()
-            .map(|topic_name| &**topic_name)
-            .collect::<Vec<_>>();
-        let _ = block_on(
-            self.admin_client
-                .delete_topics(&topic_names, &AdminOptions::new()),
-        );
-    }
-}
-
-fn send_to_topic(
-    producer: &ThreadedProducer<DefaultProducerContext>,
-    data: &[Vec<TestStruct>],
-    topic: &str,
-) {
-    for batch in data {
-        let mut writer = CsvWriterBuilder::new()
-            .has_headers(false)
-            .from_writer(Vec::with_capacity(batch.len() * 32));
-
-        for val in batch.iter().cloned() {
-            writer.serialize(val).unwrap();
-        }
-        writer.flush().unwrap();
-        let bytes = writer.into_inner().unwrap();
-
-        let record = <BaseRecord<(), [u8], ()>>::to(topic).payload(&bytes);
-        producer.send(record).unwrap();
-    }
-    // producer.flush(Timeout::Never).unwrap();
-    println!("Data written to '{topic}'");
-}
+use std::{thread::sleep, time::Duration};
 
 /// Wait to receive all records in `data` in the same order.
 fn wait_for_output_ordered(zset: &MockDeZSet<TestStruct>, data: &[Vec<TestStruct>]) {
@@ -205,18 +85,13 @@ format:
 
         endpoint.start().unwrap();
 
-        let mut producer_config = ClientConfig::new();
-        producer_config
-            .set("bootstrap.servers", "localhost")
-            .set("message.timeout.ms", "0") // infinite timeout
-            .set_log_level(RDKafkaLogLevel::Debug);
-        let producer = ThreadedProducer::from_config(&producer_config)?;
+        let producer = TestProducer::new();
 
         println!("Test: Receive from a topic with a single partition");
 
         // Send data to a topic with a single partition;
         // Make sure all records arrive in the original order.
-        send_to_topic(&producer, &data, "input_test_topic1");
+        producer.send_to_topic(&data, "input_test_topic1");
 
         wait_for_output_ordered(&zset, &data);
         zset.reset();
@@ -225,7 +100,7 @@ format:
 
         // Send data to a topic with multiple partitions.
         // Make sure all records are delivered, but not necessarily in the original order.
-        send_to_topic(&producer, &data, "input_test_topic2");
+        producer.send_to_topic(&data, "input_test_topic2");
 
         wait_for_output_unordered(&zset, &data);
         zset.reset();
@@ -239,7 +114,7 @@ format:
 
         kafka_resources.add_partition("input_test_topic2");
 
-        send_to_topic(&producer, &data, "input_test_topic2");
+        producer.send_to_topic(&data, "input_test_topic2");
         sleep(Duration::from_millis(1000));
         assert_eq!(zset.state().flushed.len(), 0);
 
@@ -254,7 +129,7 @@ format:
         endpoint.disconnect();
         sleep(Duration::from_millis(1000));
 
-        send_to_topic(&producer, &data, "input_test_topic2");
+        producer.send_to_topic(&data, "input_test_topic2");
         sleep(Duration::from_millis(1000));
         assert_eq!(zset.state().flushed.len(), 0);
 
@@ -318,99 +193,19 @@ outputs:
                 Box::new(|e| panic!("error: {e}"))
             ).unwrap();
 
-            let received_data: Arc<Mutex<Vec<TestStruct>>> = Arc::new(Mutex::new(Vec::new()));
-            let received_data_clone = received_data.clone();
+            let buffer_consumer = BufferConsumer::new("end_to_end_test_output_topic");
 
-            let shutdown_flag = Arc::new(AtomicBool::new(false));
-            let shutdown_flag_clone = shutdown_flag.clone();
-
-            // Consumer thread: read from output topic, deserialize to a shared buffer.
-            let consumer_handle = thread::Builder::new().name("test consumer".to_string()).spawn(move || {
-                let group_id = format!(
-                    "test_group_{}",
-                    SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap()
-                        .as_millis()
-                );
-
-                let kafka_consumer = ClientConfig::new()
-                    .set("bootstrap.servers", "localhost")
-                    .set("enable.auto.commit", "true")
-                    .set("enable.auto.offset.store", "true")
-                    .set("auto.offset.reset", "earliest")
-                    .set("group.id", &group_id)
-                    .create::<BaseConsumer>()
-                    .unwrap();
-
-                kafka_consumer.subscribe(&["end_to_end_test_output_topic"]).unwrap();
-
-                loop {
-                    if shutdown_flag_clone.load(Ordering::Acquire) {
-                        return;
-                    }
-
-                    match kafka_consumer.poll(Duration::from_millis(100)) {
-                        None => {
-                            // println!("poll returned None");
-                        }
-                        Some(Err(e)) => {
-                            panic!("poll returned error: {e}");
-                        }
-                        Some(Ok(message)) => {
-                            // println!("received {} bytes", message.payload().unwrap().len());
-                            // message.payload().map(|payload| consumer.input(payload));
-
-                            if let Some(payload) = message.payload() {
-                                let mut builder = CsvReaderBuilder::new();
-                                builder.has_headers(false);
-                                let mut reader = builder.from_reader(payload);
-                                let mut received_data = received_data_clone.lock().unwrap();
-                                // let mut num_received = 0;
-                                for (record, w) in reader.deserialize::<(TestStruct, i32)>().map(Result::unwrap) {
-                                    // num_received += 1;
-                                    assert_eq!(w, 1);
-                                    // println!("received record: {:?}", record);
-                                    received_data.push(record);
-                                }
-                                // println!("received {num_received} records");
-                            }
-                        }
-                    }
-                }
-
-            }).unwrap();
-
-            // Producer: write `data` to input topic.
-            let kafka_producer = ClientConfig::new()
-                .set("bootstrap.servers", "localhost")
-                .set("message.timeout.ms", "0") // infinite timeout
-                .create::<ThreadedProducer<_>>()
-                .unwrap();
-
-            send_to_topic(&kafka_producer, &data, "end_to_end_test_input_topic");
+            let producer = TestProducer::new();
+            producer.send_to_topic(&data, "end_to_end_test_input_topic");
 
             // Start controller.
             controller.start();
 
             // Wait for output buffer to contain all of `data`.
-            {
-                let num_records: usize = data.iter().map(Vec::len).sum();
 
-                println!("waiting for {num_records} records");
-                wait(|| received_data.lock().unwrap().len() == num_records, None);
-                //println!("{num_records} records received: {:?}", received_data.lock().unwrap().iter().map(|r| r.id).collect::<Vec<_>>());
+            buffer_consumer.wait_for_output_unordered(&data);
 
-                let mut expected = data.iter().flat_map(|data| data.iter()).cloned().collect::<Vec<_>>();
-                expected.sort();
-
-                let mut received = received_data.lock().unwrap().clone();
-                received.sort();
-                assert_eq!(expected, received);
-            }
-
-            shutdown_flag.store(true, Ordering::Release);
-            consumer_handle.join().unwrap();
+            drop(buffer_consumer);
 
             controller.stop().unwrap();
             sleep(Duration::from_millis(100));

--- a/adapters/static/index.html
+++ b/adapters/static/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head>
+    <title>DBSP server</title>
+  </head>
+  <body>
+      <ul>
+          <li><a href="/start">start</a></li>
+          <li><a href="/pause">pause</a></li>
+          <li><a href="/shutdown">shutdown</a></li>
+      </ul>
+  </body>
+</html>

--- a/adapters/static/test.html
+++ b/adapters/static/test.html
@@ -1,0 +1,1 @@
+Hello, world

--- a/doc/self_hosted_ci_config.md
+++ b/doc/self_hosted_ci_config.md
@@ -7,6 +7,12 @@ machine.
 
 ```bash
 sudo apt-get install libssl-dev zsh build-essential pkg-config git gcc clang libclang-dev python3-pip hub numactl cmake
+
+# Install RedPanda (see https://docs.redpanda.com/docs/platform/quickstart/)
+curl -1sLf 'https://dl.redpanda.com/nzc4ZYQK3WRGd9sy/redpanda/cfg/setup/bash.deb.sh' | sudo -E bash && \
+sudo apt install redpanda -y && \
+sudo systemctl start redpanda
+
 sudo useradd github-runner -m -s /bin/zsh
 ```
 

--- a/src/monitor/mod.rs
+++ b/src/monitor/mod.rs
@@ -93,8 +93,7 @@ impl Display for TraceError {
             Self::NotACircuit(node) => write!(f, "not a circuit node {node}"),
             Self::NodeOutsideCurrentScope(node, scope) => write!(
                 f,
-                "node id {} does not belong to the current scope {}",
-                node, scope
+                "node id {node} does not belong to the current scope {scope}",
             ),
             Self::UnexpectedNodeId => {
                 f.write_str("node id is not valid for this event type in the current state")
@@ -507,8 +506,7 @@ impl TraceMonitorInternal {
                     CircuitState::Step(visited_nodes) => {
                         if visited_nodes.contains(&local_node_id) {
                             return Err(TraceError::InvalidEvent(Cow::from(format!(
-                                "node id {} evaluated twice in one clock cycle",
-                                local_node_id
+                                "node id {local_node_id} evaluated twice in one clock cycle",
                             ))));
                         }
                         let global_id = node.global_id();


### PR DESCRIPTION
A server that allows managing a DBSP circuit via HTTP.  Only the
following commands are currently implemented:

- `/start` - start pipeline
- `/pause` - pause pipeline
- `/shutdown` - destroy the pipeline
- `index.html` - serve static `index.html` file.
- `static/filename` - serve files from the `static` directory (which
  will need to be distributed with the server).

TODOs:
- API to retrieve circuit configuration (input/output endpoints)
- API to retrieve endpoint status and statistics
- Support for grafana or similar dashboard.