### PR TITLE
Add `finalize` step to the `Aggregator` trait.

### DIFF
--- a/src/operator/aggregate/max.rs
+++ b/src/operator/aggregate/max.rs
@@ -28,11 +28,12 @@ where
     T: Timestamp,
     R: MonoidValue,
 {
+    type Accumulator = V;
     type Output = V;
     type Semigroup = MaxSemigroup<V>;
 
     // TODO: this can be more efficient with reverse iterator.
-    fn aggregate<'s, C>(&self, cursor: &mut C) -> Option<Self::Output>
+    fn aggregate<'s, C>(&self, cursor: &mut C) -> Option<Self::Accumulator>
     where
         C: Cursor<'s, V, (), T, R>,
     {
@@ -51,5 +52,9 @@ where
         }
 
         result
+    }
+
+    fn finalize(&self, accumulator: Self::Accumulator) -> Self::Output {
+        accumulator
     }
 }

--- a/src/operator/aggregate/min.rs
+++ b/src/operator/aggregate/min.rs
@@ -30,6 +30,7 @@ where
     T: Timestamp,
     R: MonoidValue,
 {
+    type Accumulator = V;
     type Output = V;
     type Semigroup = MinSemigroup<V>;
 
@@ -52,5 +53,9 @@ where
         }
 
         None
+    }
+
+    fn finalize(&self, accumulator: Self::Accumulator) -> Self::Output {
+        accumulator
     }
 }

--- a/src/operator/time_series/radix_tree/partitioned_tree_aggregate.rs
+++ b/src/operator/time_series/radix_tree/partitioned_tree_aggregate.rs
@@ -115,15 +115,15 @@ where
     pub fn partitioned_tree_aggregate<TS, V, Agg>(
         &self,
         aggregator: Agg,
-    ) -> OrdPartitionedRadixTreeStream<Z::Key, TS, Agg::Output, isize>
+    ) -> OrdPartitionedRadixTreeStream<Z::Key, TS, Agg::Accumulator, isize>
     where
         Z: PartitionedIndexedZSet<TS, V> + SizeOf,
         TS: DBData + PrimInt,
         V: DBData,
         Agg: Aggregator<V, (), Z::R>,
-        Agg::Output: Default,
+        Agg::Accumulator: Default,
     {
-        self.partitioned_tree_aggregate_generic::<TS, V, Agg, OrdPartitionedRadixTree<Z::Key, TS, Agg::Output, isize>>(
+        self.partitioned_tree_aggregate_generic::<TS, V, Agg, OrdPartitionedRadixTree<Z::Key, TS, Agg::Accumulator, isize>>(
             aggregator,
         )
     }
@@ -139,8 +139,8 @@ where
         TS: DBData + PrimInt,
         V: DBData,
         Agg: Aggregator<V, (), Z::R>,
-        Agg::Output: Default,
-        O: PartitionedRadixTreeBatch<TS, Agg::Output, Key = Z::Key>,
+        Agg::Accumulator: Default,
+        O: PartitionedRadixTreeBatch<TS, Agg::Accumulator, Key = Z::Key>,
         O::R: ZRingValue,
     {
         self.circuit()
@@ -345,10 +345,10 @@ where
     TS: DBData + PrimInt,
     V: DBData,
     IT: PartitionedBatchReader<TS, V, Key = Z::Key, R = Z::R> + Clone,
-    OT: PartitionedRadixTreeReader<TS, Agg::Output, Key = Z::Key, R = O::R> + Clone,
+    OT: PartitionedRadixTreeReader<TS, Agg::Accumulator, Key = Z::Key, R = O::R> + Clone,
     Agg: Aggregator<V, (), Z::R>,
-    Agg::Output: Default,
-    O: PartitionedRadixTreeBatch<TS, Agg::Output, Key = Z::Key>,
+    Agg::Accumulator: Default,
+    O: PartitionedRadixTreeBatch<TS, Agg::Accumulator, Key = Z::Key>,
     O::R: ZRingValue,
 {
     fn eval<'a>(

--- a/src/operator/time_series/radix_tree/tree_aggregate.rs
+++ b/src/operator/time_series/radix_tree/tree_aggregate.rs
@@ -55,14 +55,16 @@ where
     pub fn tree_aggregate<Agg>(
         &self,
         aggregator: Agg,
-    ) -> Stream<Circuit<P>, OrdRadixTree<Z::Key, Agg::Output, isize>>
+    ) -> Stream<Circuit<P>, OrdRadixTree<Z::Key, Agg::Accumulator, isize>>
     where
         Z: IndexedZSet + SizeOf + NumEntries + Send,
         Z::Key: PrimInt,
         Agg: Aggregator<Z::Val, (), Z::R>,
-        Agg::Output: Default,
+        Agg::Accumulator: Default,
     {
-        self.tree_aggregate_generic::<Agg, OrdRadixTree<Z::Key, Agg::Output, isize>>(aggregator)
+        self.tree_aggregate_generic::<Agg, OrdRadixTree<Z::Key, Agg::Accumulator, isize>>(
+            aggregator,
+        )
     }
 
     /// Like [`Self::tree_aggregate`], but can return any batch type.
@@ -71,8 +73,8 @@ where
         Z: IndexedZSet + SizeOf + NumEntries + Send,
         Z::Key: PrimInt,
         Agg: Aggregator<Z::Val, (), Z::R>,
-        Agg::Output: Default,
-        O: RadixTreeBatch<Z::Key, Agg::Output>,
+        Agg::Accumulator: Default,
+        O: RadixTreeBatch<Z::Key, Agg::Accumulator>,
         O::R: ZRingValue,
     {
         self.circuit()
@@ -186,10 +188,10 @@ where
     Z: IndexedZSet,
     Z::Key: PrimInt,
     IT: BatchReader<Key = Z::Key, Val = Z::Val, Time = (), R = Z::R> + Clone,
-    OT: RadixTreeReader<Z::Key, Agg::Output, R = O::R> + Clone,
+    OT: RadixTreeReader<Z::Key, Agg::Accumulator, R = O::R> + Clone,
     Agg: Aggregator<Z::Val, (), Z::R>,
-    Agg::Output: Default,
-    O: RadixTreeBatch<Z::Key, Agg::Output>,
+    Agg::Accumulator: Default,
+    O: RadixTreeBatch<Z::Key, Agg::Accumulator>,
     O::R: ZRingValue,
 {
     fn eval<'a>(

--- a/src/operator/time_series/radix_tree/updater.rs
+++ b/src/operator/time_series/radix_tree/updater.rs
@@ -369,19 +369,19 @@ pub(super) fn radix_tree_update<'a, 'b, TS, V, R, Agg, UC, IC, TC, OR>(
     mut input: IC,
     tree: TC,
     aggregator: &Agg,
-    output_updates: &'a mut Vec<TreeNodeUpdate<TS, Agg::Output>>,
+    output_updates: &'a mut Vec<TreeNodeUpdate<TS, Agg::Accumulator>>,
 ) where
     TS: PrimInt + Debug,
     R: MonoidValue,
     Agg: Aggregator<V, (), R>,
-    Agg::Output: Clone + Default + Eq + Debug,
+    Agg::Accumulator: Clone + Default + Eq + Debug,
     UC: Cursor<'b, TS, V, (), R>,
     IC: Cursor<'b, TS, V, (), R>,
-    TC: RadixTreeCursor<'b, TS, Agg::Output, OR>,
+    TC: RadixTreeCursor<'b, TS, Agg::Accumulator, OR>,
     OR: MonoidValue,
 {
     let mut tree_updater =
-        <TreeUpdater<'a, TS, Agg::Output, OR, Agg::Semigroup, TC>>::new(tree, output_updates);
+        <TreeUpdater<'a, TS, Agg::Accumulator, OR, Agg::Semigroup, TC>>::new(tree, output_updates);
 
     while input_delta.key_valid() {
         //println!("affected key {:x?}", input_delta.key());

--- a/src/operator/time_series/rolling_aggregate.rs
+++ b/src/operator/time_series/rolling_aggregate.rs
@@ -1,7 +1,5 @@
 use crate::{
-    algebra::{
-        DefaultSemigroup, GroupValue, HasOne, HasZero, IndexedZSet, MulByRef, Semigroup, ZRingValue,
-    },
+    algebra::{DefaultSemigroup, GroupValue, HasOne, HasZero, IndexedZSet, MulByRef, ZRingValue},
     circuit::{
         operator_traits::{Operator, QuaternaryOperator},
         OwnershipPreference, Scope,
@@ -35,40 +33,47 @@ pub type OrdPartitionedOverStream<PK, TS, A, R> =
 // for linear aggregates (specifically, updating a node when only
 // some of its children have changed can be done without computing
 // the sum of all children from scratch).
-struct LinearAggregator<V, R, A, F> {
+struct LinearAggregator<V, R, A, O, F, OF> {
     f: F,
-    phantom: PhantomData<(V, R, A)>,
+    output_func: OF,
+    phantom: PhantomData<(V, R, A, O)>,
 }
 
-impl<V, R, A, F> Clone for LinearAggregator<V, R, A, F>
+impl<V, R, A, O, F, OF> Clone for LinearAggregator<V, R, A, O, F, OF>
 where
     F: Clone,
+    OF: Clone,
 {
     fn clone(&self) -> Self {
         Self {
             f: self.f.clone(),
+            output_func: self.output_func.clone(),
             phantom: PhantomData,
         }
     }
 }
 
-impl<V, R, A, F> LinearAggregator<V, R, A, F> {
-    fn new(f: F) -> Self {
+impl<V, R, A, O, F, OF> LinearAggregator<V, R, A, O, F, OF> {
+    fn new(f: F, output_func: OF) -> Self {
         Self {
             f,
+            output_func,
             phantom: PhantomData,
         }
     }
 }
 
-impl<V, R, A, F> Aggregator<V, (), R> for LinearAggregator<V, R, A, F>
+impl<V, R, A, O, F, OF> Aggregator<V, (), R> for LinearAggregator<V, R, A, O, F, OF>
 where
     V: DBData,
     R: DBWeight + ZRingValue,
     A: DBData + MulByRef<R, Output = A> + GroupValue,
+    O: DBData,
     F: Fn(&V) -> A + Clone + 'static,
+    OF: Fn(A) -> O + Clone + 'static,
 {
-    type Output = A;
+    type Accumulator = A;
+    type Output = O;
 
     type Semigroup = DefaultSemigroup<A>;
 
@@ -88,6 +93,10 @@ where
             cursor.step_key();
         }
         res
+    }
+
+    fn finalize(&self, accumulator: Self::Accumulator) -> Self::Output {
+        (self.output_func)(accumulator)
     }
 }
 
@@ -112,7 +121,7 @@ impl<B> Stream<Circuit<()>, B> {
         B: PartitionedIndexedZSet<TS, V>,
         B::R: ZRingValue,
         Agg: Aggregator<V, (), B::R>,
-        Agg::Output: Default,
+        Agg::Accumulator: Default,
         TS: DBData + PrimInt,
         V: DBData,
     {
@@ -130,7 +139,7 @@ impl<B> Stream<Circuit<()>, B> {
         B: PartitionedIndexedZSet<TS, V>,
         B::R: ZRingValue,
         Agg: Aggregator<V, (), B::R>,
-        Agg::Output: Default,
+        Agg::Accumulator: Default,
         O: PartitionedIndexedZSet<TS, Option<Agg::Output>, Key = B::Key, R = B::R>,
         TS: DBData + PrimInt,
         V: DBData,
@@ -154,7 +163,7 @@ impl<B> Stream<Circuit<()>, B> {
             let stream = self.shard();
 
             let tree = stream
-                .partitioned_tree_aggregate::<TS, V, Agg>(aggregator)
+                .partitioned_tree_aggregate::<TS, V, Agg>(aggregator.clone())
                 .integrate_trace();
             let input_trace = stream.integrate_trace();
 
@@ -164,7 +173,7 @@ impl<B> Stream<Circuit<()>, B> {
 
             let output = circuit
                 .add_quaternary_operator(
-                    <PartitionedRollingAggregate<TS, Agg::Semigroup, V>>::new(range),
+                    <PartitionedRollingAggregate<TS, V, Agg>>::new(range, aggregator),
                     &stream,
                     &input_trace,
                     &tree,
@@ -205,40 +214,46 @@ impl<B> Stream<Circuit<()>, B> {
     /// This method only works for linear aggregation functions `f`, i.e.,
     /// functions that satisfy `f(a+b) = f(a) + f(b)`.  It will produce
     /// incorrect results if `f` is not linear.
-    pub fn partitioned_rolling_aggregate_linear<TS, V, F, A>(
+    pub fn partitioned_rolling_aggregate_linear<TS, V, A, O, F, OF>(
         &self,
         f: F,
+        output_func: OF,
         range: RelRange<TS>,
-    ) -> OrdPartitionedOverStream<B::Key, TS, A, B::R>
+    ) -> OrdPartitionedOverStream<B::Key, TS, O, B::R>
     where
         B: PartitionedIndexedZSet<TS, V>,
         B::R: ZRingValue,
         A: DBData + MulByRef<B::R, Output = A> + GroupValue + Default,
         F: Fn(&V) -> A + Clone + 'static,
+        OF: Fn(A) -> O + Clone + 'static,
         TS: DBData + PrimInt,
         V: DBData,
+        O: DBData,
     {
-        let aggregator = LinearAggregator::new(f);
+        let aggregator = LinearAggregator::new(f, output_func);
         self.partitioned_rolling_aggregate_generic::<TS, V, _, _>(aggregator, range)
     }
 
     /// Like [`Self::partitioned_rolling_aggregate_linear`], but can return any
     /// batch type.
-    pub fn partitioned_rolling_aggregate_linear_generic<TS, V, F, A, O>(
+    pub fn partitioned_rolling_aggregate_linear_generic<TS, V, A, O, F, OF, Out>(
         &self,
         f: F,
+        output_func: OF,
         range: RelRange<TS>,
-    ) -> Stream<Circuit<()>, O>
+    ) -> Stream<Circuit<()>, Out>
     where
         B: PartitionedIndexedZSet<TS, V>,
         B::R: ZRingValue,
         A: DBData + MulByRef<B::R, Output = A> + GroupValue + Default,
         F: Fn(&V) -> A + Clone + 'static,
+        OF: Fn(A) -> O + Clone + 'static,
         TS: DBData + PrimInt,
         V: DBData,
-        O: PartitionedIndexedZSet<TS, Option<A>, Key = B::Key, R = B::R>,
+        O: DBData,
+        Out: PartitionedIndexedZSet<TS, Option<O>, Key = B::Key, R = B::R>,
     {
-        let aggregator = LinearAggregator::new(f);
+        let aggregator = LinearAggregator::new(f, output_func);
         self.partitioned_rolling_aggregate_generic::<TS, V, _, _>(aggregator, range)
     }
 }
@@ -246,22 +261,24 @@ impl<B> Stream<Circuit<()>, B> {
 /// Quaternary operator that implements the internals of
 /// `partitioned_rolling_aggregate`.
 ///
-/// * Input stream 1: updates to the time series.  Uused to identify affected
+/// * Input stream 1: updates to the time series.  Used to identify affected
 ///   partitions and times.
 /// * Input stream 2: trace containing the accumulated time series data.
 /// * Input stream 3: trace containing the partitioned radix tree over the input
 ///   time series.
 /// * Input stream 4: trace of previously produced outputs.  Used to compute
 ///   retractions.
-struct PartitionedRollingAggregate<TS, S, V> {
+struct PartitionedRollingAggregate<TS, V, Agg> {
     range: RelRange<TS>,
-    phantom: PhantomData<(S, V)>,
+    aggregator: Agg,
+    phantom: PhantomData<V>,
 }
 
-impl<TS, S, V> PartitionedRollingAggregate<TS, S, V> {
-    fn new(range: RelRange<TS>) -> Self {
+impl<TS, V, Agg> PartitionedRollingAggregate<TS, V, Agg> {
+    fn new(range: RelRange<TS>, aggregator: Agg) -> Self {
         Self {
             range,
+            aggregator,
             phantom: PhantomData,
         }
     }
@@ -289,11 +306,11 @@ impl<TS, S, V> PartitionedRollingAggregate<TS, S, V> {
     }
 }
 
-impl<TS, S, V> Operator for PartitionedRollingAggregate<TS, S, V>
+impl<TS, V, Agg> Operator for PartitionedRollingAggregate<TS, V, Agg>
 where
     TS: 'static,
-    S: 'static,
     V: 'static,
+    Agg: 'static,
 {
     fn name(&self) -> Cow<'static, str> {
         Cow::from("PartitionedRollingAggregate")
@@ -304,19 +321,18 @@ where
     }
 }
 
-impl<TS, V, A, S, B, T, RT, OT, O> QuaternaryOperator<B, T, RT, OT, O>
-    for PartitionedRollingAggregate<TS, S, V>
+impl<TS, V, Agg, B, T, RT, OT, O> QuaternaryOperator<B, T, RT, OT, O>
+    for PartitionedRollingAggregate<TS, V, Agg>
 where
     TS: DBData + PrimInt,
     V: DBData,
-    A: DBData,
-    S: Semigroup<A> + 'static,
+    Agg: Aggregator<V, (), B::R>,
     B: PartitionedBatchReader<TS, V> + Clone,
     B::R: ZRingValue,
     T: PartitionedBatchReader<TS, V, Key = B::Key, R = B::R> + Clone,
-    RT: PartitionedRadixTreeReader<TS, A, Key = B::Key> + Clone,
-    OT: PartitionedBatchReader<TS, Option<A>, Key = B::Key, R = B::R> + Clone,
-    O: IndexedZSet<Key = B::Key, Val = (TS, Option<A>), R = B::R>,
+    RT: PartitionedRadixTreeReader<TS, Agg::Accumulator, Key = B::Key> + Clone,
+    OT: PartitionedBatchReader<TS, Option<Agg::Output>, Key = B::Key, R = B::R> + Clone,
+    O: IndexedZSet<Key = B::Key, Val = (TS, Option<Agg::Output>), R = B::R>,
 {
     fn eval<'a>(
         &mut self,
@@ -406,7 +422,9 @@ where
                     while input_range_cursor.val_valid() {
                         // Generate output update.
                         if !input_range_cursor.weight().le0() {
-                            let agg = tree_partition_cursor.aggregate_range::<S>(&range);
+                            let agg = tree_partition_cursor
+                                .aggregate_range::<Agg::Semigroup>(&range)
+                                .map(|acc| self.aggregator.finalize(acc));
                             // println!("key: {:?}, range: {:?}, agg: {:?}",
                             // input_range_cursor.key(), range, agg);
 
@@ -546,7 +564,11 @@ mod test {
             });
 
             let output_1000_0_linear = input_stream
-                .partitioned_rolling_aggregate_linear::<u64, i64, _, _>(|v| *v, range_spec)
+                .partitioned_rolling_aggregate_linear::<u64, i64, _, _, _, _>(
+                    |v| *v,
+                    |v| v,
+                    range_spec,
+                )
                 .gather(0)
                 .integrate();
             expected_1000_0.apply2(&output_1000_0_linear, |expected, actual| {
@@ -568,7 +590,11 @@ mod test {
             });
 
             let output_500_500_linear = input_stream
-                .partitioned_rolling_aggregate_linear::<u64, i64, _, _>(|v| *v, range_spec)
+                .partitioned_rolling_aggregate_linear::<u64, i64, _, _, _, _>(
+                    |v| *v,
+                    |v| v,
+                    range_spec,
+                )
                 .gather(0)
                 .integrate();
             expected_500_500.apply2(&output_500_500_linear, |expected, actual| {


### PR DESCRIPTION
A recent extension of the `Aggregator` trait requires aggregated values to form a semigroup, which is not the case for instance for the AVG aggregate.  The standard solution is to use an intermediate representation of the aggregate that forms a semigroup and only compute the actual value of the aggregate after all partitions have been combined.

To support such aggregates we extend the `Aggregator` trait with the `Accumulator` associated type returned by `aggregate`, which must implement `trait Semigroup`.  The
`Aggregator::Output` associated type represents the final output of the aggregator computed by applying the `finalize` method to the final value of the accumulator.