### PR TITLE
Fix the aarch64 neon vectorized implementation of `trace::consolidation::fill_indices`

### DIFF
--- a/src/trace/consolidation/fill_indices.rs
+++ b/src/trace/consolidation/fill_indices.rs
@@ -200,12 +200,9 @@ unsafe fn fill_indices_x86_avx2(original_length: usize, indices: &mut Vec<usize>
 #[cfg(target_arch = "aarch64")]
 #[target_feature(enable = "neon")]
 pub unsafe fn fill_indices_aarch64_neon(original_length: usize, indices: &mut Vec<usize>) {
-    use std::{
-        arch::aarch64::{
-            uint32x4_t, uint64x2_t, vaddq_u32, vaddq_u64, vdupq_n_u32, vdupq_n_u64, vst1q_u32,
-            vst1q_u64,
-        },
-        mem::transmute,
+    use std::arch::aarch64::{
+        uint32x4_t, uint64x2_t, vaddq_u32, vaddq_u64, vdupq_n_u32, vdupq_n_u64, vst1q_u32,
+        vst1q_u64,
     };
 
     if original_length == 0 {
@@ -222,7 +219,7 @@ pub unsafe fn fill_indices_aarch64_neon(original_length: usize, indices: &mut Ve
         let four = vdupq_n_u32(4);
 
         let mut indices_ptr = indices.as_mut_ptr().cast::<u32>();
-        let indices_end = indices_ptr.add(length / 4);
+        let indices_end = indices_ptr.add(length);
 
         while indices_ptr < indices_end {
             // Store the indices into the vec
@@ -243,7 +240,7 @@ pub unsafe fn fill_indices_aarch64_neon(original_length: usize, indices: &mut Ve
         let two = vdupq_n_u64(2);
 
         let mut indices_ptr = indices.as_mut_ptr().cast::<u64>();
-        let indices_end = indices_ptr.add(length / 2);
+        let indices_end = indices_ptr.add(length);
 
         while indices_ptr < indices_end {
             // Store the indices into the vec

--- a/src/trace/consolidation/tests/mod.rs
+++ b/src/trace/consolidation/tests/mod.rs
@@ -169,11 +169,11 @@ fn offset_retain() {
 
 #[test]
 fn fill_indices() {
-    let length = 2352;
+    for &length in &[0, 1, 2, 42, 128, 333, 1400, 2352] {
+        let mut output = Vec::new();
+        fill_indices::fill_indices(length, &mut output);
 
-    let mut output = Vec::new();
-    fill_indices::fill_indices(length, &mut output);
-
-    let expected: Vec<usize> = (0..length).collect();
-    assert_eq!(expected, output);
+        let expected: Vec<usize> = (0..length).collect();
+        assert_eq!(expected, output);
+    }
 }


### PR DESCRIPTION
Fixes #277.

`indices_ptr` is u32/u64-sized, despite the SIMD operations acting on two u32/u64 datums at a time; this is also the pointer type expected by `vst1q_u64`.

I have only tested this on my 64 bit machine, the 32 bit fix is my best guess.

* [x] Can `usize` ever be 32 bits in `aarch64` here https://github.com/vmware/database-stream-processor/blob/50e58aa34d66b3fbaa6f7481a90af2ae870f132d/src/trace/consolidation/fill_indices.rs#L217?
Apparently, yes: https://en.wikipedia.org/wiki/AArch64