### PR TITLE
Generalized incremental `distinct` operator.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,10 +110,19 @@ jobs:
           args: --workspace --no-run --no-default-features  --target ${{ matrix.target }}
 
       - name: Run tests
+        if: runner.os != 'Windows'
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --workspace ${{ env.ALMOST_ALL_FEATURES }} --target ${{ matrix.target }} -- ${{ matrix.test_flags }}
+
+      # Only run basic tests on windows, which tends to run out of resources.
+      - name: Run tests on Windows
+        if: runner.os == 'Windows'
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace --target ${{ matrix.target }} -- ${{ matrix.test_flags }}
 
   #   miri:
   #     name: Miri

--- a/benches/ldbc-graphalytics/main.rs
+++ b/benches/ldbc-graphalytics/main.rs
@@ -455,6 +455,10 @@ fn attach_profiling(dataset: DataSet, circuit: &mut Circuit<()>) {
                             Cow::Borrowed("time"),
                             MetaItem::Duration(profile.total_time()),
                         ),
+                        (
+                            Cow::Borrowed("nodeid"),
+                            MetaItem::String(node_id.to_string()),
+                        ),
                     ];
 
                     for item in default_meta {

--- a/benches/ldbc-graphalytics/pagerank.rs
+++ b/benches/ldbc-graphalytics/pagerank.rs
@@ -133,7 +133,7 @@ pub fn pagerank(
     // Find all dangling nodes (nodes without outgoing edges)
     let dangling_nodes = weighted_vertices.minus(
         &outgoing_edge_counts
-            .distinct()
+            .stream_distinct()
             .semijoin_stream::<_, OrdZSet<_, _>>(&weighted_vertices)
             .map(|&(node, _)| node),
     );

--- a/benches/path.rs
+++ b/benches/path.rs
@@ -86,7 +86,7 @@ fn main() {
             let paths = circuit
                 .recursive(|child, paths: Stream<_, OrdZSet<(u32, u32), i32>>| {
                     // ```text
-                    //                      distinct_trace
+                    //                            distinct
                     //               ┌───┐          ┌───┐
                     // edges         │   │          │   │  paths
                     // ────┬────────►│ + ├──────────┤   ├────────┬───►

--- a/proptest-regressions/operator/distinct.txt
+++ b/proptest-regressions/operator/distinct.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc d2c682b8d4a4302a866964c81bd23a54d8d5b88720a09ddcc2d374b5d922c1a3 # shrinks to inputs = [[], [OrdIndexedZSet { layer: OrderedLayer { keys: [], offs: [0], vals: ColumnLayer { keys: [], diffs: [] } } }, OrdIndexedZSet { layer: OrderedLayer { keys: [], offs: [0], vals: ColumnLayer { keys: [], diffs: [] } } }, OrdIndexedZSet { layer: OrderedLayer { keys: [], offs: [0], vals: ColumnLayer { keys: [], diffs: [] } } }, OrdIndexedZSet { layer: OrderedLayer { keys: [4], offs: [0, 1], vals: ColumnLayer { keys: [0], diffs: [1] } } }], [OrdIndexedZSet { layer: OrderedLayer { keys: [4], offs: [0, 1], vals: ColumnLayer { keys: [0], diffs: [1] } } }, OrdIndexedZSet { layer: OrderedLayer { keys: [], offs: [0], vals: ColumnLayer { keys: [], diffs: [] } } }, OrdIndexedZSet { layer: OrderedLayer { keys: [], offs: [0], vals: ColumnLayer { keys: [], diffs: [] } } }, OrdIndexedZSet { layer: OrderedLayer { keys: [2], offs: [0, 2], vals: ColumnLayer { keys: [0, 1], diffs: [1, 1] } } }]], workers = 2

--- a/src/nexmark/queries/q15.rs
+++ b/src/nexmark/queries/q15.rs
@@ -176,37 +176,37 @@ pub fn q15(input: NexmarkStream) -> Q15Stream {
     // Compute unique bidders across all bids and for each price range.
     let distinct_bidder = bids
         .map(|(day, (_auction, _price, bidder))| (*day, *bidder))
-        .distinct_incremental()
+        .distinct::<()>()
         .index();
     let rank1_distinct_bidder = rank1_bids
         .map(|(day, (_auction, _price, bidder))| (*day, *bidder))
-        .distinct_incremental()
+        .distinct::<()>()
         .index();
     let rank2_distinct_bidder = rank2_bids
         .map(|(day, (_auction, _price, bidder))| (*day, *bidder))
-        .distinct_incremental()
+        .distinct::<()>()
         .index();
     let rank3_distinct_bidder = rank3_bids
         .map(|(day, (_auction, _price, bidder))| (*day, *bidder))
-        .distinct_incremental()
+        .distinct::<()>()
         .index();
 
     // Compute unique auctions across all bids and for each price range.
     let distinct_auction = bids
         .map(|(day, (auction, _price, _bidder))| (*day, *auction))
-        .distinct_incremental()
+        .distinct::<()>()
         .index();
     let rank1_distinct_auction = rank1_bids
         .map(|(day, (auction, _price, _bidder))| (*day, *auction))
-        .distinct_incremental()
+        .distinct::<()>()
         .index();
     let rank2_distinct_auction = rank2_bids
         .map(|(day, (auction, _price, _bidder))| (*day, *auction))
-        .distinct_incremental()
+        .distinct::<()>()
         .index();
     let rank3_distinct_auction = rank3_bids
         .map(|(day, (auction, _price, _bidder))| (*day, *auction))
-        .distinct_incremental()
+        .distinct::<()>()
         .index();
 
     // Compute bids per day.

--- a/src/nexmark/queries/q16.rs
+++ b/src/nexmark/queries/q16.rs
@@ -199,25 +199,25 @@ pub fn q16(input: NexmarkStream) -> Q16Stream {
         .map(|((channel, day), (_auction, _price, bidder, _mins))| {
             ((channel.clone(), *day), *bidder)
         })
-        .distinct_incremental()
+        .distinct::<()>()
         .index();
     let rank1_distinct_bidder = rank1_bids
         .map(|((channel, day), (_auction, _price, bidder, _mins))| {
             ((channel.clone(), *day), *bidder)
         })
-        .distinct_incremental()
+        .distinct::<()>()
         .index();
     let rank2_distinct_bidder = rank2_bids
         .map(|((channel, day), (_auction, _price, bidder, _mins))| {
             ((channel.clone(), *day), *bidder)
         })
-        .distinct_incremental()
+        .distinct::<()>()
         .index();
     let rank3_distinct_bidder = rank3_bids
         .map(|((channel, day), (_auction, _price, bidder, _mins))| {
             ((channel.clone(), *day), *bidder)
         })
-        .distinct_incremental()
+        .distinct::<()>()
         .index();
 
     // Compute unique auctions across all bids and for each price range.
@@ -225,25 +225,25 @@ pub fn q16(input: NexmarkStream) -> Q16Stream {
         .map(|((channel, day), (auction, _price, _bidder, _mins))| {
             ((channel.clone(), *day), *auction)
         })
-        .distinct_incremental()
+        .distinct::<()>()
         .index();
     let rank1_distinct_auction = rank1_bids
         .map(|((channel, day), (auction, _price, _bidder, _mins))| {
             ((channel.clone(), *day), *auction)
         })
-        .distinct_incremental()
+        .distinct::<()>()
         .index();
     let rank2_distinct_auction = rank2_bids
         .map(|((channel, day), (auction, _price, _bidder, _mins))| {
             ((channel.clone(), *day), *auction)
         })
-        .distinct_incremental()
+        .distinct::<()>()
         .index();
     let rank3_distinct_auction = rank3_bids
         .map(|((channel, day), (auction, _price, _bidder, _mins))| {
             ((channel.clone(), *day), *auction)
         })
-        .distinct_incremental()
+        .distinct::<()>()
         .index();
 
     // Compute bids per channel per day.

--- a/src/operator/aggregate/mod.rs
+++ b/src/operator/aggregate/mod.rs
@@ -611,9 +611,6 @@ where
         // );
         self.empty_input = delta.is_empty();
 
-        // We iterate over keys in order, so it is safe to use `Builder`
-        // as long as we are careful to add values in order for each key in
-        // `eval_key` method.
         let mut result = Vec::with_capacity(delta.key_count());
 
         let mut delta_cursor = delta.cursor();
@@ -810,7 +807,7 @@ mod test {
                 Ok((
                     move || {
                         *counter.borrow_mut() += 1;
-                        Ok(*counter.borrow() == 4)
+                        Ok(*counter.borrow() == MAX_ITERATIONS)
                     },
                     (),
                 ))

--- a/src/operator/condition.rs
+++ b/src/operator/condition.rs
@@ -211,7 +211,7 @@ mod test {
                             let suc =
                                 feedback_indexed.stream_join(&edges_indexed, |_node, &(), &to| to);
 
-                            let reachable = init.plus(&suc).distinct();
+                            let reachable = init.plus(&suc).stream_distinct();
                             feedback.connect(&reachable);
                             let condition = reachable.differentiate().condition(|z| z.is_empty());
                             (condition, reachable.export())

--- a/src/operator/join.rs
+++ b/src/operator/join.rs
@@ -318,7 +318,7 @@ where
                 )),
                 move || {
                     let stream1 = self.shard();
-                    let stream2 = other.distinct_incremental().shard();
+                    let stream2 = other.distinct::<TS>().shard();
 
                     stream1
                         .minus(
@@ -1019,7 +1019,7 @@ mod test {
 
             let paths = circuit.recursive(|child, paths_delayed: Stream<_, OrdZSet<(usize, usize), isize>>| {
                 // ```text
-                //                          distinct_trace
+                //                             distinct
                 //               ┌───┐          ┌───┐
                 // edges         │   │          │   │  paths
                 // ────┬────────►│ + ├──────────┤   ├────────┬───►
@@ -1046,7 +1046,7 @@ mod test {
             })
             .unwrap();
 
-            paths.integrate().distinct().inspect(move |ps| {
+            paths.integrate().stream_distinct().inspect(move |ps| {
                 assert_eq!(*ps, outputs.next().unwrap());
             });
         })

--- a/src/operator/time_series/rolling_aggregate.rs
+++ b/src/operator/time_series/rolling_aggregate.rs
@@ -533,7 +533,7 @@ mod test {
 
                 OutputBatch::from_tuples((), tuples)
             })
-            .distinct()
+            .stream_distinct()
             .gather(0)
     }
 

--- a/src/time/nested_ts32.rs
+++ b/src/time/nested_ts32.rs
@@ -107,15 +107,21 @@ impl Timestamp for NestedTimestamp32 {
     }
 
     fn recede(&self, scope: Scope) -> Self {
+        self.checked_recede(scope)
+            .expect("NestedTimestamp32::recede timestamp underflow")
+    }
+
+    fn checked_recede(&self, scope: Scope) -> Option<Self> {
         if scope == 0 {
             if self.0 & INNER_MASK == 0 {
-                panic!("NestedTimestamp32::recede timestamp underflow");
+                None
+            } else {
+                Some(Self(self.0 - 1))
             }
-            Self(self.0 - 1)
         } else if scope == 1 {
-            Self(self.0 & INNER_MASK)
+            Some(Self(self.0 & INNER_MASK))
         } else {
-            self.clone()
+            Some(self.clone())
         }
     }
 

--- a/src/time/product.rs
+++ b/src/time/product.rs
@@ -105,6 +105,18 @@ where
         }
     }
 
+    fn checked_recede(&self, scope: Scope) -> Option<Self> {
+        if scope == 0 {
+            self.inner
+                .checked_recede(0)
+                .map(|inner| Self::new(self.outer.clone(), inner))
+        } else {
+            self.outer
+                .checked_recede(scope - 1)
+                .map(|outer| Self::new(outer, self.inner.clone()))
+        }
+    }
+
     fn epoch_start(&self, scope: Scope) -> Self {
         if scope == 0 {
             Self::new(self.outer.clone(), TInner::minimum())


### PR DESCRIPTION
We used to have two separate implementations of incremental `distinct`: one that only worked in the top-level scope and one that worked in the nested scope.  We replace them with a generalized implementation that works for arbitrary levels of nesting (although internally it still invokes a specialized implementation for the top-level scope, which is slightly more efficient).  The new implementation is also more general in that it works for indexed Z-sets, not just regular Z-sets. Finally, we rename the operator to be consistent with the rest of the API: `distinct` for the incremental version and `stream_distinct` for the non-incremental version.

Our implementation of `distinct` follows a different approach than the closely related `aggregate` operator (in fact, we _could_ implement `distinct` on top of `aggregate` and probably should actually have such an implementation for comparison): `aggregate` indexes both its input and output collections.  The latter means that the implementation must only compute the value of the aggregate at the current time and the delta can be diffing it with old outputs stored in the output trace.

For `distinct` we avoid indexing the output by computing the delta directly on the input trace.  This trades memory for CPU, but the hypothesis is that the cost of computing `distinct` is low enough that this doesn't matter in practice.  In reality, this design does not always save memory: oftentimes the output of `distinct` is fed to an operator that maintain the trace of its input, in which case the output trace that we optimized away still ends up being created.

Theory
------

According to the definition of a lifted incremental operator, we are computing a partial derivative:

```text
    ∂^n                      ∂^(n-1)                      ∂^(n-1)
 ------------f(t1,..,tn) = ------------f(t1,..,tn)  -  ------------f(t1-1,..,tn).
 ∂_t1 .. ∂_tn              ∂_t2 .. ∂_tn                ∂_t2 .. ∂_tn
```

where `n` is the nesting level of the circuit, i.e., 1 for the top-level circuit, 2 for its subcircuit, etc., `ti` is the i'th component of the n-dimensional timestamp, and `f(t1..tn)` is the value of the function we want to compute (in this case `distinct`) at time `t1..tn`.

For example, for a twice nested circuit, we get:

```text
     ∂^3                        ∂^2                         ∂^2
 --------------f(t1,t2,t3) = -----------f(t1,t2,t3)  -  -----------f(t1-1,t2,t3) =
 ∂_t1 ∂_t2 ∂_t3               ∂_t2 ∂_t3                  ∂_t2 ∂_t3

  ┌─                                     ─┐   ┌─                                          ─┐
  │   ∂                   ∂               │   │   ∂                    ∂                   │
  │ -----f(t1,t2,t3)  - -----f(t1,t2-1,t3)│ - │ -----f(t1-1,t2,t3)  - -----f(t1-1,t2-1,t3) │ =
= │ ∂_t3                 ∂_t3             │   │ ∂_t3                  ∂_t3                 │
  └─                                     ─┘   └─                                          ─┘

= ((f(t1,t2,t3) - f(t1,t2,t3-1)) - (f(t1,t2-1,t2) - f(t1,t2-1,t3-1))) -
  ((f(t1-1,t2,t3) - f(t1-1,t2,t3-1)) - (f(t1-1,t2-1,t2) - f(t1-1,t2-1,t3-1))).
```

In general, in order to compute the partial derivative, we need to know the values of `f` for all times within the n-dimensional cube with edge 1 of the current time `t1..tn` (i.e., all `2^n` possible combinations of `ti`'s and `ti-1`'s).

Computing the value of `f` at time `t`, in turn, requires first computing the sum of all updates with time `t' < t` in the input stream:

```text
             __
             \
f(t) =dist(  / stream[t'][k][v].weight )
             --
             t'<=t
```

where `stream[t'][k][v].weight` is pseudocode for selecting the weight of the update at time `t'` for key `k` and value `v`, and

```text
           ┌
           │  1, if w > 0
dist(w) = <
           │  0, otherwise
           └
```

We compute `f(t)` for all `2^n` times `t` of interest simultaneously in a single run of the cursor by maintaining an array of `2^n` accumulators and updating a subset of them at each step.

`keys_of_interest` map
----------------------

The `distinct` operator does not have nice properties like linearity that help with incremental evaluation: computing an update for each key/value pair requires inspecting the entire history of updates for this pair.  Fortunately, we do not need to look at all key/value pairs in the trace.  Specifically, a key/value pair `(k, v)` can only appear in the output of the operator at time `t` if it satisfies one of the following conditions:

* `(k,v)` occurs in the current input `delta`
* there exist `t1<t` and `t2<t` such that `t = t1 T t2` and `(k,v)` occurs in the inputs of the operator at times `t1` and `t2`.

To efficiently compute tuples that satisfy the second condition, we use the `keys_of_interest` map.  For each `(k,v)` observed at time `t1` we lookup the smallest time `t'` such that `t' = t1 T t2` for some `t2` such that `not (t2 <= t1)` at which we've encountered `(k,v)` and record `(k,v)` in `keys_of_interest[t']`.  When evaluating the operator at time `t'` we simply scan all tuples in `keys_of_interest[t2]` for candidates.