### PR TITLE
Cleanup & document pipeline manager API.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,16 +44,16 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.2.2"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c83abf9903e1f0ad9973cc4f7b9767fd5a03a583f51a5b7a339e07987cd2724"
+checksum = "0070905b2c4a98d184c4e81025253cb192aa8a73827553f38e9410801ceb35bb"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-utils",
  "ahash",
- "base64",
+ "base64 0.21.0",
  "bitflags",
  "brotli",
  "bytes",
@@ -75,8 +75,10 @@ dependencies = [
  "rand",
  "sha1",
  "smallvec",
+ "tokio",
+ "tokio-util",
  "tracing",
- "zstd 0.11.2+zstd.1.5.2",
+ "zstd 0.12.2+zstd.1.5.2",
 ]
 
 [[package]]
@@ -142,6 +144,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-tls"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde0cf292f7cdc7f070803cb9a0d45c018441321a78b1042ffbbb81ec333297"
+dependencies = [
+ "actix-codec",
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "http",
+ "log",
+ "pin-project-lite",
+ "tokio-util",
+]
+
+[[package]]
 name = "actix-utils"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.2.1"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d48f7b6534e06c7bfc72ee91db7917d4af6afe23e7d223b51e68fffbb21e96b9"
+checksum = "464e0fddc668ede5f26ec1f9557a8d44eda948732f40c6b0ad79126930eb775f"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -357,10 +376,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "awc"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dff3fc64a176e0d4398c71b0f2c2679ff4a723c6ed8fcc68dfe5baa00665388"
+dependencies = [
+ "actix-codec",
+ "actix-http",
+ "actix-rt",
+ "actix-service",
+ "actix-tls",
+ "actix-utils",
+ "ahash",
+ "base64 0.21.0",
+ "bytes",
+ "cfg-if",
+ "cookie",
+ "derive_more",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "itoa",
+ "log",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rand",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "base64ct"
@@ -1256,6 +1315,8 @@ dependencies = [
  "actix-web",
  "actix-web-static-files",
  "anyhow",
+ "awc",
+ "chrono",
  "clap 4.0.32",
  "env_logger",
  "fs_extra",
@@ -1269,6 +1330,8 @@ dependencies = [
  "static-files",
  "tokio",
  "tokio-postgres",
+ "utoipa",
+ "utoipa-swagger-ui",
 ]
 
 [[package]]
@@ -1293,6 +1356,26 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -2476,7 +2559,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "878c6cbf956e03af9aa8204b407b9cbf47c072164800aa918c516cd4b056c50c"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "byteorder",
  "bytes",
  "fallible-iterator",
@@ -2495,6 +2578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73d946ec7d256b04dfadc4e6a3292324e6f417124750fc5c0950f981b703a0f1"
 dependencies = [
  "bytes",
+ "chrono",
  "fallible-iterator",
  "postgres-protocol",
 ]
@@ -2796,6 +2880,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2838,11 +2933,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
+checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
 dependencies = [
- "base64",
+ "base64 0.21.0",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2931,6 +3026,41 @@ dependencies = [
  "quote 1.0.23",
  "rustc_version",
  "syn 1.0.107",
+]
+
+[[package]]
+name = "rust-embed"
+version = "6.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "283ffe2f866869428c92e0d61c2f35dfb4355293cdfdc48f49e895c15f1333d1"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31ab23d42d71fb9be1b643fe6765d292c5e14d46912d13f3ae2815ca048ea04d"
+dependencies = [
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "rust-embed-utils",
+ "shellexpand",
+ "syn 1.0.107",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "7.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1669d81dfabd1b5f8e2856b8bbe146c6192b0ba22162edc738ac0a5de18f054"
+dependencies = [
+ "sha2",
+ "walkdir",
 ]
 
 [[package]]
@@ -3112,7 +3242,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d904179146de381af4c93d3af6ca4984b3152db687dacb9c3c35e86f39809c"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "chrono",
  "hex",
  "indexmap",
@@ -3167,6 +3297,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "shellexpand"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]
@@ -3432,9 +3571,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.24.1"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
+checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
 dependencies = [
  "autocfg",
  "bytes",
@@ -3633,6 +3772,48 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+]
+
+[[package]]
+name = "utoipa"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3920fa753064b1be7842bea26175ffa0dfc4a8f30bcb52b8ff03fddf8889914c"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "720298fac6efca20df9e457e67a1eab41a20d1c3101380b5c4dca1ca60ae0062"
+dependencies = [
+ "lazy_static",
+ "proc-macro-error",
+ "proc-macro2 1.0.49",
+ "quote 1.0.23",
+ "regex",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae3d4f4da6408f0f20ff58196ed619c94306ab32635aeca3d3fa0768c0bd0de2"
+dependencies = [
+ "actix-web",
+ "mime_guess",
+ "regex",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "utoipa",
+ "zip",
 ]
 
 [[package]]

--- a/adapters/Cargo.toml
+++ b/adapters/Cargo.toml
@@ -25,7 +25,7 @@ csv = { git = "https://github.com/ryzhyk/rust-csv.git" }
 bincode = { version = "2.0.0-rc.2", features = ["serde"] }
 # cmake-build is required on Windows.
 rdkafka = { version = "0.29.0", features = ["cmake-build"], optional = true }
-actix-web = { version = "4.2", optional = true }
+actix-web = { version = "4.3", optional = true }
 actix-web-static-files = "4.0.0"
 static-files = "0.2.3"
 mime = { version = "0.3.16", optional = true }
@@ -36,7 +36,7 @@ proptest = { version = "1.0.0", optional = true}
 proptest-derive = { version = "0.3.0", optional = true }
 env_logger = "0.10.0"
 clap = {version = "4.0.32", features = ["derive"] }
-tokio = { version = "1.24.1", features = ["sync"] }
+tokio = { version = "1.25.0", features = ["sync"] }
 prometheus = "0.13.3"
 
 [dev-dependencies]

--- a/adapters/src/lib.rs
+++ b/adapters/src/lib.rs
@@ -139,7 +139,7 @@ pub use deinput::{
 pub use format::{Encoder, InputFormat, OutputConsumer, OutputFormat, Parser};
 pub use seroutput::{SerBatch, SerCursor, SerOutputBatchHandle};
 
-pub use controller::{Controller, ControllerConfig, ControllerError};
+pub use controller::{Controller, ControllerConfig, ControllerError, ControllerStatus};
 pub use transport::{
     FileInputTransport, InputConsumer, InputEndpoint, InputTransport, OutputEndpoint,
     OutputTransport,

--- a/adapters/static/errReporter.ts
+++ b/adapters/static/errReporter.ts
@@ -123,8 +123,20 @@ export class WebClient {
     }
 
     public post(url: string, data: object, continuation: (response: Response) => void): void {
+        this.http_request('POST', url, data, continuation)
+    }
+
+    public delete(url: string, data: object, continuation: (response: Response) => void): void {
+        this.http_request('DELETE', url, data, continuation)
+    }
+
+    public patch(url: string, data: object, continuation: (response: Response) => void): void {
+        this.http_request('PATCH', url, data, continuation)
+    }
+
+    public http_request(method: string, url: string, data: object, continuation: (response: Response) => void): void {
         fetch(url, {
-            method: 'POST',
+            method: method,
             headers: {
                 "content-type": 'application/json',
             },

--- a/deploy/start_manager.sh
+++ b/deploy/start_manager.sh
@@ -42,6 +42,7 @@ manager_config="
 
 printf "$manager_config" > "${WORKING_DIR}/manager.yaml"
 
+cd "${MANAGER_DIR}" && ~/.cargo/bin/cargo build --release
 cd "${MANAGER_DIR}" && ~/.cargo/bin/cargo run --release -- --static-html=static --config-file="${WORKING_DIR}/manager.yaml" 2> "${WORKING_DIR}/manager.log"&
 
 TIMEOUT=10

--- a/pipeline_manager/Cargo.toml
+++ b/pipeline_manager/Cargo.toml
@@ -6,13 +6,14 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 
-actix-web = "4.2"
+actix-web = "4.3"
 actix-web-static-files = "4.0.0"
+awc = "3.1.0"
 static-files = "0.2.3"
 actix-files = "0.6.2"
 anyhow = "1.0.57"
-tokio = { version = "1.24.1", features = ["fs", "macros", "process", "io-util"] }
-tokio-postgres = "0.7.7"
+tokio = { version = "1.25.0", features = ["fs", "macros", "process", "io-util"] }
+tokio-postgres = { version = "0.7.7", features = ["with-chrono-0_4"] }
 log = "0.4.17"
 env_logger = "0.10.0"
 serde = { version = "1.0", features = ["derive"] }
@@ -21,8 +22,11 @@ serde_yaml = "0.9.14"
 mime = "0.3.16"
 clap = { version = "4.0.32", features = ["derive"] }
 regex = "1.7.0"
-reqwest = "0.11.13"
+reqwest = "0.11.14"
 fs_extra = "1.2.0"
+utoipa = { version = "3.0.1", features = ["actix_extras", "chrono"] }
+utoipa-swagger-ui = { version = "3.0.2", features = ["actix-web"] }
+chrono = { version = "0.4.23", default-features = false, features = ["serde"] }
 
 [build-dependencies]
 static-files = "0.2.3"

--- a/pipeline_manager/create_db.sql
+++ b/pipeline_manager/create_db.sql
@@ -8,7 +8,7 @@ CREATE TABLE project (
     code varchar,
     status varchar,
     error varchar,
-    status_since timestamp,
+    status_since timestamp with time zone,
     PRIMARY KEY (id)
 );
 
@@ -21,7 +21,7 @@ CREATE TABLE pipeline (
     -- TODO: add 'host' field when we support remote pipelines.
     port int NOT NULL,
     killed bool NOT NULL,
-    created timestamp,
+    created timestamp with time zone,
     PRIMARY KEY (id),
     FOREIGN KEY (project_id) REFERENCES project(id) ON DELETE CASCADE
 );

--- a/pipeline_manager/scripts/compile_project.sh
+++ b/pipeline_manager/scripts/compile_project.sh
@@ -9,4 +9,4 @@ if [ "$#" -ne 2 ]; then
     exit 1
 fi
 
-curl -X POST http://localhost:8080/compile_project  -H 'Content-Type: application/json' -d '{"project_id":'$1',"version":'$2'}'
+curl -X POST http://localhost:8080/projects/compile  -H 'Content-Type: application/json' -d '{"project_id":'$1',"version":'$2'}'

--- a/pipeline_manager/scripts/delete_config.sh
+++ b/pipeline_manager/scripts/delete_config.sh
@@ -9,4 +9,4 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 
-curl -X POST http://localhost:8080/delete_config  -H 'Content-Type: application/json' -d '{"config_id":'$1'}'
+curl -X DELETE http://localhost:8080/configs/$1  -H 'Content-Type: application/json' -d '{}'

--- a/pipeline_manager/scripts/delete_pipeline.sh
+++ b/pipeline_manager/scripts/delete_pipeline.sh
@@ -9,4 +9,4 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 
-curl -X POST http://localhost:8080/delete_pipeline  -H 'Content-Type: application/json' -d '{"pipeline_id":'$1'}'
+curl -X DELETE http://localhost:8080/pipelines/$1 -H 'Content-Type: application/json' -d '{}'

--- a/pipeline_manager/scripts/delete_project.sh
+++ b/pipeline_manager/scripts/delete_project.sh
@@ -9,4 +9,4 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 
-curl -X POST http://localhost:8080/delete_project  -H 'Content-Type: application/json' -d '{"project_id":'$1'}'
+curl -X DELETE http://localhost:8080/projects/$1 -H 'Content-Type: application/json' -d '{}'

--- a/pipeline_manager/scripts/kill_pipeline.sh
+++ b/pipeline_manager/scripts/kill_pipeline.sh
@@ -9,4 +9,4 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 
-curl -X POST http://localhost:8080/kill_pipeline  -H 'Content-Type: application/json' -d '{"pipeline_id":'$1'}'
+curl -X POST http://localhost:8080/pipelines/shutdown  -H 'Content-Type: application/json' -d '{"pipeline_id":'$1'}'

--- a/pipeline_manager/scripts/list_project_configs.sh
+++ b/pipeline_manager/scripts/list_project_configs.sh
@@ -9,4 +9,4 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 
-curl -X POST http://localhost:8080/list_project_configs  -H 'Content-Type: application/json' -d '{"project_id":'$1'}'
+curl http://localhost:8080/projects/$1/configs

--- a/pipeline_manager/scripts/list_project_pipelines.sh
+++ b/pipeline_manager/scripts/list_project_pipelines.sh
@@ -9,4 +9,4 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 
-curl -X POST http://localhost:8080/list_project_pipelines  -H 'Content-Type: application/json' -d '{"project_id":'$1'}'
+curl http://localhost:8080/projects/$1/pipelines

--- a/pipeline_manager/scripts/list_projects.sh
+++ b/pipeline_manager/scripts/list_projects.sh
@@ -11,4 +11,4 @@ fi
 
 # echo $ESCAPED_CODE
 
-curl http://localhost:8080/list_projects
+curl http://localhost:8080/projects

--- a/pipeline_manager/scripts/new_config.sh
+++ b/pipeline_manager/scripts/new_config.sh
@@ -19,4 +19,4 @@ ESCAPED_CONFIG="$(json_escape "$CONFIG")"
 
 # echo $ESCAPED_CONFIG
 
-curl -s -X POST http://localhost:8080/new_config  -H 'Content-Type: application/json' -d '{"project_id":'$1',"name":"'$2'","config":'"${ESCAPED_CONFIG}"'}'
+curl -s -X POST http://localhost:8080/configs  -H 'Content-Type: application/json' -d '{"project_id":'$1',"name":"'$2'","config":'"${ESCAPED_CONFIG}"'}'

--- a/pipeline_manager/scripts/new_pipeline.sh
+++ b/pipeline_manager/scripts/new_pipeline.sh
@@ -9,7 +9,7 @@ if [ "$#" -ne 4 ]; then
     exit 1
 fi
 
-response=$(curl -s -X POST http://localhost:8080/new_pipeline -H 'Content-Type: application/json' -d '{"project_id":'$1',"project_version":'$2',"config_id":'$3',"config_version":'$4'}')
+response=$(curl -s -X POST http://localhost:8080/pipelines -H 'Content-Type: application/json' -d '{"project_id":'$1',"project_version":'$2',"config_id":'$3',"config_version":'$4'}')
 
 port=$(echo ${response} | jq '.port')
 id=$(echo ${response} | jq '.pipeline_id')

--- a/pipeline_manager/scripts/new_project.sh
+++ b/pipeline_manager/scripts/new_project.sh
@@ -19,4 +19,4 @@ ESCAPED_CODE="$(json_escape "$CODE")"
 
 # echo $ESCAPED_CODE
 
-curl -s -X POST http://localhost:8080/new_project  -H 'Content-Type: application/json' -d '{"name":"'$1'","code":'"${ESCAPED_CODE}"'}'
+curl -s -X POST http://localhost:8080/projects  -H 'Content-Type: application/json' -d '{"name":"'$1'","code":'"${ESCAPED_CODE}"'}'

--- a/pipeline_manager/scripts/project_code.sh
+++ b/pipeline_manager/scripts/project_code.sh
@@ -11,4 +11,4 @@ fi
 
 # echo $ESCAPED_CODE
 
-curl http://localhost:8080/project_code/$1
+curl http://localhost:8080/projects/$1/code

--- a/pipeline_manager/scripts/project_status.sh
+++ b/pipeline_manager/scripts/project_status.sh
@@ -11,4 +11,4 @@ fi
 
 # echo $ESCAPED_CODE
 
-curl http://localhost:8080/project_status/$1
+curl http://localhost:8080/projects/$1

--- a/pipeline_manager/scripts/update_config.sh
+++ b/pipeline_manager/scripts/update_config.sh
@@ -19,4 +19,4 @@ ESCAPED_CONFIG="$(json_escape "$CONFIG")"
 
 # echo $ESCAPED_CONFIG
 
-curl -X POST http://localhost:8080/update_config  -H 'Content-Type: application/json' -d '{"config_id":'$1',"name":"'$2'","config":'"${ESCAPED_CONFIG}"'}'
+curl -X PATCH http://localhost:8080/configs -H 'Content-Type: application/json' -d '{"config_id":'$1',"name":"'$2'","config":'"${ESCAPED_CONFIG}"'}'

--- a/pipeline_manager/scripts/update_project.sh
+++ b/pipeline_manager/scripts/update_project.sh
@@ -19,4 +19,4 @@ ESCAPED_CODE="$(json_escape "$CODE")"
 
 # echo $ESCAPED_CODE
 
-curl -X POST http://localhost:8080/update_project  -H 'Content-Type: application/json' -d '{"project_id":'$1',"name":"'$2'","code":'"${ESCAPED_CODE}"'}'
+curl -X PATCH http://localhost:8080/projects -H 'Content-Type: application/json' -d '{"project_id":'$1',"name":"'$2'","code":'"${ESCAPED_CODE}"'}'

--- a/pipeline_manager/src/compiler.rs
+++ b/pipeline_manager/src/compiler.rs
@@ -17,12 +17,14 @@ use tokio::{
     task::JoinHandle,
     time::{sleep, Duration},
 };
+use utoipa::ToSchema;
 
 /// The frequency with which the compiler polls the project database
 /// for new compilation requests.
 const COMPILER_POLL_INTERVAL: Duration = Duration::from_millis(1000);
 
-#[derive(Serialize, Eq, PartialEq)]
+/// Project compilation status.
+#[derive(Serialize, Eq, PartialEq, ToSchema)]
 pub(crate) enum ProjectStatus {
     /// Initial state: project has been created or modified, but the user
     /// hasn't yet started compiling the project.


### PR DESCRIPTION
Use the `utoipa` crate to generate OpenAPI spec for the pipeline manager API, and Swagger documentation for it, available on `/api-doc/openapi.json` and `/swagger-ui/` endpoints respectively.

Unlike OpenAPI generators, `utoipa` doesn't automatically generate server-side stubs for the API, but rather documents an existing, manually implemented, API.  Although it does interact with the Rust type system, it is not 100% type-safe, i.e., the generated API may not match the actual input and output formats used by the server.  Unfortunately, this appears to be the best option the Rust ecosystem offers today.

While at it, I also cleaned up the API in a couple of ways:

- Use JSON for all inputs and outputs (as opposed to returning plain text strings in some cases).  In particular, errors are now returned as JSON:

  ``` { "message": "Cannot delete a project while some of its pipelines are running" } ```

- Convert `list_project_configs` and `list_project_pipelines` into `GET` methods that take project id as URL-encoded parameter for consistency with `project_status`, `project_code`, etc.

@mbudiu-vmw, the preferred way to work with this API from the browser would be to generate client-side typescript bindings for it, but it's probably not worth bothering with now, since we will eventually re-implement the UI anyway.