### PR TITLE
Make it easy to bring up a local instance of DBSP

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -45,4 +45,7 @@ RUN cp /database-stream-processor/deploy/prometheus_datasource.yaml /etc/grafana
    && cp /database-stream-processor/deploy/grafana_dashboard_provision.yaml /etc/grafana/provisioning/dashboards/ \
    && cp /database-stream-processor/deploy/grafana_dashboard.json /etc/grafana/provisioning/dashboards/
 
-CMD service postgresql start && bash
+CMD service postgresql start && \
+    mkdir /working-dir && \
+    /database-stream-processor/deploy/start_manager.sh /working-dir 0.0.0.0 && \
+    bash

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -46,6 +46,5 @@ RUN cp /database-stream-processor/deploy/prometheus_datasource.yaml /etc/grafana
    && cp /database-stream-processor/deploy/grafana_dashboard.json /etc/grafana/provisioning/dashboards/
 
 CMD service postgresql start && \
-    mkdir /working-dir && \
     /database-stream-processor/deploy/start_manager.sh /working-dir 0.0.0.0 && \
     bash

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,16 @@
+Bringing up a local instance of DBSP
+===================================
+
+First, build a DBSP Docker image:
+
+```
+./docker.sh
+```
+
+Next, bring up an instance of the container:
+
+```
+docker run --name dbsp -p 8081:8080 -itd dbspmanager
+```
+
+Open your browser and you should now be able to see the pipeline maanger dashboard on localhost:8081.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -7,10 +7,11 @@ First, build a DBSP Docker image:
 ./docker.sh
 ```
 
-Next, bring up an instance of the container:
+Next, bring up an instance of the container and forward the container's port
+8080 to a port on the host of your choice (e.g. 8081):
 
 ```
 docker run --name dbsp -p 8081:8080 -itd dbspmanager
 ```
 
-Open your browser and you should now be able to see the pipeline maanger dashboard on localhost:8081.
+Open your browser and you should now be able to see the pipeline manager dashboard on localhost:8081.

--- a/deploy/docker.sh
+++ b/deploy/docker.sh
@@ -6,6 +6,11 @@ DEFAULT_SQL_COMPILER_PATH="${THIS_DIR}/../../sql-to-dbsp-compiler"
 SQL_COMPILER="${1:-$DEFAULT_SQL_COMPILER_PATH}"
 DBSP_PATH="${THIS_DIR}/../"
 
+if [ ! -d "$SQL_COMPILER" ]; then
+    echo "Could not find SQL compiler source (https://github.com/vmware/sql-to-dbsp-compiler) at path $SQL_COMPILER."
+    exit 1
+fi
+
 (cd ${DBSP_PATH} && (git ls-files | tar -cvf ${THIS_DIR}/dbsp_files.tar -T -))
 (cd ${SQL_COMPILER} && (git ls-files | tar -cvf ${THIS_DIR}/sql_compiler_files.tar -T -))
 

--- a/deploy/start_manager.sh
+++ b/deploy/start_manager.sh
@@ -5,12 +5,14 @@ ROOT_DIR="${THIS_DIR}/.."
 SQL_COMPILER_DIR="${ROOT_DIR}/../sql-to-dbsp-compiler"
 MANAGER_DIR="${ROOT_DIR}/pipeline_manager"
 
-if [ "$#" -ne 1 ]; then
-    echo "Usage '$0 <working_directory_path>'"
+if [ "$#" -lt 1 ]; then
+    echo "Usage '$0 <working_directory_path> <bind address (optional)>'"
     exit 1
 fi
 
 WORKING_DIR=$(realpath "${1}")
+DEFAULT_BIND_ADDRESS="127.0.0.1"
+BIND_ADDRESS="${2:-$DEFAULT_BIND_ADDRESS}"
 
 mkdir -p "${WORKING_DIR}"
 
@@ -30,6 +32,7 @@ psql -h localhost -U postgres -f "${ROOT_DIR}/pipeline_manager/create_db.sql"
 
 manager_config="
     port: 8080
+    bind_address:  \"${BIND_ADDRESS}\"
     pg_connection_string: \"host=localhost user=dbsp\"
     working_directory: \"${WORKING_DIR}\"
     sql_compiler_home: \"${SQL_COMPILER_DIR}\"
@@ -39,7 +42,7 @@ manager_config="
 
 printf "$manager_config" > "${WORKING_DIR}/manager.yaml"
 
-cd "${MANAGER_DIR}" && cargo run --release -- --static-html=static --config-file="${WORKING_DIR}/manager.yaml" 2> "${WORKING_DIR}/manager.log"&
+cd "${MANAGER_DIR}" && ~/.cargo/bin/cargo run --release -- --static-html=static --config-file="${WORKING_DIR}/manager.yaml" 2> "${WORKING_DIR}/manager.log"&
 
 TIMEOUT=10
 

--- a/pipeline_manager/src/config.rs
+++ b/pipeline_manager/src/config.rs
@@ -8,6 +8,10 @@ const fn default_server_port() -> u16 {
     8080
 }
 
+fn default_server_address() -> String {
+    "127.0.0.1".to_string()
+}
+
 fn default_pg_connection_string() -> String {
     "host=localhost user=dbsp".to_string()
 }
@@ -22,6 +26,10 @@ pub(crate) struct ManagerConfig {
     /// Port number for the HTTP service, defaults to 8080.
     #[serde(default = "default_server_port")]
     pub port: u16,
+
+    /// Bind address for the HTTP service, defaults to 127.0.0.1.
+    #[serde(default = "default_server_address")]
+    pub bind_address: String,
 
     /// Postgres database connection string.
     ///

--- a/pipeline_manager/src/main.rs
+++ b/pipeline_manager/src/main.rs
@@ -163,12 +163,12 @@ async fn run(config: ManagerConfig) -> AnyResult<()> {
     // reset all projects to `ProjectStatus::None`, which will force
     // us to recompile projects before running them.
     db.lock().await.reset_project_status().await?;
-
-    let port = config.port;
+    let bind_address = config.bind_address.clone();
+    let bind_port = config.port;
     let state = WebData::new(ServerState::new(config, db, compiler).await?);
 
     HttpServer::new(move || build_app(App::new().wrap(Logger::default()), state.clone()))
-        .bind(("127.0.0.1", port))?
+        .bind((bind_address, bind_port))?
         .run()
         .await?;
 


### PR DESCRIPTION
Adds some changes to bring up a docker container locally with the DBSP pipeline manager running. For now, anyone trying this out would need to build the docker image locally first and then run the docker command to bring up the deployment. Later, we can make prebuilt images available so it becomes just the docker run command to get started with DBSP. 