### PR TITLE
Iterator interface to `trait IndexedZSet`.

### DIFF
--- a/examples/orgchart.rs
+++ b/examples/orgchart.rs
@@ -9,11 +9,7 @@
 use anyhow::Result;
 use bincode::{Decode, Encode};
 use clap::Parser;
-use dbsp::{
-    operator::FilterMap,
-    trace::{BatchReader, Cursor},
-    OrdZSet, OutputHandle, Runtime, Stream,
-};
+use dbsp::{operator::FilterMap, IndexedZSet, OrdZSet, OutputHandle, Runtime, Stream};
 use size_of::SizeOf;
 use std::hash::Hash;
 
@@ -41,17 +37,11 @@ type Weight = i32;
 type SkipLevels = OrdZSet<SkipLevel, Weight>;
 
 fn print_output(output: &OutputHandle<OrdZSet<SkipLevel, Weight>>) {
-    let output = output.consolidate();
-    let mut cursor = output.cursor();
-    while cursor.key_valid() {
-        let weight = cursor.weight();
-        let SkipLevel {
-            grandmanager,
-            manager,
-            employee,
-        } = cursor.key();
-        println!("    ({grandmanager}, {manager}, {employee}) {weight:+}");
-        cursor.step_key();
+    for (key, _value, weight) in output.consolidate().iter() {
+        println!(
+            "    ({}, {}, {}) {:+}",
+            key.grandmanager, key.manager, key.employee, weight
+        );
     }
     println!();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub use crate::num_entries::NumEntries;
 pub use crate::ref_pair::RefPair;
 pub use crate::time::Timestamp;
 
+pub use algebra::{IndexedZSet, ZSet};
 pub use circuit::{
     Circuit, CircuitHandle, DBSPHandle, Runtime, RuntimeError, SchedulerError, Stream,
 };

--- a/src/trace/spine_fueled.rs
+++ b/src/trace/spine_fueled.rs
@@ -120,8 +120,6 @@ where
 impl<B> Display for Spine<B>
 where
     B: Batch + Display,
-    B::Key: Ord,
-    B::Val: Ord,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.try_fold_batches((), |_, batch| {


### PR DESCRIPTION
Internally DBSP uses the cursor API for iterating over batches.  Cursors are designed to be fast but they have relatively poor ergonomics and are unsafe.  This is ok for internal use by the library, but we expose batches to the user via output handles.  We therefore add an iterator-based interface to batches (specifically, for indexed z-sets only) in order to make it easier and less error-prone for users to iterate over the output of the computation.

Unfortunately, the only way to wrap `Cursor` in `trait Iterator` is to iterate over updates by value (because `Iterator` doesn't take advantage of GATs).

@blp , I moved your `impl Iterator` for batches into the library, so you can simplify #296 