### PR TITLE
Make sure manager can run without a config.yaml.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,9 @@ nexmark_results.csv
 nexmark_comment.txt
 galen_results.csv
 ldbc_results.csv
+
+# pipeline manager
+manager.db
+manager.pid
+config.yaml
+cargo_workspace

--- a/pipeline_manager/src/config.rs
+++ b/pipeline_manager/src/config.rs
@@ -18,6 +18,14 @@ fn default_working_directory() -> String {
     ".".to_string()
 }
 
+fn default_logfile() -> String {
+    "pipeline_manager.log".to_string()
+}
+
+fn default_sql_compiler_home() -> String {
+    "../../sql-to-dbsp-compiler".to_string()
+}
+
 /// Pipeline manager configuration read from a YAML config file.
 #[derive(Deserialize, Clone)]
 pub(crate) struct ManagerConfig {
@@ -30,6 +38,7 @@ pub(crate) struct ManagerConfig {
     pub bind_address: String,
 
     /// File to write manager logs to.
+    #[serde(default = "default_logfile")]
     pub logfile: String,
 
     /// Directory where the manager stores its filesystem state:
@@ -40,6 +49,7 @@ pub(crate) struct ManagerConfig {
     pub working_directory: String,
 
     /// Location of the SQL-to-DBSP compiler.
+    #[serde(default = "default_sql_compiler_home")]
     pub sql_compiler_home: String,
 
     /// Override DBSP dependencies in generated Rust crates.
@@ -69,6 +79,15 @@ pub(crate) struct ManagerConfig {
     /// The default is `false`.
     #[serde(default)]
     pub debug: bool,
+
+    /// Run as a UNIX daemon (detach from terminal).
+    ///
+    /// The default is `false`.
+    ///
+    /// # Compatibility
+    /// This only has effect UNIX platform.
+    #[serde(default)]
+    pub unix_daemon: bool,
 }
 
 impl ManagerConfig {

--- a/pipeline_manager/src/config.rs
+++ b/pipeline_manager/src/config.rs
@@ -100,7 +100,8 @@ pub(crate) struct ManagerConfig {
     #[arg(short, long)]
     pub static_html: Option<String>,
 
-    /// [Developers only] Dump OpenAPI specification to `openapi.json` file.
+    /// [Developers only] dump OpenAPI specification to `openapi.json` file and
+    /// exit immediately.
     #[serde(skip)]
     #[arg(long)]
     pub dump_openapi: bool,

--- a/pipeline_manager/src/config.rs
+++ b/pipeline_manager/src/config.rs
@@ -100,8 +100,7 @@ pub(crate) struct ManagerConfig {
     #[arg(short, long)]
     pub static_html: Option<String>,
 
-    /// [Developers only] dump OpenAPI specification to `openapi.json` file and
-    /// exit immediately.
+    /// [Developers only] Dump OpenAPI specification to `openapi.json` file.
     #[serde(skip)]
     #[arg(long)]
     pub dump_openapi: bool,

--- a/pipeline_manager/src/main.rs
+++ b/pipeline_manager/src/main.rs
@@ -271,18 +271,19 @@ fn run(config: ManagerConfig) -> AnyResult<()> {
     let db = ProjectDB::connect(&config)?;
 
     #[cfg(unix)]
-    let daemonize = Daemonize::new()
-        .pid_file(config.manager_pid_file_path())
-        .working_directory(&config.working_directory)
-        .stdout(logfile_clone)
-        .stderr(logfile);
+    if config.unix_daemon {
+        let daemonize = Daemonize::new()
+            .pid_file(config.manager_pid_file_path())
+            .working_directory(&config.working_directory)
+            .stdout(logfile_clone)
+            .stderr(logfile);
 
-    #[cfg(unix)]
-    daemonize.start().map_err(|e| {
-        AnyError::msg(format!(
-            "failed to detach server process from terminal: '{e}'",
-        ))
-    })?;
+        daemonize.start().map_err(|e| {
+            AnyError::msg(format!(
+                "failed to detach server process from terminal: '{e}'",
+            ))
+        })?;
+    }
 
     rt::System::new().block_on(async {
         let db = Arc::new(Mutex::new(db));

--- a/pipeline_manager/src/main.rs
+++ b/pipeline_manager/src/main.rs
@@ -184,6 +184,7 @@ fn main() -> AnyResult<()> {
     if config.dump_openapi {
         let openapi_json = ApiDoc::openapi().to_json()?;
         write("openapi.json", openapi_json.as_bytes())?;
+        return Ok(());
     }
 
     if let Some(config_file) = &config.config_file {

--- a/pipeline_manager/src/main.rs
+++ b/pipeline_manager/src/main.rs
@@ -184,7 +184,6 @@ fn main() -> AnyResult<()> {
     if config.dump_openapi {
         let openapi_json = ApiDoc::openapi().to_json()?;
         write("openapi.json", openapi_json.as_bytes())?;
-        return Ok(());
     }
 
     if let Some(config_file) = &config.config_file {
@@ -927,6 +926,10 @@ async fn delete_config(state: WebData<ServerState>, req: HttpRequest) -> impl Re
             , description = "Specified `project_id` does not exist in the database."
             , body = ErrorResponse
             , example = json!(ErrorResponse::new("Unknown project id '42'"))),
+        (status = BAD_REQUEST
+            , description = "Specified `project_id` is not a valid integer."
+            , body = ErrorResponse
+            , example = json!(ErrorResponse::new("invalid project id 'a'"))),
     ),
     params(
         ("project_id" = i64, Path, description = "Unique project identifier")
@@ -1025,6 +1028,10 @@ async fn new_pipeline(
             , description = "Specified `project_id` does not exist in the database."
             , body = ErrorResponse
             , example = json!(ErrorResponse::new("Unknown project id '42'"))),
+        (status = BAD_REQUEST
+            , description = "Specified `project_id` is not a valid integer."
+            , body = ErrorResponse
+            , example = json!(ErrorResponse::new("invalid project id 'a'"))),
     ),
     params(
         ("project_id" = i64, Path, description = "Unique project identifier")
@@ -1063,6 +1070,10 @@ async fn list_project_pipelines(state: WebData<ServerState>, req: HttpRequest) -
             , description = "Specified `pipeline_id` does not exist in the database."
             , body = ErrorResponse
             , example = json!(ErrorResponse::new("Unknown pipeline id '13'"))),
+        (status = BAD_REQUEST
+            , description = "Specified `pipeline_id` is not a valid integer."
+            , body = ErrorResponse
+            , example = json!(ErrorResponse::new("invalid pipeline id 'abc'"))),
     ),
     params(
         ("pipeline_id" = i64, Path, description = "Unique pipeline identifier")
@@ -1093,6 +1104,10 @@ async fn pipeline_status(state: WebData<ServerState>, req: HttpRequest) -> impl 
             , description = "Specified `pipeline_id` does not exist in the database."
             , body = ErrorResponse
             , example = json!(ErrorResponse::new("Unknown pipeline id '13'"))),
+        (status = BAD_REQUEST
+            , description = "Specified `pipeline_id` is not a valid integer."
+            , body = ErrorResponse
+            , example = json!(ErrorResponse::new("invalid pipeline id 'abc'"))),
     ),
     params(
         ("pipeline_id" = i64, Path, description = "Unique pipeline identifier")
@@ -1126,6 +1141,10 @@ async fn pipeline_metadata(state: WebData<ServerState>, req: HttpRequest) -> imp
             , description = "Specified `pipeline_id` does not exist in the database."
             , body = ErrorResponse
             , example = json!(ErrorResponse::new("Unknown pipeline id '13'"))),
+        (status = BAD_REQUEST
+            , description = "Specified `pipeline_id` is not a valid integer."
+            , body = ErrorResponse
+            , example = json!(ErrorResponse::new("invalid pipeline id 'abc'"))),
     ),
     params(
         ("pipeline_id" = i64, Path, description = "Unique pipeline identifier")
@@ -1159,6 +1178,10 @@ async fn pipeline_start(state: WebData<ServerState>, req: HttpRequest) -> impl R
             , description = "Specified `pipeline_id` does not exist in the database."
             , body = ErrorResponse
             , example = json!(ErrorResponse::new("Unknown pipeline id '13'"))),
+        (status = BAD_REQUEST
+            , description = "Specified `pipeline_id` is not a valid integer."
+            , body = ErrorResponse
+            , example = json!(ErrorResponse::new("invalid pipeline id 'abc'"))),
     ),
     params(
         ("pipeline_id" = i64, Path, description = "Unique pipeline identifier")

--- a/scripts/start_manager.sh
+++ b/scripts/start_manager.sh
@@ -16,26 +16,16 @@ WORKING_DIR=$(cd "$(dirname "${1}")" && pwd -P)/$(basename "${1}")
 DEFAULT_BIND_ADDRESS="127.0.0.1"
 BIND_ADDRESS="${2:-$DEFAULT_BIND_ADDRESS}"
 
-mkdir -p "${WORKING_DIR}"
-
 # Kill manager. pkill doesn't handle process names >15 characters.
 pkill -9 dbsp_pipeline_
 
 set -e
 
-# Start pipeline manager.
-
-manager_config="
-    port: 8080
-    bind_address:  \"${BIND_ADDRESS}\"
-    logfile: \"${WORKING_DIR}/manager.log\"
-    working_directory: \"${WORKING_DIR}\"
-    sql_compiler_home: \"${SQL_COMPILER_DIR}\"
-    dbsp_override_path: \"${ROOT_DIR}\"
-    with_prometheus: false
-    debug: false"
-
-printf "$manager_config" > "${WORKING_DIR}/manager.yaml"
-
 cd "${MANAGER_DIR}" && ~/.cargo/bin/cargo build --release
-cd "${MANAGER_DIR}" && ~/.cargo/bin/cargo run --release -- --static-html=static --config-file="${WORKING_DIR}/manager.yaml"
+cd "${MANAGER_DIR}" && ~/.cargo/bin/cargo run --release -- \
+    --bind-address="${BIND_ADDRESS}" \
+    --working-directory="${WORKING_DIR}" \
+    --sql-compiler-home="${SQL_COMPILER_DIR}" \
+    --dbsp-override-path="${ROOT_DIR}" \
+    --static-html=static \
+    --unix-daemon


### PR DESCRIPTION
- Define defaults for everything in config.yaml
- Add an option to run it as daemon or not (default is false was true before (on unix)).

With this I can run the pipeline manager to run by just typing `cargo run` on the command line (for easier development).