### PR TITLE
Pass to simplify and optimize docker container

### DIFF
--- a/demo/hello-world/config.yml
+++ b/demo/hello-world/config.yml
@@ -4,7 +4,7 @@ inputs:
     transport:
       name: file
       config: 
-        path: "/examples/messages.csv"
+        path: "/database-stream-processor/demo/hello-world/messages.csv"
         follow: true
 
     format:
@@ -15,7 +15,7 @@ inputs:
     transport:
       name: file
       config: 
-        path: "/examples/records.csv"
+        path: "/database-stream-processor/demo/hello-world/records.csv"
         follow: true
 
     format:
@@ -27,7 +27,7 @@ outputs:
     transport:
       name: file
       config: 
-        path: "/examples/matches.csv"
+        path: "/database-stream-processor/demo/hello-world/matches.csv"
 
     format:
       name: csv

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -49,5 +49,7 @@ RUN cp /database-stream-processor/deploy/prometheus_datasource.yaml /etc/grafana
    && cp /database-stream-processor/deploy/grafana_dashboard.json /etc/grafana/provisioning/dashboards/ \
    && mkdir /working-dir
 
+ENV PATH="$PATH:/root/.cargo/bin"
+
 CMD /database-stream-processor/scripts/start_prometheus.sh /working-dir && \
     /root/.cargo/bin/dbsp_pipeline_manager --bind-address=0.0.0.0 --working-directory=/working-dir --sql-compiler-home=/database-stream-processor/sql-to-dbsp-compiler --dbsp-override-path=/database-stream-processor

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt update && apt install libssl-dev build-essential pkg-config \
      git gcc clang libclang-dev python3-pip hub numactl cmake \
-     curl openjdk-19-jdk maven netcat jq \
+     curl openjdk-19-jre-headless maven netcat jq \
      adduser libfontconfig1 unzip -y
 
 RUN pip install gdown
@@ -13,33 +13,41 @@ RUN pip install gdown
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
 # Install rpk
-RUN curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-linux-amd64.zip \
-   && unzip rpk-linux-amd64.zip -d /bin/ \
-   && rpk version
+RUN arch=`dpkg --print-architecture`; \
+   curl -LO https://github.com/redpanda-data/redpanda/releases/latest/download/rpk-linux-$arch.zip \
+   && unzip rpk-linux-$arch.zip -d /bin/ \
+   && rpk version \
+   && rm rpk-linux-$arch.zip
+
 
 # Install Prometheus
 RUN arch=`dpkg --print-architecture`; \
    curl -LO https://github.com/prometheus/prometheus/releases/download/v2.41.0/prometheus-2.41.0.linux-$arch.tar.gz \
    && tar xvfz prometheus-*.tar.gz \
    && cd prometheus-* \
-   && mv prometheus /bin/
+   && mv prometheus /bin/ \
+   && rm /prometheus-*.tar.gz
 
 # Install grafana
 RUN arch=`dpkg --print-architecture`; \
     curl -LO https://dl.grafana.com/enterprise/release/grafana-enterprise_9.3.6_$arch.deb \
-    && dpkg -i grafana-enterprise_9.3.6_$arch.deb
+    && dpkg -i grafana-enterprise_9.3.6_$arch.deb \
+    && rm grafana-enterprise_9.3.6_$arch.deb
 
 ADD ./dbsp_files.tar /database-stream-processor
 ADD ./sql_compiler_files.tar /database-stream-processor/sql-to-dbsp-compiler
 
-RUN cd /database-stream-processor/pipeline_manager && ~/.cargo/bin/cargo build --release
+RUN cd /database-stream-processor/pipeline_manager \
+    && ~/.cargo/bin/cargo install --path . \
+    && rm -rf /database-stream-processor/target
+
 RUN cd /database-stream-processor/sql-to-dbsp-compiler/SQL-compiler && mvn -DskipTests package
 
 # Provision Prometheus data source + DBSP dashboard in Grafana.
 RUN cp /database-stream-processor/deploy/prometheus_datasource.yaml /etc/grafana/provisioning/datasources/ \
    && cp /database-stream-processor/deploy/grafana_dashboard_provision.yaml /etc/grafana/provisioning/dashboards/ \
-   && cp /database-stream-processor/deploy/grafana_dashboard.json /etc/grafana/provisioning/dashboards/
+   && cp /database-stream-processor/deploy/grafana_dashboard.json /etc/grafana/provisioning/dashboards/ \
+   && mkdir /working-dir
 
-CMD /database-stream-processor/scripts/start_manager.sh /working-dir 0.0.0.0 && \
-    /database-stream-processor/scripts/start_prometheus.sh /working-dir && \
-    bash
+CMD /database-stream-processor/scripts/start_prometheus.sh /working-dir && \
+    /root/.cargo/bin/dbsp_pipeline_manager --bind-address=0.0.0.0 --working-directory=/working-dir --sql-compiler-home=/database-stream-processor/sql-to-dbsp-compiler --dbsp-override-path=/database-stream-processor

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -11,7 +11,14 @@ Next, bring up an instance of the container and forward the container's port
 8080 to a port on the host of your choice (e.g. 8081):
 
 ```
-docker run --name dbsp -p 8081:8080 -itd dbspmanager
+docker run --name dbsp -p 8081:8080 --rm dbspmanager
 ```
 
 Open your browser and you should now be able to see the pipeline manager dashboard on localhost:8081.
+
+
+To shutdown the container, run:
+
+```
+docker kill dbsp
+```

--- a/pipeline_manager/scripts/new_project.sh
+++ b/pipeline_manager/scripts/new_project.sh
@@ -19,4 +19,4 @@ ESCAPED_CODE="$(json_escape "$CODE")"
 
 # echo $ESCAPED_CODE
 
-curl -s -X POST http://localhost:8080/projects  -H 'Content-Type: application/json' -d '{"name":"'$1'","code":'"${ESCAPED_CODE}"'}'
+curl -s -X POST http://localhost:8080/projects  -H 'Content-Type: application/json' -d '{"name":"'$1'","description": "","code":'"${ESCAPED_CODE}"'}'

--- a/pipeline_manager/static/app.js
+++ b/pipeline_manager/static/app.js
@@ -614,6 +614,7 @@ define("dbsp-project", ["require", "exports", "errReporter", "ui"], function (re
             reader.addEventListener("load", () => {
                 const data = {
                     "name": name,
+                    "description": "",
                     "code": reader.result,
                 };
                 console.log(data);

--- a/pipeline_manager/static/dbsp-project.ts
+++ b/pipeline_manager/static/dbsp-project.ts
@@ -555,6 +555,7 @@ class ProjectListDisplay extends WebClient implements IHtmlElement {
         reader.addEventListener("load", () => {
             const data = {
                 "name": name,
+                "description": "",
                 "code": reader.result,
             };
             console.log(data);


### PR DESCRIPTION
* Pipeline server: use cargo install and run the binary directly instead of using cargo build -> run -> start_manager.sh script
* Cleanup a bunch of build artifacts: the dbsp project /target folder and downloaded dependency packages
* Use OpenJDK JRE instead of JDK

@ryzhyk could you test your demo workflow end-to-end with these changes just to be sure I didn't break anything?

The changes bring the container size down from ~6.2GB to 4.2GB. Most of this is currently taken by the rust and llvm toolchains (~2GB total) and about 1.5GB in /usr/lib.