### PR TITLE
Return entire project meta-data when fetching code.

### DIFF
--- a/crates/pipeline_manager/src/db.rs
+++ b/crates/pipeline_manager/src/db.rs
@@ -196,9 +196,7 @@ impl ProjectDB {
     /// database created with `create_db.sql` along with access credentials.
     pub(crate) fn connect(config: &ManagerConfig) -> AnyResult<Self> {
         unsafe {
-            rusqlite::trace::config_log(Some(|errcode, msg| {
-                debug!("sqlite: {msg}:{errcode}")
-            }))?
+            rusqlite::trace::config_log(Some(|errcode, msg| debug!("sqlite: {msg}:{errcode}")))?
         };
         let dbclient = Connection::open(config.database_file_path())?;
 

--- a/crates/pipeline_manager/src/main.rs
+++ b/crates/pipeline_manager/src/main.rs
@@ -127,6 +127,7 @@ observed by the user is outdated, so the request is rejected."
         pipeline_delete,
     ),
     components(schemas(
+        compiler::SqlCompilerMessage,
         db::ProjectDescr,
         db::ConfigDescr,
         db::PipelineDescr,
@@ -630,6 +631,7 @@ struct UpdateProjectRequest {
     /// New name for the project.
     name: String,
     /// New description for the project.
+    #[serde(default)]
     description: String,
     /// New SQL code for the project or `None` to keep existing project
     /// code unmodified.

--- a/crates/pipeline_manager/src/runner.rs
+++ b/crates/pipeline_manager/src/runner.rs
@@ -472,11 +472,15 @@ scrape_configs:
 
     /// Kill the pipeline if it is still running, delete its file system state
     /// and remove the pipeline from the database.
-    pub(crate) async fn delete_pipeline(&self, pipeline_id: PipelineId) -> AnyResult<HttpResponse> {
-        let db = self.db.lock().await;
-
+    // Takes a reference to an already locked DB instance, since this function
+    // is invoked in contexts where the client already holds the lock.
+    pub(crate) async fn delete_pipeline(
+        &self,
+        db: &ProjectDB,
+        pipeline_id: PipelineId,
+    ) -> AnyResult<HttpResponse> {
         // Kill pipeline.
-        let response = self.do_shutdown_pipeline(&db, pipeline_id).await?;
+        let response = self.do_shutdown_pipeline(db, pipeline_id).await?;
         if !response.status().is_success() {
             return Ok(response);
         }

--- a/crates/pipeline_manager/static/app.js
+++ b/crates/pipeline_manager/static/app.js
@@ -485,7 +485,7 @@ define("dbsp-project", ["require", "exports", "errReporter", "ui"], function (re
             response.json().then(descr => this.showStatus(descr));
         }
         showStatus(descr) {
-            var _a;
+            var _a, _b;
             this.project.version = descr.version;
             this.refresh();
             if (typeof descr.status === 'string') {
@@ -495,8 +495,8 @@ define("dbsp-project", ["require", "exports", "errReporter", "ui"], function (re
                 }
             }
             else if (typeof descr.status === 'object') {
-                const error = (_a = descr.status.SqlError) !== null && _a !== void 0 ? _a : descr.status.RustError;
-                this.display.reportError("Compilation error:\n" + error);
+                const error = (_b = (_a = descr.status.SqlError) !== null && _a !== void 0 ? _a : descr.status.RustError) !== null && _b !== void 0 ? _b : descr.status.SystemError;
+                this.display.reportError("Compilation error:\n" + JSON.stringify(error));
             }
         }
         fetchCode() {

--- a/crates/pipeline_manager/static/dbsp-project.ts
+++ b/crates/pipeline_manager/static/dbsp-project.ts
@@ -16,9 +16,20 @@ interface ProjectCode {
     code: string,
 }
 
+interface SqlCompilerMessage {
+    start_line_number: number,
+    start_column: number,
+    end_line_number: number,
+    end_column: number,
+    warning: boolean,
+    error_type: string,
+    message: string,
+}
+
 interface CompilationError {
-    SqlError: string | null,
+    SqlError: SqlCompilerMessage[] | null,
     RustError: string | null,
+    SystemError: string | null,
 }
 
 interface SwitchChild {
@@ -398,8 +409,8 @@ class ProjectDisplay extends WebClient implements IHtmlElement {
                 runAfterDelay(1000, () => this.fetchStatus());
             }
         } else if (typeof descr.status === 'object') {
-            const error = descr.status.SqlError ?? descr.status.RustError;
-            this.display.reportError("Compilation error:\n" + error);
+            const error = descr.status.SqlError ?? descr.status.RustError ?? descr.status.SystemError;
+            this.display.reportError("Compilation error:\n" + JSON.stringify(error));
         }
     }
 

--- a/python/dbsp/error.py
+++ b/python/dbsp/error.py
@@ -24,9 +24,11 @@ class CompilationException(Exception):
     """
     def __init__(self, status):
         if hasattr(status, 'sql_error'):
-            self.message = "SQL error: " + status.sql_error
+            self.message = "SQL error: " + str(status.sql_error)
         elif hasattr(status, 'rust_error'):
             self.message = "Rust compiler error: " + status.rust_error
+        elif hasattr(status, 'system_error'):
+            self.message = "System error: " + status.system_error
         else:
             self.message = "Unexpected project status: " + str(status)
 

--- a/python/dbsp/project.py
+++ b/python/dbsp/project.py
@@ -53,7 +53,7 @@ class DBSPProject:
                 if status == 'Success':
                     return
                 else:
-                    raise CompilationException(status)
+                    raise CompilationException(str(status))
             time.sleep(0.5)
 
         raise TimeoutException("Timeout waiting for the project to compile after " + str(timeout) + "s")


### PR DESCRIPTION
Avoids multiple API calls since we usually want to display more project information with the code.