### PR TITLE
Use docker compose to bring up dbsp and redpanda containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# Ignore target and git directories
+target
+.git
+**/Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,7 @@
 target
 .git
 **/Dockerfile
+**/pipeline_data
+**/ldbc-graphalytics-data
+**/fraud_data
+demo

--- a/crates/adapters/src/server/mod.rs
+++ b/crates/adapters/src/server/mod.rs
@@ -141,6 +141,10 @@ pub fn run_server<F>(
 where
     F: Fn(usize) -> (DBSPHandle, Catalog),
 {
+    // NOTE: The pipeline manager monitors pipeline log for one of the following
+    // messages ("Failed to create pipeline..." or "Started HTTP server...").
+    // If you change these messages, make sure to make a corresponding change to
+    // `runner.rs`.
     let (port, server, mut terminate_receiver) =
         create_server(circuit_factory, yaml_config, meta, default_port)
             .map_err(|e| AnyError::msg(format!("Failed to create pipeline: {e}")))?;

--- a/crates/pipeline_manager/scripts/compile_project.sh
+++ b/crates/pipeline_manager/scripts/compile_project.sh
@@ -9,4 +9,4 @@ if [ "$#" -ne 2 ]; then
     exit 1
 fi
 
-curl -X POST http://localhost:8080/projects/compile  -H 'Content-Type: application/json' -d '{"project_id":'$1',"version":'$2'}'
+curl -X POST http://"${DBSP_MANAGER:-localhost:8080}"/projects/compile  -H 'Content-Type: application/json' -d '{"project_id":'$1',"version":'$2'}'

--- a/crates/pipeline_manager/scripts/delete_config.sh
+++ b/crates/pipeline_manager/scripts/delete_config.sh
@@ -9,4 +9,4 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 
-curl -X DELETE http://localhost:8080/configs/$1  -H 'Content-Type: application/json' -d '{}'
+curl -X DELETE http://"${DBSP_MANAGER:-localhost:8080}"/configs/$1  -H 'Content-Type: application/json' -d '{}'

--- a/crates/pipeline_manager/scripts/delete_pipeline.sh
+++ b/crates/pipeline_manager/scripts/delete_pipeline.sh
@@ -9,4 +9,4 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 
-curl -X DELETE http://localhost:8080/pipelines/$1 -H 'Content-Type: application/json' -d '{}'
+curl -X DELETE http://"${DBSP_MANAGER:-localhost:8080}"/pipelines/$1 -H 'Content-Type: application/json' -d '{}'

--- a/crates/pipeline_manager/scripts/delete_project.sh
+++ b/crates/pipeline_manager/scripts/delete_project.sh
@@ -9,4 +9,4 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 
-curl -X DELETE http://localhost:8080/projects/$1 -H 'Content-Type: application/json' -d '{}'
+curl -X DELETE http://"${DBSP_MANAGER:-localhost:8080}"/projects/$1 -H 'Content-Type: application/json' -d '{}'

--- a/crates/pipeline_manager/scripts/kill_pipeline.sh
+++ b/crates/pipeline_manager/scripts/kill_pipeline.sh
@@ -9,4 +9,4 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 
-curl -X POST http://localhost:8080/pipelines/shutdown  -H 'Content-Type: application/json' -d '{"pipeline_id":'$1'}'
+curl -X POST http://"${DBSP_MANAGER:-localhost:8080}"/pipelines/shutdown  -H 'Content-Type: application/json' -d '{"pipeline_id":'$1'}'

--- a/crates/pipeline_manager/scripts/list_project_configs.sh
+++ b/crates/pipeline_manager/scripts/list_project_configs.sh
@@ -9,4 +9,4 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 
-curl http://localhost:8080/projects/$1/configs
+curl http://"${DBSP_MANAGER:-localhost:8080}"/projects/$1/configs

--- a/crates/pipeline_manager/scripts/list_project_pipelines.sh
+++ b/crates/pipeline_manager/scripts/list_project_pipelines.sh
@@ -9,4 +9,4 @@ if [ "$#" -ne 1 ]; then
     exit 1
 fi
 
-curl http://localhost:8080/projects/$1/pipelines
+curl http://"${DBSP_MANAGER:-localhost:8080}"/projects/$1/pipelines

--- a/crates/pipeline_manager/scripts/list_projects.sh
+++ b/crates/pipeline_manager/scripts/list_projects.sh
@@ -11,4 +11,4 @@ fi
 
 # echo $ESCAPED_CODE
 
-curl http://localhost:8080/projects
+curl http://"${DBSP_MANAGER:-localhost:8080}"/projects

--- a/crates/pipeline_manager/scripts/new_config.sh
+++ b/crates/pipeline_manager/scripts/new_config.sh
@@ -19,4 +19,4 @@ ESCAPED_CONFIG="$(json_escape "$CONFIG")"
 
 # echo $ESCAPED_CONFIG
 
-curl -s -X POST http://localhost:8080/configs  -H 'Content-Type: application/json' -d '{"project_id":'$1',"name":"'$2'","config":'"${ESCAPED_CONFIG}"'}'
+curl -s -X POST http://"${DBSP_MANAGER:-localhost:8080}"/configs  -H 'Content-Type: application/json' -d '{"project_id":'$1',"name":"'$2'","config":'"${ESCAPED_CONFIG}"'}'

--- a/crates/pipeline_manager/scripts/new_pipeline.sh
+++ b/crates/pipeline_manager/scripts/new_pipeline.sh
@@ -9,7 +9,7 @@ if [ "$#" -ne 4 ]; then
     exit 1
 fi
 
-response=$(curl -s -X POST http://localhost:8080/pipelines -H 'Content-Type: application/json' -d '{"project_id":'$1',"project_version":'$2',"config_id":'$3',"config_version":'$4'}')
+response=$(curl -s -X POST http://"${DBSP_MANAGER:-localhost:8080}"/pipelines -H 'Content-Type: application/json' -d '{"project_id":'$1',"project_version":'$2',"config_id":'$3',"config_version":'$4'}')
 
 port=$(echo ${response} | jq '.port')
 id=$(echo ${response} | jq '.pipeline_id')

--- a/crates/pipeline_manager/scripts/new_project.sh
+++ b/crates/pipeline_manager/scripts/new_project.sh
@@ -19,4 +19,4 @@ ESCAPED_CODE="$(json_escape "$CODE")"
 
 # echo $ESCAPED_CODE
 
-curl -s -X POST http://localhost:8080/projects  -H 'Content-Type: application/json' -d '{"name":"'$1'","description": "","overwrite_existing":true,"code":'"${ESCAPED_CODE}"'}'
+curl -s -X POST http://"${DBSP_MANAGER:-localhost:8080}"/projects  -H 'Content-Type: application/json' -d '{"name":"'$1'","description": "","overwrite_existing":true,"code":'"${ESCAPED_CODE}"'}'

--- a/crates/pipeline_manager/scripts/project_code.sh
+++ b/crates/pipeline_manager/scripts/project_code.sh
@@ -11,4 +11,4 @@ fi
 
 # echo $ESCAPED_CODE
 
-curl http://localhost:8080/projects/$1/code
+curl http://"${DBSP_MANAGER:-localhost:8080}"/projects/$1/code

--- a/crates/pipeline_manager/scripts/project_status.sh
+++ b/crates/pipeline_manager/scripts/project_status.sh
@@ -11,4 +11,4 @@ fi
 
 # echo $ESCAPED_CODE
 
-curl http://localhost:8080/projects/$1
+curl http://"${DBSP_MANAGER:-localhost:8080}"/projects/$1

--- a/crates/pipeline_manager/scripts/update_config.sh
+++ b/crates/pipeline_manager/scripts/update_config.sh
@@ -19,4 +19,4 @@ ESCAPED_CONFIG="$(json_escape "$CONFIG")"
 
 # echo $ESCAPED_CONFIG
 
-curl -X PATCH http://localhost:8080/configs -H 'Content-Type: application/json' -d '{"config_id":'$1',"name":"'$2'","config":'"${ESCAPED_CONFIG}"'}'
+curl -X PATCH http://"${DBSP_MANAGER:-localhost:8080}"/configs -H 'Content-Type: application/json' -d '{"config_id":'$1',"name":"'$2'","config":'"${ESCAPED_CONFIG}"'}'

--- a/crates/pipeline_manager/scripts/update_project.sh
+++ b/crates/pipeline_manager/scripts/update_project.sh
@@ -19,4 +19,4 @@ ESCAPED_CODE="$(json_escape "$CODE")"
 
 # echo $ESCAPED_CODE
 
-curl -X PATCH http://localhost:8080/projects -H 'Content-Type: application/json' -d '{"project_id":'$1',"name":"'$2'","code":'"${ESCAPED_CODE}"'}'
+curl -X PATCH http://"${DBSP_MANAGER:-localhost:8080}"/projects -H 'Content-Type: application/json' -d '{"project_id":'$1',"name":"'$2'","code":'"${ESCAPED_CODE}"'}'

--- a/crates/pipeline_manager/src/runner.rs
+++ b/crates/pipeline_manager/src/runner.rs
@@ -304,7 +304,7 @@ scrape_configs:
         let start = Instant::now();
 
         let portnum_regex = Regex::new(r"Started HTTP server on port (\w+)\b").unwrap();
-        let error_regex = Regex::new(r"Failed to create server.*").unwrap();
+        let error_regex = Regex::new(r"Failed to create pipeline.*").unwrap();
 
         loop {
             if let Some(line) = log_file_lines.next_line().await? {

--- a/demo/create_demo_projects.sh
+++ b/demo/create_demo_projects.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT="${THIS_DIR}/../"
+SERVER_DIR="${ROOT}/crates/pipeline_manager/"
+
+set -e
+
+# We want non-matching wildcards to return an empty list
+# instead of a non-expanded wildcard.
+shopt -s nullglob
+
+project_prefix=${THIS_DIR}/project_
+
+# for each demo directory
+for project_dir in "${project_prefix}"*
+do
+    project_name=${project_dir#$project_prefix}
+
+    printf "Creating project '${project_name}'... "
+    project_id=$("${SERVER_DIR}/scripts/new_project.sh" "${project_name}" < "${project_dir}/project.sql" | jq '.project_id')
+    printf "OK(project_id=$project_id)\n"
+
+    for config_file in "${project_dir}/"*.yaml
+    do
+        config_name=$(basename "${config_file}" .yaml)
+        printf "  Adding project config '${config_name}'... "
+        config_id=$("${SERVER_DIR}/scripts/new_config.sh" "${project_id}" "${config_name}"  < "${config_file}" | jq '.config_id')
+        printf "OK(config_id=$config_id)\n"
+    done
+done
+
+for project_dir in "${project_prefix}"*
+do
+    project_name=${project_dir#$project_prefix}
+
+    if test -f "${project_dir}/prepare.sh"; then
+        echo "  Running custom project setup script"
+        "${project_dir}"/prepare.sh
+    fi
+done

--- a/demo/create_demo_projects.sh
+++ b/demo/create_demo_projects.sh
@@ -4,8 +4,6 @@ THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT="${THIS_DIR}/../"
 SERVER_DIR="${ROOT}/crates/pipeline_manager/"
 
-export REDPANDA_BROKERS=localhost:19092
-
 set -e
 
 # We want non-matching wildcards to return an empty list

--- a/demo/create_demo_projects.sh
+++ b/demo/create_demo_projects.sh
@@ -4,6 +4,8 @@ THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT="${THIS_DIR}/../"
 SERVER_DIR="${ROOT}/crates/pipeline_manager/"
 
+export REDPANDA_BROKERS=localhost:19092
+
 set -e
 
 # We want non-matching wildcards to return an empty list

--- a/demo/demo.sh
+++ b/demo/demo.sh
@@ -6,6 +6,12 @@ SERVER_DIR="${ROOT}/crates/pipeline_manager/"
 
 set -e
 
+export REDPANDA_BROKERS=localhost:9092
+
+docker kill redpanda || true
+docker rm redpanda || true
+docker run --name redpanda -p 9092:9092 --rm -itd docker.redpanda.com/vectorized/redpanda:v22.3.11
+
 ${ROOT}/scripts/start_manager.sh ${THIS_DIR}/pipeline_data
 ${ROOT}/scripts/start_prometheus.sh ${THIS_DIR}/pipeline_data
 

--- a/demo/demo.sh
+++ b/demo/demo.sh
@@ -9,36 +9,4 @@ set -e
 ${ROOT}/scripts/start_manager.sh ${THIS_DIR}/pipeline_data
 ${ROOT}/scripts/start_prometheus.sh ${THIS_DIR}/pipeline_data
 
-# We want non-matching wildcards to return an empty list
-# instead of a non-expanded wildcard.
-shopt -s nullglob
-
-project_prefix=${THIS_DIR}/project_
-
-# for each demo directory
-for project_dir in "${project_prefix}"*
-do
-    project_name=${project_dir#$project_prefix}
-
-    printf "Creating project '${project_name}'... "
-    project_id=$("${SERVER_DIR}/scripts/new_project.sh" "${project_name}" < "${project_dir}/project.sql" | jq '.project_id')
-    printf "OK(project_id=$project_id)\n"
-
-    for config_file in "${project_dir}/"*.yaml
-    do
-        config_name=$(basename "${config_file}" .yaml)
-        printf "  Adding project config '${config_name}'... "
-        config_id=$("${SERVER_DIR}/scripts/new_config.sh" "${project_id}" "${config_name}"  < "${config_file}" | jq '.config_id')
-        printf "OK(config_id=$config_id)\n"
-    done
-done
-
-for project_dir in "${project_prefix}"*
-do
-    project_name=${project_dir#$project_prefix}
-
-    if test -f "${project_dir}/prepare.sh"; then
-        echo "  Running custom project setup script"
-        "${project_dir}"/prepare.sh
-    fi
-done
+${THIS_DIR}/create_demo_projects.sh

--- a/demo/docker_demo.sh
+++ b/demo/docker_demo.sh
@@ -4,4 +4,6 @@ THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 set -e
 
+export REDPANDA_BROKERS=localhost:19092
+
 DBSP_MANAGER="localhost:8085" ${THIS_DIR}/create_demo_projects.sh

--- a/demo/docker_demo.sh
+++ b/demo/docker_demo.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+set -e
+
+DBSP_MANAGER="localhost:8081" ${THIS_DIR}/create_demo_projects.sh

--- a/demo/docker_demo.sh
+++ b/demo/docker_demo.sh
@@ -4,4 +4,4 @@ THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 set -e
 
-DBSP_MANAGER="localhost:8081" ${THIS_DIR}/create_demo_projects.sh
+DBSP_MANAGER="localhost:8085" ${THIS_DIR}/create_demo_projects.sh

--- a/demo/project_demo00-SimpleSelect/default.yaml
+++ b/demo/project_demo00-SimpleSelect/default.yaml
@@ -4,7 +4,6 @@ inputs:
         transport:
             name: kafka
             config:
-                bootstrap.servers: "localhost"
                 auto.offset.reset: "earliest"
                 topics: [null_demo_input]
         format:
@@ -15,7 +14,6 @@ outputs:
         transport:
             name: kafka
             config:
-                bootstrap.servers: "localhost"
                 topic: null_demo_output
         format:
             name: csv

--- a/demo/project_demo01-TimeSeriesEnrich/large.yaml
+++ b/demo/project_demo01-TimeSeriesEnrich/large.yaml
@@ -5,7 +5,6 @@ inputs:
         transport:
             name: kafka
             config:
-                bootstrap.servers: "localhost"
                 auto.offset.reset: "earliest"
                 topics: [fraud_demo_large_demographics]
         format:
@@ -15,7 +14,6 @@ inputs:
         transport:
             name: kafka
             config:
-                bootstrap.servers: "localhost"
                 auto.offset.reset: "earliest"
                 topics: [fraud_demo_large_transactions]
         format:
@@ -26,7 +24,6 @@ outputs:
         transport:
             name: kafka
             config:
-                bootstrap.servers: "localhost"
                 topic: fraud_demo_large_enriched
         format:
             name: csv

--- a/demo/project_demo01-TimeSeriesEnrich/prepare.sh
+++ b/demo/project_demo01-TimeSeriesEnrich/prepare.sh
@@ -19,11 +19,12 @@ then
 fi
 
 # Push test data to topics.
+printf -v pasteargs %*s 1000
+while read i; do
+  echo $i | rpk topic produce fraud_demo_large_demographics -f '%v'
+done <  <(cat "${THIS_DIR}"/demographics.csv | paste -d "\n" ${pasteargs// /- })
 
-while mapfile -t -n 1000 ary && ((${#ary[@]})); do
-    printf '%s\n' "${ary[@]}" | rpk topic produce fraud_demo_large_demographics -f '%v'
-done < "${THIS_DIR}"/demographics.csv
-
-while mapfile -t -n 5000 ary && ((${#ary[@]})); do
-    printf '%s\n' "${ary[@]}" | rpk topic produce fraud_demo_large_transactions -f '%v'
-done < "${THIS_DIR}"/transactions.csv
+printf -v pasteargs %*s 5000
+while read i; do
+  echo $i | rpk topic produce fraud_demo_large_transactions -f '%v'
+done <  <(cat "${THIS_DIR}"/transactions.csv | paste -d "\n" ${pasteargs// /- })

--- a/demo/project_demo02-FraudDetection/large.yaml
+++ b/demo/project_demo02-FraudDetection/large.yaml
@@ -5,7 +5,6 @@ inputs:
         transport:
             name: kafka
             config:
-                bootstrap.servers: "localhost"
                 auto.offset.reset: "earliest"
                 topics: [fraud_demo_large_demographics]
         format:
@@ -15,7 +14,6 @@ inputs:
         transport:
             name: kafka
             config:
-                bootstrap.servers: "localhost"
                 auto.offset.reset: "earliest"
                 topics: [fraud_demo_large_transactions]
         format:
@@ -26,7 +24,6 @@ outputs:
         transport:
             name: kafka
             config:
-                bootstrap.servers: "localhost"
                 topic: fraud_demo_large_features
         format:
             name: csv

--- a/demo/project_demo03-GreenTrip/large.yaml
+++ b/demo/project_demo03-GreenTrip/large.yaml
@@ -6,7 +6,6 @@ inputs:
         transport:
             name: kafka
             config:
-                bootstrap.servers: "localhost"
                 auto.offset.reset: "earliest"
                 topics: [green_trip_demo_large_input]
         format:
@@ -17,7 +16,6 @@ outputs:
         transport:
             name: kafka
             config:
-                bootstrap.servers: "localhost"
                 topic: green_trip_demo_large_output
         format:
             name: csv

--- a/demo/project_demo03-GreenTrip/prepare.sh
+++ b/demo/project_demo03-GreenTrip/prepare.sh
@@ -15,6 +15,7 @@ then
 fi
 
 # Push test data to topic.
-while mapfile -t -n 10000 ary && ((${#ary[@]})); do
-    printf '%s\n' "${ary[@]}" | rpk topic produce green_trip_demo_large_input -f '%v'
-done < "${THIS_DIR}"/green_tripdata.csv
+printf -v pasteargs %*s 10000
+while read i; do
+  echo $i | rpk topic produce green_trip_demo_large_input -f '%v'
+done <  <(cat "${THIS_DIR}"/green_tripdata.csv | paste -d "\n" ${pasteargs// /- })

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -34,8 +34,7 @@ RUN arch=`dpkg --print-architecture`; \
     && dpkg -i grafana-enterprise_9.3.6_$arch.deb \
     && rm grafana-enterprise_9.3.6_$arch.deb
 
-ADD ./dbsp_files.tar /database-stream-processor
-ADD ./sql_compiler_files.tar /database-stream-processor/sql-to-dbsp-compiler
+COPY . /database-stream-processor
 
 RUN cd /database-stream-processor/crates/pipeline_manager \
     && ~/.cargo/bin/cargo install --path . \

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,10 +1,14 @@
 Bringing up a local instance of DBSP
 ===================================
 
-To bring up a local DBSP instance and a Redpanda container, run the following:
+First, install [Docker compose](https://github.com/docker/compose).
+
+Next, to bring up a local DBSP instance and a Redpanda container, run the following from the `deploy/` folder:
 
 ```docker compose up``
 
 This will bring up two containers: `dbsp` and `redpanda`.
 
-Open your browser and you should now be able to see the pipeline manager dashboard on localhost:8081.
+Open your browser and you should now be able to see the pipeline manager dashboard on `localhost:8081`.
+If you don't, double check that there are no port conflicts on your system (you can view and modify
+the port mappings in `deploy/docker-compose.yml`).

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,14 +1,14 @@
 Bringing up a local instance of DBSP
 ===================================
 
-First, install [Docker compose](https://github.com/docker/compose).
+First, install [Docker compose](https://docs.docker.com/compose/install/).
 
 Next, to bring up a local DBSP instance and a Redpanda container, run the following from the `deploy/` folder:
 
-```docker compose up``
+```docker compose up```
 
 This will bring up two containers: `dbsp` and `redpanda`.
 
-Open your browser and you should now be able to see the pipeline manager dashboard on `localhost:8081`.
+Open your browser and you should now be able to see the pipeline manager dashboard on `localhost:8085`.
 If you don't, double check that there are no port conflicts on your system (you can view and modify
 the port mappings in `deploy/docker-compose.yml`).

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,24 +1,10 @@
 Bringing up a local instance of DBSP
 ===================================
 
-First, build a DBSP Docker image:
+To bring up a local DBSP instance and a Redpanda container, run the following:
 
-```
-./docker.sh
-```
+```docker compose up``
 
-Next, bring up an instance of the container and forward the container's port
-8080 to a port on the host of your choice (e.g. 8081):
-
-```
-docker run --name dbsp -p 8081:8080 --rm dbspmanager
-```
+This will bring up two containers: `dbsp` and `redpanda`.
 
 Open your browser and you should now be able to see the pipeline manager dashboard on localhost:8081.
-
-
-To shutdown the container, run:
-
-```
-docker kill dbsp
-```

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,18 +1,50 @@
+volumes:
+  redpanda-0: null
+
 services:
   dbsp:
     build:
       context: ../
       dockerfile: deploy/Dockerfile
     ports:
-      - "8081:8080"
+      - "8085:8080"
     stop_grace_period: 0s
     container_name: dbsp
+    environment:
+      - REDPANDA_BROKERS=redpanda:9092
+
   redpanda:
-    image: docker.redpanda.com/redpandadata/redpanda:latest
+    command:
+      - redpanda
+      - start
+      - --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:19092
+      # Address the broker advertises to clients that connect to the Kafka API.
+      # Use the internal addresses to connect to the Redpanda brokers'
+      # from inside the same Docker network.
+      # Use the external addresses to connect to the Redpanda brokers'
+      # from outside the Docker network.
+      - --advertise-kafka-addr internal://redpanda:9092,external://localhost:19092
+      - --pandaproxy-addr internal://0.0.0.0:8082,external://0.0.0.0:18082
+      # Address the broker advertises to clients that connect to the HTTP Proxy.
+      - --advertise-pandaproxy-addr internal://redpanda:8082,external://localhost:18082
+      - --schema-registry-addr internal://0.0.0.0:8081,external://0.0.0.0:18081
+      # Redpanda brokers use the RPC API to communicate with eachother internally.
+      - --rpc-addr redpanda:33145
+      - --advertise-rpc-addr redpanda:33145
+      # Tells Seastar (the framework Redpanda uses under the hood) to use 1 core on the system.
+      - --smp 1
+      # The amount of memory to make available to Redpanda.
+      - --memory 1G
+      # Mode dev-container uses well-known configuration properties for development in containers.
+      - --mode dev-container
+      # enable logs for debugging.
+      # - --default-log-level=debug
+    image: docker.redpanda.com/vectorized/redpanda:v22.3.11
     container_name: redpanda
+    volumes:
+      - redpanda-0:/var/lib/redpanda/data
     ports:
-      - "3000:3000"
-      - "8083:8081"
-      - "8084:8082"
-      - "9092:9092"
-      - "9644:9644"
+      - 18081:18081
+      - 18082:18082
+      - 19092:19092
+      - 19644:9644

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,17 +1,17 @@
 services:
-  web:
+  dbsp:
     build:
       context: ../
       dockerfile: deploy/Dockerfile
     ports:
-      - "8001:8000"
+      - "8081:8080"
     container_name: dbsp
   redpanda:
     image: docker.redpanda.com/redpandadata/redpanda:latest
     container_name: redpanda
     ports:
       - "3000:3000"
-      - "8081:8081"
-      - "8082:8082"
+      - "8083:8081"
+      - "8084:8082"
       - "9092:9092"
       - "9644:9644"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  web:
+    build:
+      context: ../
+      dockerfile: deploy/Dockerfile
+    ports:
+      - "8001:8000"
+    container_name: dbsp
+  redpanda:
+    image: docker.redpanda.com/redpandadata/redpanda:latest
+    container_name: redpanda
+    ports:
+      - "3000:3000"
+      - "8081:8081"
+      - "8082:8082"
+      - "9092:9092"
+      - "9644:9644"

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       dockerfile: deploy/Dockerfile
     ports:
       - "8081:8080"
+    stop_grace_period: 0s
     container_name: dbsp
   redpanda:
     image: docker.redpanda.com/redpandadata/redpanda:latest

--- a/deploy/docker.sh
+++ b/deploy/docker.sh
@@ -4,17 +4,10 @@ set -e
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DEFAULT_SQL_COMPILER_PATH="${THIS_DIR}/../sql-to-dbsp-compiler"
 SQL_COMPILER="${1:-$DEFAULT_SQL_COMPILER_PATH}"
-DBSP_PATH="${THIS_DIR}/../"
 
 if [ ! -d "$SQL_COMPILER" ]; then
     echo "Could not find SQL compiler source (https://github.com/vmware/sql-to-dbsp-compiler) at path $SQL_COMPILER."
     exit 1
 fi
 
-(cd ${DBSP_PATH} && (git ls-files | tar -cvf ${THIS_DIR}/dbsp_files.tar -T -))
-(cd ${SQL_COMPILER} && (git ls-files | tar -cvf ${THIS_DIR}/sql_compiler_files.tar -T -))
-
-docker build -f "${THIS_DIR}/Dockerfile" -t dbspmanager ${THIS_DIR}
-
-rm ${THIS_DIR}/dbsp_files.tar
-rm ${THIS_DIR}/sql_compiler_files.tar
+docker build -f "${THIS_DIR}/Dockerfile" -t dbspmanager ${THIS_DIR}/..


### PR DESCRIPTION
We can now just run `docker compose up` to bring up a DBSP container alongside a Redpanda container.

Also simplifies the Docker container build process. We now avoid using git-ls and instead send the local folder over as is, with a `.dockerignore` file to avoid sending `/target` and some other files.