### PR TITLE
#321 postfix: read in batches of inputs at a time

### DIFF
--- a/crates/pipeline_manager/src/db.rs
+++ b/crates/pipeline_manager/src/db.rs
@@ -127,6 +127,7 @@ impl ProjectStatus {
                 }
             }
             Some("rust_error") => Ok(Self::RustError(error_string.unwrap_or_default())),
+            Some("system_error") => Ok(Self::SystemError(error_string.unwrap_or_default())),
             Some(status) => Err(AnyError::msg(format!("invalid status string '{status}'"))),
         }
     }

--- a/demo/project_demo01-TimeSeriesEnrich/prepare.sh
+++ b/demo/project_demo01-TimeSeriesEnrich/prepare.sh
@@ -19,12 +19,10 @@ then
 fi
 
 # Push test data to topics.
-printf -v pasteargs %*s 1000
-while read i; do
-  echo $i | rpk topic produce fraud_demo_large_demographics -f '%v'
-done <  <(cat "${THIS_DIR}"/demographics.csv | paste -d "\n" ${pasteargs// /- })
+while IFS= read -r line; do
+  { printf '%s\n' "$line"; head -n 999; } | rpk topic produce fraud_demo_large_demographics -f '%v'
+done < "${THIS_DIR}"/demographics.csv
 
-printf -v pasteargs %*s 5000
-while read i; do
-  echo $i | rpk topic produce fraud_demo_large_transactions -f '%v'
-done <  <(cat "${THIS_DIR}"/transactions.csv | paste -d "\n" ${pasteargs// /- })
+while IFS= read -r line; do
+  { printf '%s\n' "$line"; head -n 4999; } | rpk topic produce fraud_demo_large_transactions -f '%v'
+done < "${THIS_DIR}"/transactions.csv

--- a/demo/project_demo03-GreenTrip/prepare.sh
+++ b/demo/project_demo03-GreenTrip/prepare.sh
@@ -15,7 +15,6 @@ then
 fi
 
 # Push test data to topic.
-printf -v pasteargs %*s 10000
-while read i; do
-  echo $i | rpk topic produce green_trip_demo_large_input -f '%v'
-done <  <(cat "${THIS_DIR}"/green_tripdata.csv | paste -d "\n" ${pasteargs// /- })
+while IFS= read -r line; do
+  { printf '%s\n' "$line"; head -n 9999; }  | rpk topic produce green_trip_demo_large_input -f '%v'
+done < "${THIS_DIR}"/green_tripdata.csv 


### PR DESCRIPTION
This method to read a batch of inputs at a time should work across various shells and be consistent between Linux and Mac OSX. I suspect it's not as fast as mapfile/readarray, but fast enough to run `demo/docker_demo.sh` in about 10 minutes.