### PR TITLE
Have a one-liner to run Docker without building from sources

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,4 +1,3 @@
-
 on:
   push:
   release:
@@ -6,7 +5,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: dbsp-demo/dbspmanager
+  IMAGE_NAME: ${{ github.repository_owner }}/dbspmanager
 
 jobs:
   build-and-push-image:
@@ -38,8 +37,8 @@ jobs:
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.USER }}
-          password: ${{ secrets.TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,14 +1,24 @@
 Bringing up a local instance of DBSP
 ===================================
 
+
 First, install [Docker compose](https://docs.docker.com/compose/install/).
 
-Next, to bring up a local DBSP instance and a Redpanda container, run the following from the `deploy/` folder:
+Next, to bring up a local DBSP instance and a Redpanda container, run the following:
 
-```docker compose up```
+```
+curl https://raw.githubusercontent.com/vmware/database-stream-processor/main/deploy/docker-compose.yml | docker compose -f - up
+```
 
 This will bring up two containers: `dbsp` and `redpanda`.
 
 Open your browser and you should now be able to see the pipeline manager dashboard on `localhost:8085`.
 If you don't, double check that there are no port conflicts on your system (you can view and modify
 the port mappings in `deploy/docker-compose.yml`).
+
+If you're a developer and want to bring up a local instance of DBSP from sources, run the following from the
+`deploy/` folder:
+
+```
+docker compose -f docker-compose-dev.yml up
+```

--- a/deploy/docker-compose-dev.yml
+++ b/deploy/docker-compose-dev.yml
@@ -3,7 +3,9 @@ volumes:
 
 services:
   dbsp:
-    image: ghcr.io/vmware/dbspmanager:latest
+   build:
+     context: ../
+     dockerfile: deploy/Dockerfile
     ports:
       - "8085:8080"
     stop_grace_period: 0s


### PR DESCRIPTION
We'll need to do a release to get a container pushed for the one liner to work, but the set up is in place to do so. I tested it from a fork.

Also uses GITHUB_TOKEN to not have to set up secrets in the repo.

We can also consider having a script that checks if docker is installed before running compose.