### PR TITLE
Move timekeeping into the circuit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -385,12 +385,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Checkout SQL compiler
-        uses: actions/checkout@v3
         with:
-          repository: vmware/sql-to-dbsp-compiler
-          path: 'sql-to-dbsp-compiler'
+          submodules: true
 
       - name: Set up JDK 11
         uses: actions/setup-java@v2

--- a/crates/adapters/src/deinput.rs
+++ b/crates/adapters/src/deinput.rs
@@ -144,11 +144,11 @@ pub trait DeCollectionHandle: Send {
     ///
     /// The `deserializer` argument wraps a single serialized record whose
     /// type depends on the underlying input stream: streams created by
-    /// [`Circuit::add_input_zset`](`dbsp::Circuit::add_input_zset`)
-    /// and [`Circuit::add_input_set`](`dbsp::Circuit::add_input_set`)
+    /// [`RootCircuit::add_input_zset`](`dbsp::RootCircuit::add_input_zset`)
+    /// and [`RootCircuit::add_input_set`](`dbsp::RootCircuit::add_input_set`)
     /// methods support deletion by value, hence the serialized record must
     /// match the value type of the stream.  Streams created with
-    /// [`Circuit::add_input_map`](`dbsp::Circuit::add_input_map`)
+    /// [`RootCircuit::add_input_map`](`dbsp::RootCircuit::add_input_map`)
     /// support deletion by key, so the serialized record must match the key
     /// type of the stream.
     ///
@@ -197,7 +197,8 @@ pub trait DeCollectionHandle: Send {
 }
 
 /// An input handle that wraps a [`CollectionHandle<V, R>`](`CollectionHandle`)
-/// returned by [`Circuit::add_input_zset`](`dbsp::Circuit::add_input_zset`).
+/// returned by
+/// [`RootCircuit::add_input_zset`](`dbsp::RootCircuit::add_input_zset`).
 ///
 /// The [`insert`](`Self::insert`) method of this handle deserializes value
 /// `v` type `V` and buffers a `(v, +1)` update for the underlying
@@ -265,7 +266,8 @@ where
 }
 
 /// An input handle that wraps a [`UpsertHandle<V, bool>`](`UpsertHandle`)
-/// returned by [`Circuit::add_input_set`](`dbsp::Circuit::add_input_set`).
+/// returned by
+/// [`RootCircuit::add_input_set`](`dbsp::RootCircuit::add_input_set`).
 ///
 /// The [`insert`](`Self::insert`) method of this handle deserializes value
 /// `v` type `V` and buffers a `(v, true)` update for the underlying
@@ -326,7 +328,8 @@ where
 }
 
 /// An input handle that wraps a [`UpsertHandle<K, Option<V>>`](`UpsertHandle`)
-/// returned by [`Circuit::add_input_map`](`dbsp::Circuit::add_input_map`).
+/// returned by
+/// [`RootCircuit::add_input_map`](`dbsp::RootCircuit::add_input_map`).
 ///
 /// The [`insert`](`Self::insert`) method of this handle deserializes value
 /// `v` type `V` and buffers a `(key_func(v), Some(v))` update for the

--- a/crates/dbsp/benches/gdelt/personal_network.rs
+++ b/crates/dbsp/benches/gdelt/personal_network.rs
@@ -43,7 +43,7 @@ use dbsp::{
         spine_fueled::{MergeState, MergeVariant, Spine},
         Batch, BatchReader, Batcher, Builder, Consumer, Cursor, Merger, ValueConsumer,
     },
-    Circuit, DBData, DBWeight, NumEntries, OrdIndexedZSet, OrdZSet, Stream,
+    Circuit, DBData, DBWeight, NumEntries, OrdIndexedZSet, OrdZSet, RootCircuit, Stream,
 };
 use hashbrown::HashMap;
 use size_of::SizeOf;
@@ -60,8 +60,8 @@ pub fn personal_network(
     target: ArcStr,
     date_start: Option<u64>,
     date_end: Option<u64>,
-    events: &Stream<Circuit<()>, OrdZSet<PersonalNetworkGkgEntry, i32>>,
-) -> Stream<Circuit<()>, OrdZSet<(ArcStr, ArcStr), i32>> {
+    events: &Stream<RootCircuit, OrdZSet<PersonalNetworkGkgEntry, i32>>,
+) -> Stream<RootCircuit, OrdZSet<(ArcStr, ArcStr), i32>> {
     // Filter out events outside of our date range and that don't mention our target
     let events_filter: Box<dyn Fn(&PersonalNetworkGkgEntry) -> bool> = match (date_start, date_end)
     {
@@ -126,13 +126,12 @@ pub fn personal_network(
 }
 
 // TODO: Hash collections/traces
-fn hashjoin<C, F, Iter, K, V1, V2, R, Z>(
-    left: &Stream<Circuit<C>, OrdIndexedZSet<K, V1, R>>,
-    right: &Stream<Circuit<C>, OrdIndexedZSet<K, V2, R>>,
+fn hashjoin<F, Iter, K, V1, V2, R, Z>(
+    left: &Stream<RootCircuit, OrdIndexedZSet<K, V1, R>>,
+    right: &Stream<RootCircuit, OrdIndexedZSet<K, V2, R>>,
     join: F,
-) -> Stream<Circuit<C>, Z>
+) -> Stream<RootCircuit, Z>
 where
-    C: Clone + 'static,
     F: Fn(&K, &V1, &V2) -> Iter + Clone + 'static,
     Iter: IntoIterator<Item = (Z::Key, Z::Val)> + 'static,
     K: DBData,

--- a/crates/dbsp/benches/ldbc-graphalytics/data.rs
+++ b/crates/dbsp/benches/ldbc-graphalytics/data.rs
@@ -3,7 +3,7 @@ use dbsp::{
     algebra::{HasOne, Present, F64},
     default_hash,
     trace::{Batch, Batcher, Builder},
-    Circuit, OrdIndexedZSet, OrdZSet, Stream,
+    ChildCircuit, OrdIndexedZSet, OrdZSet, Stream,
 };
 use indicatif::{HumanBytes, ProgressBar, ProgressState, ProgressStyle};
 use reqwest::header::CONTENT_LENGTH;
@@ -35,7 +35,7 @@ pub type EdgeMap<D = Present> = OrdIndexedZSet<Node, Node, D>;
 pub type DistanceSet<D = Present> = OrdZSet<(Node, Distance), D>;
 pub type DistanceMap<D = Present> = OrdIndexedZSet<Node, Distance, D>;
 
-pub type Streamed<P, T> = Stream<Circuit<P>, T>;
+pub type Streamed<P, T> = Stream<ChildCircuit<P>, T>;
 
 pub type Ranks<P> = Streamed<P, RankMap>;
 pub type Edges<P, D = Present> = Streamed<P, EdgeMap<D>>;

--- a/crates/dbsp/benches/ldbc-graphalytics/main.rs
+++ b/crates/dbsp/benches/ldbc-graphalytics/main.rs
@@ -18,7 +18,7 @@ use dbsp::{
     operator::Generator,
     profile::CPUProfiler,
     trace::{BatchReader, Cursor},
-    Circuit,
+    Circuit, RootCircuit,
 };
 use hashbrown::HashMap;
 use indicatif::HumanBytes;
@@ -150,7 +150,7 @@ fn main() {
 
         let output_inner = output.clone();
         let args_for_circuit = args.clone();
-        let root = Circuit::build(move |circuit| {
+        let root = RootCircuit::build(move |circuit| {
             if config.profile && is_leader {
                 attach_profiling(dataset, circuit);
             }
@@ -415,7 +415,7 @@ fn main() {
     std::process::exit(incorrect_results_main.load(Ordering::Relaxed) as i32);
 }
 
-fn attach_profiling(dataset: DataSet, circuit: &mut Circuit<()>) {
+fn attach_profiling(dataset: DataSet, circuit: &mut RootCircuit) {
     let cpu_profiler = CPUProfiler::new();
     cpu_profiler.attach(circuit, "cpu profiler");
 

--- a/crates/dbsp/benches/path.rs
+++ b/crates/dbsp/benches/path.rs
@@ -1,9 +1,8 @@
 use dbsp::{
     mimalloc::MiMalloc,
     operator::{FilterMap, Generator},
-    time::NestedTimestamp32,
     trace::{ord::OrdZSet, Batch},
-    Circuit, Runtime, Stream,
+    Circuit, RootCircuit, Runtime, Stream,
 };
 
 #[global_allocator]
@@ -11,7 +10,7 @@ static ALLOC: MiMalloc = MiMalloc;
 
 fn main() {
     let hruntime = Runtime::run(16, || {
-        let circuit = Circuit::build(|circuit| {
+        let circuit = RootCircuit::build(|circuit| {
             /*
             use dbsp::{
                 circuit::{trace::SchedulerEvent, GlobalNodeId},
@@ -107,10 +106,7 @@ fn main() {
                     let edges_indexed = edges.index();
 
                     Ok(edges.plus(
-                        &paths_inverted_indexed.join::<NestedTimestamp32, _, _, _>(
-                            &edges_indexed,
-                            |_via, from, to| (*from, *to),
-                        ),
+                        &paths_inverted_indexed.join(&edges_indexed, |_via, from, to| (*from, *to)),
                     ))
                 })
                 .unwrap();

--- a/crates/dbsp/examples/degrees.rs
+++ b/crates/dbsp/examples/degrees.rs
@@ -59,14 +59,12 @@ fn main() -> Result<()> {
 
         // Count the number of edges with each node as its source (each node's
         // out-degree).
-        let degrees = edges
-            .map(|(src, _dst)| *src)
-            .aggregate_linear::<(), _, _>(|_k, _v| 1);
+        let degrees = edges.map(|(src, _dst)| *src).aggregate_linear(|_k, _v| 1);
 
         // Count the number of nodes with each out-degree.
         let distribution = degrees
             .map(|(_src, count)| *count)
-            .aggregate_linear::<(), _, _>(|_k, _v| 1);
+            .aggregate_linear(|_k, _v| 1);
 
         (hedges, degrees.output(), distribution.output())
     })

--- a/crates/dbsp/examples/orgchart.rs
+++ b/crates/dbsp/examples/orgchart.rs
@@ -70,12 +70,10 @@ fn main() -> Result<()> {
         // employee } then SkipLevel { grandmanager: manager, manager: common,
         // employee }.
         let skiplevels: Stream<_, SkipLevels> =
-            manages_by_employee.join::<(), _, _, _>(&manages_by_manager, |common, m1, m2| {
-                SkipLevel {
-                    grandmanager: m1.manager,
-                    manager: *common,
-                    employee: m2.employee,
-                }
+            manages_by_employee.join(&manages_by_manager, |common, m1, m2| SkipLevel {
+                grandmanager: m1.manager,
+                manager: *common,
+                employee: m2.employee,
             });
 
         (hmanages, skiplevels.output())

--- a/crates/dbsp/src/circuit/mod.rs
+++ b/crates/dbsp/src/circuit/mod.rs
@@ -20,8 +20,8 @@ pub mod trace;
 
 pub use activations::{Activations, Activator};
 pub use circuit_builder::{
-    Circuit, CircuitHandle, ExportId, ExportStream, FeedbackConnector, GlobalNodeId, NodeId,
-    OwnershipPreference, Scope, Stream,
+    ChildCircuit, Circuit, CircuitHandle, ExportId, ExportStream, FeedbackConnector, GlobalNodeId,
+    NodeId, OwnershipPreference, RootCircuit, Scope, Stream, WithClock,
 };
 pub use dbsp_handle::DBSPHandle;
 pub use runtime::{Error as RuntimeError, LocalStore, LocalStoreMarker, Runtime, RuntimeHandle};

--- a/crates/dbsp/src/circuit/runtime.rs
+++ b/crates/dbsp/src/circuit/runtime.rs
@@ -112,13 +112,13 @@ impl Runtime {
     ///
     /// # #[cfg(not(all(windows, miri)))]
     /// # fn main() {
-    /// use dbsp::circuit::{Circuit, Runtime};
+    /// use dbsp::circuit::{Circuit, RootCircuit, Runtime};
     ///
     /// // Create a runtime with 4 worker threads.
     /// let hruntime = Runtime::run(4, || {
     ///     // This closure runs within each worker thread.
     ///
-    ///     let root = Circuit::build(move |circuit| {
+    ///     let root = RootCircuit::build(move |circuit| {
     ///         // Populate `circuit` with operators.
     ///     })
     ///     .unwrap()
@@ -351,7 +351,7 @@ mod tests {
     use crate::{
         circuit::schedule::{DynamicScheduler, Scheduler, StaticScheduler},
         operator::Generator,
-        Circuit,
+        Circuit, RootCircuit,
     };
     use std::{cell::RefCell, rc::Rc, thread::sleep, time::Duration};
 
@@ -374,7 +374,7 @@ mod tests {
         let hruntime = Runtime::run(4, || {
             let data = Rc::new(RefCell::new(vec![]));
             let data_clone = data.clone();
-            let root = Circuit::build_with_scheduler::<_, _, S>(move |circuit| {
+            let root = RootCircuit::build_with_scheduler::<_, _, S>(move |circuit| {
                 let runtime = Runtime::runtime().unwrap();
                 // Generator that produces values using `sequence_next`.
                 circuit
@@ -415,7 +415,7 @@ mod tests {
     {
         let hruntime = Runtime::run(16, || {
             // Create a nested circuit that iterates forever.
-            let root = Circuit::build_with_scheduler::<_, _, S>(move |circuit| {
+            let root = RootCircuit::build_with_scheduler::<_, _, S>(move |circuit| {
                 circuit
                     .iterate_with_scheduler::<_, _, _, S>(|child| {
                         let mut n: usize = 0;

--- a/crates/dbsp/src/circuit/schedule/dynamic_scheduler.rs
+++ b/crates/dbsp/src/circuit/schedule/dynamic_scheduler.rs
@@ -193,9 +193,9 @@ impl Inner {
     }
 
     /// Process and dequeue new notifications.
-    fn process_notifications<P>(&mut self, circuit: &Circuit<P>)
+    fn process_notifications<C>(&mut self, circuit: &C)
     where
-        P: Clone + 'static,
+        C: Circuit,
     {
         let mut nodes = self.notifications.nodes.lock().unwrap();
 
@@ -226,9 +226,9 @@ impl Inner {
         }
     }
 
-    fn prepare<P>(circuit: &Circuit<P>) -> Result<Self, Error>
+    fn prepare<C>(circuit: &C) -> Result<Self, Error>
     where
-        P: Clone + 'static,
+        C: Circuit,
     {
         // Check that ownership constraints don't introduce cycles.
         let mut g = circuit_graph(circuit);
@@ -325,9 +325,9 @@ impl Inner {
         Ok(scheduler)
     }
 
-    fn step<P>(&mut self, circuit: &Circuit<P>) -> Result<(), Error>
+    fn step<C>(&mut self, circuit: &C) -> Result<(), Error>
     where
-        P: Clone + 'static,
+        C: Circuit,
     {
         circuit.log_scheduler_event(&SchedulerEvent::step_start());
 
@@ -371,6 +371,7 @@ impl Inner {
                 }
             }
         }
+        circuit.tick();
 
         circuit.log_scheduler_event(&SchedulerEvent::step_end());
         Ok(())
@@ -386,16 +387,16 @@ impl DynamicScheduler {
 }
 
 impl Scheduler for DynamicScheduler {
-    fn prepare<P>(circuit: &Circuit<P>) -> Result<Self, Error>
+    fn prepare<C>(circuit: &C) -> Result<Self, Error>
     where
-        P: Clone + 'static,
+        C: Circuit,
     {
         Ok(Self(RefCell::new(Inner::prepare(circuit)?)))
     }
 
-    fn step<P>(&self, circuit: &Circuit<P>) -> Result<(), Error>
+    fn step<C>(&self, circuit: &C) -> Result<(), Error>
     where
-        P: Clone + 'static,
+        C: Circuit,
     {
         self.inner_mut().step(circuit)
     }

--- a/crates/dbsp/src/circuit/schedule/static_scheduler.rs
+++ b/crates/dbsp/src/circuit/schedule/static_scheduler.rs
@@ -23,9 +23,9 @@ impl Scheduler for StaticScheduler {
     // nodes in a topological order.
     // TODO: compute a schedule that takes into account operators that consume
     // inputs by-value.
-    fn prepare<P>(circuit: &Circuit<P>) -> Result<Self, Error>
+    fn prepare<C>(circuit: &C) -> Result<Self, Error>
     where
-        P: Clone + 'static,
+        C: Circuit,
     {
         let mut g = circuit_graph(circuit);
 
@@ -49,9 +49,9 @@ impl Scheduler for StaticScheduler {
         Ok(Self { schedule })
     }
 
-    fn step<P>(&self, circuit: &Circuit<P>) -> Result<(), Error>
+    fn step<C>(&self, circuit: &C) -> Result<(), Error>
     where
-        P: Clone + 'static,
+        C: Circuit,
     {
         circuit.log_scheduler_event(&SchedulerEvent::step_start());
 
@@ -74,6 +74,7 @@ impl Scheduler for StaticScheduler {
                 }
             }
         }
+        circuit.tick();
 
         circuit.log_scheduler_event(&SchedulerEvent::step_end());
         Ok(())

--- a/crates/dbsp/src/circuit/trace.rs
+++ b/crates/dbsp/src/circuit/trace.rs
@@ -8,9 +8,10 @@
 //! [`SchedulerEvent`]s carrying information about circuit's runtime
 //! behavior.
 //!
-//! See [`super::Circuit::register_circuit_event_handler`] and
-//! [`super::CircuitHandle::register_scheduler_event_handler`] APIs for
-//! attaching event handlers to a circuit.
+//! See
+//! [`RootCircuit::register_circuit_event_handler`](`crate::RootCircuit::register_circuit_event_handler`)
+//! and [`CircuitHandle::register_scheduler_event_handler`](`crate::CircuitHandle::register_scheduler_event_handler`)
+//! APIs for attaching event handlers to a circuit.
 //!
 //! Event handlers are invoked synchronously and therefore must complete
 //! quickly, with any expensive processing completed asynchronously.
@@ -453,9 +454,10 @@ impl Display for CircuitEvent {
 ///                ClockEnd               StepEnd       EvalEnd(id)
 /// ```
 ///
-/// The root circuit automaton is instantiated by the [`super::Circuit::build`]
-/// function.  A subcircuit automaton is instantiated when its parent scheduler
-/// evaluates the node that contains this subcircuit (see below).
+/// The root circuit automaton is instantiated by the
+/// [`RootCircuit::build`](`crate::RootCircuit::build`) function.  A subcircuit
+/// automaton is instantiated when its parent scheduler evaluates the node that
+/// contains this subcircuit (see below).
 ///
 /// In the initial state, the circuit issues a
 /// [`ClockStart`](`SchedulerEvent::ClockStart`) event to reset its clock and

--- a/crates/dbsp/src/lib.rs
+++ b/crates/dbsp/src/lib.rs
@@ -25,7 +25,8 @@ pub use crate::time::Timestamp;
 
 pub use algebra::{IndexedZSet, ZSet};
 pub use circuit::{
-    Circuit, CircuitHandle, DBSPHandle, Runtime, RuntimeError, SchedulerError, Stream,
+    ChildCircuit, Circuit, CircuitHandle, DBSPHandle, RootCircuit, Runtime, RuntimeError,
+    SchedulerError, Stream,
 };
 pub use operator::{CollectionHandle, InputHandle, OutputHandle, UpsertHandle};
 pub use trace::ord::{OrdIndexedZSet, OrdZSet};

--- a/crates/dbsp/src/monitor/mod.rs
+++ b/crates/dbsp/src/monitor/mod.rs
@@ -8,7 +8,7 @@ pub mod visual_graph;
 use crate::circuit::{
     metadata::OperatorLocation,
     trace::{CircuitEvent, SchedulerEvent},
-    Circuit, GlobalNodeId, NodeId,
+    GlobalNodeId, NodeId, RootCircuit,
 };
 use circuit_graph::{CircuitGraph, Node, NodeKind, Region, RegionId};
 use std::{
@@ -133,7 +133,7 @@ pub struct TraceMonitor(Arc<Mutex<TraceMonitorInternal>>);
 impl TraceMonitor {
     /// Attach trace monitor to a circuit.  The monitor will register for
     /// both `CircuitEvent`s and `SchedulerEvent`s.
-    pub fn attach(&self, circuit: &Circuit<()>, handler_name: &str) {
+    pub fn attach(&self, circuit: &RootCircuit, handler_name: &str) {
         TraceMonitorInternal::attach(self.0.clone(), circuit, true, handler_name);
     }
 
@@ -143,7 +143,7 @@ impl TraceMonitor {
     /// [`Self::visualize_circuit`] and [`Self::visualize_circuit_annotate`],
     /// but it will not validate scheduler events, nor incur the associated
     /// overheads.
-    pub fn attach_circuit_events(&self, circuit: &Circuit<()>, handler_name: &str) {
+    pub fn attach_circuit_events(&self, circuit: &RootCircuit, handler_name: &str) {
         TraceMonitorInternal::attach(self.0.clone(), circuit, false, handler_name);
     }
 
@@ -197,7 +197,7 @@ pub struct TraceMonitorInternal {
 impl TraceMonitorInternal {
     fn attach(
         this: Arc<Mutex<Self>>,
-        circuit: &Circuit<()>,
+        circuit: &RootCircuit,
         monitor_eval: bool,
         handler_name: &str,
     ) {

--- a/crates/dbsp/src/operator/apply.rs
+++ b/crates/dbsp/src/operator/apply.rs
@@ -7,14 +7,14 @@ use crate::circuit::{
 };
 use std::{borrow::Cow, panic::Location};
 
-impl<P, T1> Stream<Circuit<P>, T1>
+impl<C, T1> Stream<C, T1>
 where
-    P: Clone + 'static,
+    C: Circuit,
     T1: Clone + 'static,
 {
     /// Apply  the `Apply` operator to `self`.
     #[track_caller]
-    pub fn apply<F, T2>(&self, func: F) -> Stream<Circuit<P>, T2>
+    pub fn apply<F, T2>(&self, func: F) -> Stream<C, T2>
     where
         F: FnMut(&T1) -> T2 + 'static,
         T2: Clone + 'static,
@@ -27,7 +27,7 @@ where
 
     /// Apply  the `Apply` operator to `self`.
     #[track_caller]
-    pub fn apply_named<N, F, T2>(&self, name: N, func: F) -> Stream<Circuit<P>, T2>
+    pub fn apply_named<N, F, T2>(&self, name: N, func: F) -> Stream<C, T2>
     where
         N: Into<Cow<'static, str>>,
         F: FnMut(&T1) -> T2 + 'static,
@@ -39,7 +39,7 @@ where
 
     /// Apply the `ApplyOwned` operator to `self`
     #[track_caller]
-    pub fn apply_owned<F, T2>(&self, func: F) -> Stream<Circuit<P>, T2>
+    pub fn apply_owned<F, T2>(&self, func: F) -> Stream<C, T2>
     where
         F: FnMut(T1) -> T2 + 'static,
         T2: Clone + 'static,
@@ -52,7 +52,7 @@ where
 
     /// Apply the `ApplyOwned` operator to `self` with a custom name
     #[track_caller]
-    pub fn apply_owned_named<N, F, T2>(&self, name: N, func: F) -> Stream<Circuit<P>, T2>
+    pub fn apply_owned_named<N, F, T2>(&self, name: N, func: F) -> Stream<C, T2>
     where
         N: Into<Cow<'static, str>>,
         F: FnMut(T1) -> T2 + 'static,
@@ -70,7 +70,7 @@ where
         owned: O,
         borrowed: B,
         fixpoint: F,
-    ) -> Stream<Circuit<P>, T2>
+    ) -> Stream<C, T2>
     where
         N: Into<Cow<'static, str>>,
         T2: Data,

--- a/crates/dbsp/src/operator/apply2.rs
+++ b/crates/dbsp/src/operator/apply2.rs
@@ -7,18 +7,14 @@ use crate::circuit::{
 };
 use std::{borrow::Cow, panic::Location};
 
-impl<P, T1> Stream<Circuit<P>, T1>
+impl<C, T1> Stream<C, T1>
 where
-    P: Clone + 'static,
+    C: Circuit,
     T1: Clone + 'static,
 {
     /// Apply a user-provided binary function to its inputs at each timestamp.
     #[track_caller]
-    pub fn apply2<F, T2, T3>(
-        &self,
-        other: &Stream<Circuit<P>, T2>,
-        func: F,
-    ) -> Stream<Circuit<P>, T3>
+    pub fn apply2<F, T2, T3>(&self, other: &Stream<C, T2>, func: F) -> Stream<C, T3>
     where
         T2: Clone + 'static,
         T3: Clone + 'static,
@@ -31,11 +27,7 @@ where
     /// Apply a user-provided binary function to its inputs at each timestamp,
     /// consuming the first input.
     #[track_caller]
-    pub fn apply2_owned<F, T2, T3>(
-        &self,
-        other: &Stream<Circuit<P>, T2>,
-        func: F,
-    ) -> Stream<Circuit<P>, T3>
+    pub fn apply2_owned<F, T2, T3>(&self, other: &Stream<C, T2>, func: F) -> Stream<C, T3>
     where
         T2: Clone + 'static,
         T3: Clone + 'static,
@@ -153,12 +145,12 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::{operator::Generator, Circuit};
+    use crate::{operator::Generator, Circuit, RootCircuit};
     use std::vec;
 
     #[test]
     fn apply2_test() {
-        let circuit = Circuit::build(move |circuit| {
+        let circuit = RootCircuit::build(move |circuit| {
             let mut inputs1 = vec![1, 2, 3].into_iter();
             let mut inputs2 = vec![-1, -2, -3].into_iter();
 

--- a/crates/dbsp/src/operator/communication/gather.rs
+++ b/crates/dbsp/src/operator/communication/gather.rs
@@ -27,9 +27,9 @@ type NotifyCallback = dyn Fn() + Send + Sync + 'static;
 circuit_cache_key!(GatherId<C, D>((GlobalNodeId, usize) => Stream<C, D>));
 circuit_cache_key!(local GatherDataId<T>(usize => Arc<GatherData<T>>));
 
-impl<P, B> Stream<Circuit<P>, B>
+impl<C, B> Stream<C, B>
 where
-    P: Clone + 'static,
+    C: Circuit,
     B: Send + 'static,
 {
     /// Collect all shards of a stream at the same worker.
@@ -38,7 +38,7 @@ where
     /// input batches across all workers. The output streams in all other
     /// workers will contain empty batches.
     #[track_caller]
-    pub fn gather(&self, receiver_worker: usize) -> Stream<Circuit<P>, B>
+    pub fn gather(&self, receiver_worker: usize) -> Stream<C, B>
     where
         // FIXME: Remove `Time = ()` restriction currently imposed by `.consolidate()`
         B: Batch<Time = ()> + Send,

--- a/crates/dbsp/src/operator/communication/mod.rs
+++ b/crates/dbsp/src/operator/communication/mod.rs
@@ -3,4 +3,4 @@ mod gather;
 mod shard;
 
 pub(crate) use exchange::Exchange;
-pub use exchange::{ExchangeReceiver, ExchangeSender};
+pub use exchange::{new_exchange_operators, ExchangeReceiver, ExchangeSender};

--- a/crates/dbsp/src/operator/consolidate.rs
+++ b/crates/dbsp/src/operator/consolidate.rs
@@ -13,9 +13,9 @@ use crate::{
 
 circuit_cache_key!(ConsolidateId<C, D>(GlobalNodeId => Stream<C, D>));
 
-impl<P, T> Stream<Circuit<P>, T>
+impl<C, T> Stream<C, T>
 where
-    P: Clone + 'static,
+    C: Circuit,
     T: Trace<Time = ()> + Clone,
 {
     // TODO: drop the `Time = ()` requirement?
@@ -30,7 +30,7 @@ where
     /// computed as the sum of deltas across all iterations of the circuit.
     /// Once the iteration has converged (e.g., reaching a fixed point) is a
     /// good time to consolidate the output.
-    pub fn consolidate(&self) -> Stream<Circuit<P>, T::Batch> {
+    pub fn consolidate(&self) -> Stream<C, T::Batch> {
         self.circuit()
             .cache_get_or_insert_with(ConsolidateId::new(self.origin_node_id().clone()), || {
                 let consolidated = self.circuit().add_unary_operator_with_preference(

--- a/crates/dbsp/src/operator/csv.rs
+++ b/crates/dbsp/src/operator/csv.rs
@@ -96,12 +96,12 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::{operator::CsvSource, zset, Circuit, OrdZSet};
+    use crate::{operator::CsvSource, zset, Circuit, OrdZSet, RootCircuit};
     use csv::ReaderBuilder;
 
     #[test]
     fn test_csv_reader() {
-        let circuit = Circuit::build(move |circuit| {
+        let circuit = RootCircuit::build(move |circuit| {
             let expected = zset! {
                 (18, 3, 237641) => 1,
                 (237641, 4, 18) => 1,

--- a/crates/dbsp/src/operator/delta0.rs
+++ b/crates/dbsp/src/operator/delta0.rs
@@ -9,16 +9,19 @@ use crate::{
 };
 use std::borrow::Cow;
 
-impl<P, D> Stream<Circuit<P>, D>
+impl<C, D> Stream<C, D>
 where
     D: HasZero + Clone + 'static,
-    P: Clone + 'static,
+    C: Circuit,
 {
     /// Import `self` from the parent circuit to `subcircuit` via the `Delta0`
     /// operator.
     ///
     /// See [`Delta0`] operator documentation.
-    pub fn delta0(&self, subcircuit: &Circuit<Circuit<P>>) -> Stream<Circuit<Circuit<P>>, D> {
+    pub fn delta0<CC>(&self, subcircuit: &CC) -> Stream<CC, D>
+    where
+        CC: Circuit<Parent = C>,
+    {
         let delta = subcircuit.import_stream(Delta0::new(), &self.try_sharded_version());
         delta.mark_sharded_if(self);
 
@@ -27,11 +30,14 @@ where
 
     /// Like [`Self::delta0`], but overrides the ownership
     /// preference on the input stream with `input_preference`.
-    pub fn delta0_with_preference(
+    pub fn delta0_with_preference<CC>(
         &self,
-        subcircuit: &Circuit<Circuit<P>>,
+        subcircuit: &CC,
         input_preference: OwnershipPreference,
-    ) -> Stream<Circuit<Circuit<P>>, D> {
+    ) -> Stream<CC, D>
+    where
+        CC: Circuit<Parent = C>,
+    {
         let delta = subcircuit.import_stream_with_preference(
             Delta0::new(),
             &self.try_sharded_version(),

--- a/crates/dbsp/src/operator/differentiate.rs
+++ b/crates/dbsp/src/operator/differentiate.rs
@@ -12,16 +12,16 @@ use size_of::SizeOf;
 circuit_cache_key!(DifferentiateId<C, D>(GlobalNodeId => Stream<C, D>));
 circuit_cache_key!(NestedDifferentiateId<C, D>(GlobalNodeId => Stream<C, D>));
 
-impl<P, D> Stream<Circuit<P>, D>
+impl<C, D> Stream<C, D>
 where
-    P: Clone + 'static,
+    C: Circuit + 'static,
     D: SizeOf + NumEntries + GroupValue,
 {
     /// Stream differentiation.
     ///
     /// Computes the difference between current and previous value
     /// of `self`: `differentiate(a) = a - z^-1(a)`.
-    pub fn differentiate(&self) -> Stream<Circuit<P>, D> {
+    pub fn differentiate(&self) -> Stream<C, D> {
         self.circuit()
             .cache_get_or_insert_with(DifferentiateId::new(self.origin_node_id().clone()), || {
                 let differentiated = self.circuit().add_binary_operator(
@@ -36,7 +36,7 @@ where
     }
 
     /// Nested stream differentiation.
-    pub fn differentiate_nested(&self) -> Stream<Circuit<P>, D> {
+    pub fn differentiate_nested(&self) -> Stream<C, D> {
         self.circuit()
             .cache_get_or_insert_with(
                 NestedDifferentiateId::new(self.origin_node_id().clone()),

--- a/crates/dbsp/src/operator/filter_map.rs
+++ b/crates/dbsp/src/operator/filter_map.rs
@@ -158,9 +158,9 @@ pub trait FilterMap<C> {
         O: Batch<Key = K, Val = V, Time = (), R = Self::R> + Clone + 'static;
 }
 
-impl<P, K, R> FilterMap<Circuit<P>> for Stream<Circuit<P>, OrdZSet<K, R>>
+impl<C, K, R> FilterMap<C> for Stream<C, OrdZSet<K, R>>
 where
-    P: Clone + 'static,
+    C: Circuit,
     K: DBData,
     R: DBWeight,
 {
@@ -179,7 +179,7 @@ where
         filtered
     }
 
-    fn map_generic<F, T, O>(&self, map_func: F) -> Stream<Circuit<P>, O>
+    fn map_generic<F, T, O>(&self, map_func: F) -> Stream<C, O>
     where
         F: Fn(Self::ItemRef<'_>) -> T + Clone + 'static,
         O: Batch<Key = T, Val = (), Time = (), R = Self::R>,
@@ -190,7 +190,7 @@ where
         )
     }
 
-    fn map_index_generic<F, KT, VT, O>(&self, map_func: F) -> Stream<Circuit<P>, O>
+    fn map_index_generic<F, KT, VT, O>(&self, map_func: F) -> Stream<C, O>
     where
         F: Fn(Self::ItemRef<'_>) -> (KT, VT) + 'static,
         O: Batch<Key = KT, Val = VT, Time = (), R = Self::R>,
@@ -201,7 +201,7 @@ where
         )
     }
 
-    fn flat_map_generic<F, I, O>(&self, func: F) -> Stream<Circuit<P>, O>
+    fn flat_map_generic<F, I, O>(&self, func: F) -> Stream<C, O>
     where
         F: Fn(Self::ItemRef<'_>) -> I + 'static,
         I: IntoIterator + 'static,
@@ -215,7 +215,7 @@ where
         )
     }
 
-    fn flat_map_index_generic<F, KT, VT, I, O>(&self, func: F) -> Stream<Circuit<P>, O>
+    fn flat_map_index_generic<F, KT, VT, I, O>(&self, func: F) -> Stream<C, O>
     where
         F: Fn(Self::ItemRef<'_>) -> I + 'static,
         I: IntoIterator<Item = (KT, VT)> + 'static,
@@ -228,9 +228,9 @@ where
     }
 }
 
-impl<P, K, V, R> FilterMap<Circuit<P>> for Stream<Circuit<P>, OrdIndexedZSet<K, V, R>>
+impl<C, K, V, R> FilterMap<C> for Stream<C, OrdIndexedZSet<K, V, R>>
 where
-    P: Clone + 'static,
+    C: Circuit,
     R: DBWeight,
     K: DBData,
     V: DBData,
@@ -250,7 +250,7 @@ where
         filtered
     }
 
-    fn map_generic<F, T, O>(&self, map_func: F) -> Stream<Circuit<P>, O>
+    fn map_generic<F, T, O>(&self, map_func: F) -> Stream<C, O>
     where
         F: Fn(Self::ItemRef<'_>) -> T + Clone + 'static,
         O: Batch<Key = T, Val = (), Time = (), R = Self::R>,
@@ -261,7 +261,7 @@ where
         )
     }
 
-    fn map_index_generic<F, KT, VT, O>(&self, map_func: F) -> Stream<Circuit<P>, O>
+    fn map_index_generic<F, KT, VT, O>(&self, map_func: F) -> Stream<C, O>
     where
         F: Fn(Self::ItemRef<'_>) -> (KT, VT) + 'static,
         O: Batch<Key = KT, Val = VT, Time = (), R = Self::R>,
@@ -269,7 +269,7 @@ where
         self.circuit().add_unary_operator(Map::new(map_func), self)
     }
 
-    fn flat_map_generic<F, I, O>(&self, func: F) -> Stream<Circuit<P>, O>
+    fn flat_map_generic<F, I, O>(&self, func: F) -> Stream<C, O>
     where
         F: Fn(Self::ItemRef<'_>) -> I + 'static,
         I: IntoIterator + 'static,
@@ -281,7 +281,7 @@ where
         )
     }
 
-    fn flat_map_index_generic<F, KT, VT, I, O>(&self, func: F) -> Stream<Circuit<P>, O>
+    fn flat_map_index_generic<F, KT, VT, I, O>(&self, func: F) -> Stream<C, O>
     where
         F: Fn(Self::ItemRef<'_>) -> I + 'static,
         I: IntoIterator<Item = (KT, VT)> + 'static,
@@ -730,13 +730,13 @@ mod test {
         indexed_zset,
         operator::{FilterMap, Generator},
         trace::ord::OrdZSet,
-        zset, Circuit,
+        zset, Circuit, RootCircuit,
     };
     use std::vec;
 
     #[test]
     fn filter_map_test() {
-        let circuit = Circuit::build(move |circuit| {
+        let circuit = RootCircuit::build(move |circuit| {
             let mut input: vec::IntoIter<OrdZSet<(isize, String), isize>> =
                 vec![zset! { (1, "1".to_string()) => 1, (-1, "-1".to_string()) => 1, (5, "5 foo".to_string()) => 1, (-2, "-2".to_string()) => 1 }].into_iter();
 

--- a/crates/dbsp/src/operator/inspect.rs
+++ b/crates/dbsp/src/operator/inspect.rs
@@ -7,10 +7,10 @@ use crate::circuit::{
 };
 use std::{borrow::Cow, marker::PhantomData};
 
-impl<P, D> Stream<Circuit<P>, D>
+impl<C, D> Stream<C, D>
 where
     D: Clone + 'static,
-    P: Clone + 'static,
+    C: Circuit,
 {
     /// Apply [`Inspect`] operator to `self`.
     ///
@@ -19,9 +19,9 @@ where
     /// ```
     /// # use dbsp::{
     /// #     operator::Generator,
-    /// #     Circuit,
+    /// #     Circuit, RootCircuit,
     /// # };
-    /// let circuit = Circuit::build(move |circuit| {
+    /// let circuit = RootCircuit::build(move |circuit| {
     ///     let mut n = 1;
     ///     let stream = circuit.add_source(Generator::new(move || {
     ///         let res = n;

--- a/crates/dbsp/src/operator/join_range.rs
+++ b/crates/dbsp/src/operator/join_range.rs
@@ -25,9 +25,9 @@ use crate::{
 };
 use std::{borrow::Cow, marker::PhantomData};
 
-impl<P, I1> Stream<Circuit<P>, I1>
+impl<C, I1> Stream<C, I1>
 where
-    P: Clone + 'static,
+    C: Circuit,
 {
     /// Range-join two streams into an `OrdZSet`.
     ///
@@ -38,10 +38,10 @@ where
     /// receives at each timestamp ignoring previous inputs.
     pub fn stream_join_range<RF, JF, It, I2>(
         &self,
-        other: &Stream<Circuit<P>, I2>,
+        other: &Stream<C, I2>,
         range_func: RF,
         join_func: JF,
-    ) -> Stream<Circuit<P>, OrdZSet<It::Item, I1::R>>
+    ) -> Stream<C, OrdZSet<It::Item, I1::R>>
     where
         I1: BatchReader<Time = ()> + Clone,
         I1::R: ZRingValue,
@@ -69,10 +69,10 @@ where
     /// receives at each timestamp ignoring previous inputs.
     pub fn stream_join_range_index<RF, JF, It, K, V, I2>(
         &self,
-        other: &Stream<Circuit<P>, I2>,
+        other: &Stream<C, I2>,
         range_func: RF,
         join_func: JF,
-    ) -> Stream<Circuit<P>, OrdIndexedZSet<K, V, I1::R>>
+    ) -> Stream<C, OrdIndexedZSet<K, V, I1::R>>
     where
         I1: BatchReader<Time = ()> + Clone,
         I1::R: ZRingValue,
@@ -89,10 +89,10 @@ where
     /// Like [`Self::stream_join_range`], but can return any indexed Z-set type.
     pub fn stream_join_range_generic<RF, JF, It, I2, O>(
         &self,
-        other: &Stream<Circuit<P>, I2>,
+        other: &Stream<C, I2>,
         range_func: RF,
         join_func: JF,
-    ) -> Stream<Circuit<P>, O>
+    ) -> Stream<C, O>
     where
         I1: BatchReader<Time = (), R = O::R> + Clone,
         I2: BatchReader<Time = (), R = O::R> + Clone,
@@ -198,11 +198,11 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::{operator::Generator, zset, Circuit};
+    use crate::{operator::Generator, zset, Circuit, RootCircuit};
 
     #[test]
     fn stream_join_range_test() {
-        let circuit = Circuit::build(move |circuit| {
+        let circuit = RootCircuit::build(move |circuit| {
             let mut input1 = vec![
                 zset! {
                     (1, 'a') => 1,

--- a/crates/dbsp/src/operator/neg.rs
+++ b/crates/dbsp/src/operator/neg.rs
@@ -9,12 +9,12 @@ use crate::{
 };
 use std::{borrow::Cow, marker::PhantomData, ops::Neg};
 
-impl<P, D> Stream<Circuit<P>, D>
+impl<C, D> Stream<C, D>
 where
     D: Clone + 'static + Neg<Output = D> + NegByRef,
-    P: Clone + 'static,
+    C: Circuit,
 {
-    pub fn neg(&self) -> Stream<Circuit<P>, D> {
+    pub fn neg(&self) -> Stream<C, D> {
         let negated = self
             .circuit()
             .add_unary_operator(UnaryMinus::new(), &self.try_sharded_version());
@@ -79,12 +79,12 @@ mod test {
         algebra::HasZero,
         operator::Generator,
         trace::{ord::OrdZSet, Batch},
-        zset, Circuit,
+        zset, Circuit, RootCircuit,
     };
 
     #[test]
     fn zset_sum() {
-        let build_circuit = |circuit: &Circuit<()>| {
+        let build_circuit = |circuit: &RootCircuit| {
             let mut s = <OrdZSet<_, _> as HasZero>::zero();
             let source = circuit.add_source(Generator::new(move || {
                 let res = s.clone();
@@ -98,7 +98,7 @@ mod test {
             source
         };
 
-        let circuit = Circuit::build(move |circuit| {
+        let circuit = RootCircuit::build(move |circuit| {
             build_circuit(circuit);
         })
         .unwrap()

--- a/crates/dbsp/src/operator/output.rs
+++ b/crates/dbsp/src/operator/output.rs
@@ -2,7 +2,7 @@ use super::Mailbox;
 use crate::{
     circuit::{
         operator_traits::{Operator, SinkOperator},
-        LocalStoreMarker, OwnershipPreference, Scope,
+        LocalStoreMarker, OwnershipPreference, RootCircuit, Scope,
     },
     trace::{Batch, Spine, Trace},
     Circuit, Runtime, Stream,
@@ -15,7 +15,7 @@ use std::{
 };
 use typedmap::TypedMapKey;
 
-impl<T> Stream<Circuit<()>, T>
+impl<T> Stream<RootCircuit, T>
 where
     T: Clone + Send + 'static,
 {

--- a/crates/dbsp/src/operator/semijoin.rs
+++ b/crates/dbsp/src/operator/semijoin.rs
@@ -17,9 +17,9 @@ use std::{
 
 circuit_cache_key!(SemijoinId<C, D>((GlobalNodeId, GlobalNodeId) => Stream<C, D>));
 
-impl<S, Pairs> Stream<Circuit<S>, Pairs>
+impl<C, Pairs> Stream<C, Pairs>
 where
-    S: Clone + 'static,
+    C: Circuit,
 {
     /// Semijoin two streams of batches.
     ///
@@ -35,10 +35,7 @@ where
     /// * `Pairs` - batch type in the first input stream.
     /// * `Keys` - batch type in the second input stream.
     /// * `Out` - output Z-set type.
-    pub fn semijoin_stream<Keys, Out>(
-        &self,
-        keys: &Stream<Circuit<S>, Keys>,
-    ) -> Stream<Circuit<S>, Out>
+    pub fn semijoin_stream<Keys, Out>(&self, keys: &Stream<C, Keys>) -> Stream<C, Out>
     where
         // TODO: Associated type bounds (rust/#52662) really simplify things
         // TODO: Allow non-unit timestamps

--- a/crates/dbsp/src/operator/stream_fold.rs
+++ b/crates/dbsp/src/operator/stream_fold.rs
@@ -1,11 +1,11 @@
 use crate::{
     circuit::OwnershipPreference,
     operator::{z1::DelayedId, Z1},
-    Circuit, NumEntries, Stream,
+    Circuit, NumEntries, RootCircuit, Stream,
 };
 use size_of::SizeOf;
 
-impl<T> Stream<Circuit<()>, T>
+impl<T> Stream<RootCircuit, T>
 where
     T: Clone + 'static,
 {
@@ -18,7 +18,7 @@ where
     /// * `fold_func` - closure that computes the new value of the accumulator
     ///   as a function of the previous value and the new input at each clock
     ///   cycle.
-    pub fn stream_fold<A, F>(&self, init: A, fold_func: F) -> Stream<Circuit<()>, A>
+    pub fn stream_fold<A, F>(&self, init: A, fold_func: F) -> Stream<RootCircuit, A>
     where
         F: Fn(A, &T) -> A + 'static,
         A: Eq + Clone + SizeOf + NumEntries + 'static,

--- a/crates/dbsp/src/operator/time_series/rolling_aggregate.rs
+++ b/crates/dbsp/src/operator/time_series/rolling_aggregate.rs
@@ -15,7 +15,7 @@ use crate::{
         Aggregator,
     },
     trace::{Builder, Cursor, Spine},
-    Circuit, DBData, DBWeight, Stream,
+    Circuit, DBData, DBWeight, RootCircuit, Stream,
 };
 use num::PrimInt;
 use std::{borrow::Cow, marker::PhantomData, ops::Neg};
@@ -24,7 +24,7 @@ use std::{borrow::Cow, marker::PhantomData, ops::Neg};
 // detail and can in principle be avoided.
 
 pub type OrdPartitionedOverStream<PK, TS, A, R> =
-    Stream<Circuit<()>, OrdPartitionedIndexedZSet<PK, TS, Option<A>, R>>;
+    Stream<RootCircuit, OrdPartitionedIndexedZSet<PK, TS, Option<A>, R>>;
 
 /// `Aggregator` object that computes a linear aggregation function.
 // TODO: we need this because we currently compute linear aggregates
@@ -100,7 +100,7 @@ where
     }
 }
 
-impl<B> Stream<Circuit<()>, B> {
+impl<B> Stream<RootCircuit, B> {
     /// Rolling aggregate of a partitioned stream over time range.
     ///
     /// For each record in the input stream, computes an aggregate
@@ -134,7 +134,7 @@ impl<B> Stream<Circuit<()>, B> {
         &self,
         aggregator: Agg,
         range: RelRange<TS>,
-    ) -> Stream<Circuit<()>, O>
+    ) -> Stream<RootCircuit, O>
     where
         B: PartitionedIndexedZSet<TS, V>,
         B::R: ZRingValue,
@@ -241,7 +241,7 @@ impl<B> Stream<Circuit<()>, B> {
         f: F,
         output_func: OF,
         range: RelRange<TS>,
-    ) -> Stream<Circuit<()>, Out>
+    ) -> Stream<RootCircuit, Out>
     where
         B: PartitionedIndexedZSet<TS, V>,
         B::R: ZRingValue,
@@ -466,13 +466,13 @@ mod test {
             Fold,
         },
         trace::{Batch, BatchReader, Cursor},
-        Circuit, CollectionHandle, DBSPHandle, OrdIndexedZSet, Runtime, Stream,
+        CollectionHandle, DBSPHandle, OrdIndexedZSet, RootCircuit, Runtime, Stream,
     };
 
     type DataBatch = OrdIndexedZSet<u64, (u64, i64), isize>;
-    type DataStream = Stream<Circuit<()>, DataBatch>;
+    type DataStream = Stream<RootCircuit, DataBatch>;
     type OutputBatch = OrdIndexedZSet<u64, (u64, Option<i64>), isize>;
-    type OutputStream = Stream<Circuit<()>, OutputBatch>;
+    type OutputStream = Stream<RootCircuit, OutputBatch>;
 
     // Reference implementation of `aggregate_range` for testing.
     fn aggregate_range_slow(batch: &DataBatch, partition: u64, range: Range<u64>) -> Option<i64> {

--- a/crates/dbsp/src/operator/time_series/window.rs
+++ b/crates/dbsp/src/operator/time_series/window.rs
@@ -10,9 +10,9 @@ use crate::{
 };
 use std::{borrow::Cow, cmp::max, marker::PhantomData};
 
-impl<P, B> Stream<Circuit<P>, B>
+impl<C, B> Stream<C, B>
 where
-    P: Clone + 'static,
+    C: Circuit,
     B: IndexedZSet,
     B::R: NegByRef,
 {
@@ -66,10 +66,7 @@ where
     ///                     └┬─┘                           │
     ///                      └─────────────────────────────┘
     /// ```
-    pub fn window(
-        &self,
-        bounds: &Stream<Circuit<P>, (B::Key, B::Key)>,
-    ) -> Stream<Circuit<P>, OrdZSet<B::Val, B::R>> {
+    pub fn window(&self, bounds: &Stream<C, (B::Key, B::Key)>) -> Stream<C, OrdZSet<B::Val, B::R>> {
         let trace = self.integrate_trace().delay_trace();
         self.circuit()
             .add_ternary_operator(<Window<B>>::new(), &trace, self, bounds)
@@ -214,12 +211,14 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::{operator::Generator, trace::ord::OrdIndexedZSet, zset, Circuit, Stream};
+    use crate::{
+        operator::Generator, trace::ord::OrdIndexedZSet, zset, Circuit, RootCircuit, Stream,
+    };
     use std::vec;
 
     #[test]
     fn sliding() {
-        let circuit = Circuit::build(move |circuit| {
+        let circuit = RootCircuit::build(move |circuit| {
             type Time = usize;
 
             let mut input = vec![
@@ -282,7 +281,7 @@ mod test {
 
     #[test]
     fn tumbling() {
-        let circuit = Circuit::build(move |circuit| {
+        let circuit = RootCircuit::build(move |circuit| {
             type Time = usize;
 
             let mut input = vec![
@@ -344,7 +343,7 @@ mod test {
 
     #[test]
     fn shrinking() {
-        let circuit = Circuit::build(move |circuit| {
+        let circuit = RootCircuit::build(move |circuit| {
             type Time = usize;
 
             let mut input = vec![

--- a/crates/dbsp/src/profile/cpu.rs
+++ b/crates/dbsp/src/profile/cpu.rs
@@ -6,7 +6,7 @@
 // - We currently do not measure the time spent in `clock_start`/`clock_end`
 //   events, which can in theory do non-trivial work.
 
-use crate::circuit::{trace::SchedulerEvent, Circuit, GlobalNodeId};
+use crate::circuit::{trace::SchedulerEvent, GlobalNodeId, RootCircuit};
 use hashbrown::HashMap;
 use std::{
     cell::RefCell,
@@ -78,7 +78,7 @@ impl CPUProfiler {
 
     /// Attach CPU profiler to a circuit.  The profiler will start measuring
     /// circuit's CPU usage.
-    pub fn attach(&self, circuit: &Circuit<()>, handler_name: &str) {
+    pub fn attach(&self, circuit: &RootCircuit, handler_name: &str) {
         let self_clone = self.clone();
 
         circuit.register_scheduler_event_handler(handler_name, move |event| {

--- a/crates/dbsp/src/profile/mod.rs
+++ b/crates/dbsp/src/profile/mod.rs
@@ -7,7 +7,7 @@ use crate::{
         GlobalNodeId,
     },
     monitor::TraceMonitor,
-    Circuit,
+    RootCircuit,
 };
 use std::{borrow::Cow, collections::HashMap, fmt::Write};
 
@@ -21,14 +21,14 @@ pub use cpu::CPUProfiler;
 pub struct Profiler {
     cpu_profiler: CPUProfiler,
     monitor: TraceMonitor,
-    circuit: Circuit<()>,
+    circuit: RootCircuit,
 }
 
 impl Profiler {
     /// Create profiler; attach it to `circuit`.
     ///
     /// Profiler is created with CPU profiling disabled.
-    pub fn new(circuit: &Circuit<()>) -> Self {
+    pub fn new(circuit: &RootCircuit) -> Self {
         let cpu_profiler = CPUProfiler::new();
 
         let monitor = TraceMonitor::new_panic_on_error();

--- a/crates/dbsp/src/time/nested_ts32.rs
+++ b/crates/dbsp/src/time/nested_ts32.rs
@@ -1,7 +1,7 @@
 use crate::{
     algebra::{Lattice, PartialOrder},
     circuit::Scope,
-    time::Timestamp,
+    time::{Product, Timestamp},
     trace::ord::OrdValBatch,
     DBData, DBWeight,
 };
@@ -84,6 +84,7 @@ impl PartialOrder for NestedTimestamp32 {
 }
 
 impl Timestamp for NestedTimestamp32 {
+    type Nested = Product<Self, u32>;
     type OrdValBatch<K: DBData, V: DBData, R: DBWeight> = OrdValBatch<K, V, Self, R>;
 
     fn minimum() -> Self {

--- a/crates/dbsp/src/time/product.rs
+++ b/crates/dbsp/src/time/product.rs
@@ -79,6 +79,8 @@ where
     TOuter: DBTimestamp,
     TInner: DBTimestamp,
 {
+    type Nested = Product<Self, u32>;
+
     type OrdValBatch<K: DBData, V: DBData, R: DBWeight> = OrdValBatch<K, V, Self, R>;
 
     fn minimum() -> Self {

--- a/crates/nexmark/benches/nexmark/main.rs
+++ b/crates/nexmark/benches/nexmark/main.rs
@@ -11,7 +11,7 @@ use clap::Parser;
 use dbsp::{
     mimalloc::{AllocStats, MiMalloc},
     trace::ord::OrdZSet,
-    Circuit, CollectionHandle, DBSPHandle, Runtime,
+    CollectionHandle, DBSPHandle, RootCircuit, Runtime,
 };
 use dbsp_nexmark::{
     config::{Config as NexmarkConfig, Query as NexmarkQuery},

--- a/crates/nexmark/benches/nexmark/run_queries.rs
+++ b/crates/nexmark/benches/nexmark/run_queries.rs
@@ -61,7 +61,7 @@ macro_rules! run_queries {
     // Returns a closure for a circuit with the nexmark source that returns
     // the input handle.
     (@circuit q13) => {
-        |circuit: &mut Circuit<()>| {
+        |circuit: &mut RootCircuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
             let (side_stream, mut side_input_handle) =
                 circuit.add_input_zset::<(usize, String, u64), isize>();
@@ -78,7 +78,7 @@ macro_rules! run_queries {
         }
     };
     (@circuit $query:ident) => {
-        |circuit: &mut Circuit<()>| {
+        |circuit: &mut RootCircuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let output = $query(stream);

--- a/crates/nexmark/src/lib.rs
+++ b/crates/nexmark/src/lib.rs
@@ -240,7 +240,7 @@ pub mod tests {
 
     use super::*;
     use core::ops::Range;
-    use dbsp::{trace::Batch, Circuit, OrdZSet};
+    use dbsp::{trace::Batch, OrdZSet, RootCircuit};
     use rand::rngs::mock::StepRng;
     use rstest::rstest;
 
@@ -301,7 +301,7 @@ pub mod tests {
 
     #[test]
     fn test_nexmark_dbsp_source_full_batch() {
-        let (circuit, mut input_handle) = Circuit::build(move |circuit| {
+        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset();
 
             let expected_zset = generate_expected_zset(0, 10);

--- a/crates/nexmark/src/queries/mod.rs
+++ b/crates/nexmark/src/queries/mod.rs
@@ -1,10 +1,10 @@
 //! Nexmark Queries in DBSP.
 
 use super::model::Event;
-use dbsp::{Circuit, OrdZSet, Stream};
+use dbsp::{OrdZSet, RootCircuit, Stream};
 use std::time::SystemTime;
 
-type NexmarkStream = Stream<Circuit<()>, OrdZSet<Event, isize>>;
+type NexmarkStream = Stream<RootCircuit, OrdZSet<Event, isize>>;
 
 type OrdinalDate = (i32, u16);
 

--- a/crates/nexmark/src/queries/q0.rs
+++ b/crates/nexmark/src/queries/q0.rs
@@ -14,7 +14,7 @@ mod tests {
         generator::tests::{make_auction, make_bid},
         model::{Auction, Bid, Event},
     };
-    use dbsp::{trace::Batch, Circuit, OrdZSet};
+    use dbsp::{trace::Batch, RootCircuit, OrdZSet};
 
     #[test]
     fn test_q0() {
@@ -81,7 +81,7 @@ mod tests {
             ]
         }
 
-        let (circuit, mut input_handle) = Circuit::build(move |circuit| {
+        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let output = q0(stream);

--- a/crates/nexmark/src/queries/q1.rs
+++ b/crates/nexmark/src/queries/q1.rs
@@ -44,7 +44,7 @@ mod tests {
         generator::tests::{make_auction, make_bid},
         model::{Auction, Bid, Event},
     };
-    use dbsp::{trace::Batch, Circuit, OrdZSet};
+    use dbsp::{trace::Batch, RootCircuit, OrdZSet};
 
     #[test]
     fn test_q1() {
@@ -111,7 +111,7 @@ mod tests {
             ]
         }
 
-        let (circuit, mut input_handle) = Circuit::build(move |circuit| {
+        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let output = q1(stream);

--- a/crates/nexmark/src/queries/q13.rs
+++ b/crates/nexmark/src/queries/q13.rs
@@ -1,5 +1,5 @@
 use super::{process_time, NexmarkStream};
-use dbsp::{operator::FilterMap, Circuit, OrdZSet, Stream};
+use dbsp::{operator::FilterMap, RootCircuit, OrdZSet, Stream};
 use crate::model::Event;
 
 use csv;
@@ -61,9 +61,9 @@ use std::{
 /// simple static file is used for this bounded side-input for the Nexmark tests
 /// and that is also what is tested here.
 
-type Q13Stream = Stream<Circuit<()>, OrdZSet<(u64, u64, usize, u64, String), isize>>;
+type Q13Stream = Stream<RootCircuit, OrdZSet<(u64, u64, usize, u64, String), isize>>;
 
-type SideInputStream = Stream<Circuit<()>, OrdZSet<(usize, String, u64), isize>>;
+type SideInputStream = Stream<RootCircuit, OrdZSet<(usize, String, u64), isize>>;
 
 const Q13_SIDE_INPUT_CSV: &str = "benches/nexmark/data/side_input.txt";
 
@@ -99,7 +99,7 @@ pub fn q13(input: NexmarkStream, side_input: SideInputStream) -> Q13Stream {
 
     // Join on the key from the side input
     bids_by_auction_mod
-        .join::<(), _, _, _>(
+        .join(
             &side_input_indexed,
             |&_, &(auction, bidder, price, date_time, b_p_time), (input_value, input_p_time)| {
                 (
@@ -152,7 +152,7 @@ mod tests {
         ]]
         .into_iter();
 
-        let (circuit, (mut input_handle, mut side_input_handle)) = Circuit::build(move |circuit| {
+        let (circuit, (mut input_handle, mut side_input_handle)) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
             let (side_stream, side_input_handle) =
                 circuit.add_input_zset::<(usize, String, u64), isize>();

--- a/crates/nexmark/src/queries/q14.rs
+++ b/crates/nexmark/src/queries/q14.rs
@@ -1,6 +1,6 @@
 use super::NexmarkStream;
 use crate::model::Event;
-use dbsp::{operator::FilterMap, Circuit, OrdZSet, Stream};
+use dbsp::{operator::FilterMap, RootCircuit, OrdZSet, Stream};
 use arcstr::ArcStr;
 use rust_decimal::Decimal;
 use size_of::SizeOf;
@@ -47,7 +47,7 @@ use std::ops::Deref;
 #[derive(Eq, Clone, Debug, Hash, PartialEq, PartialOrd, Ord, SizeOf, bincode::Decode, bincode::Encode)]
 pub struct Q14Output(u64, u64, BincodeDecimal, BidTimeType, u64, ArcStr, usize);
 
-type Q14Stream = Stream<Circuit<()>, OrdZSet<Q14Output, isize>>;
+type Q14Stream = Stream<RootCircuit, OrdZSet<Q14Output, isize>>;
 
 /// Wrapper type for `Decimal` that implements Decode and Encode.
 /// 
@@ -178,7 +178,7 @@ mod tests {
         )]]
         .into_iter();
 
-        let (circuit, mut input_handle) = Circuit::build(move |circuit| {
+        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let mut expected_output = vec![expected_zset].into_iter();

--- a/crates/nexmark/src/queries/q15.rs
+++ b/crates/nexmark/src/queries/q15.rs
@@ -1,7 +1,7 @@
 use super::NexmarkStream;
 use dbsp::{
     operator::FilterMap,
-    Circuit, OrdIndexedZSet, OrdZSet, Stream,
+    RootCircuit, OrdIndexedZSet, OrdZSet, Stream,
 };
 use crate::{model::Event, queries::OrdinalDate};
 use size_of::SizeOf;
@@ -73,7 +73,7 @@ pub struct Q15Output {
     rank3_auctions: usize,
 }
 
-type Q15Stream = Stream<Circuit<()>, OrdZSet<Q15Output, isize>>;
+type Q15Stream = Stream<RootCircuit, OrdZSet<Q15Output, isize>>;
 
 pub fn q15(input: NexmarkStream) -> Q15Stream {
     // Dug for a long time to figure out how to use the const generics
@@ -112,72 +112,72 @@ pub fn q15(input: NexmarkStream) -> Q15Stream {
     // Compute unique bidders across all bids and for each price range.
     let distinct_bidder = bids
         .map(|(day, (_auction, _price, bidder))| (*day, *bidder))
-        .distinct::<()>()
+        .distinct()
         .index();
     let rank1_distinct_bidder = rank1_bids
         .map(|(day, (_auction, _price, bidder))| (*day, *bidder))
-        .distinct::<()>()
+        .distinct()
         .index();
     let rank2_distinct_bidder = rank2_bids
         .map(|(day, (_auction, _price, bidder))| (*day, *bidder))
-        .distinct::<()>()
+        .distinct()
         .index();
     let rank3_distinct_bidder = rank3_bids
         .map(|(day, (_auction, _price, bidder))| (*day, *bidder))
-        .distinct::<()>()
+        .distinct()
         .index();
 
     // Compute unique auctions across all bids and for each price range.
     let distinct_auction = bids
         .map(|(day, (auction, _price, _bidder))| (*day, *auction))
-        .distinct::<()>()
+        .distinct()
         .index();
     let rank1_distinct_auction = rank1_bids
         .map(|(day, (auction, _price, _bidder))| (*day, *auction))
-        .distinct::<()>()
+        .distinct()
         .index();
     let rank2_distinct_auction = rank2_bids
         .map(|(day, (auction, _price, _bidder))| (*day, *auction))
-        .distinct::<()>()
+        .distinct()
         .index();
     let rank3_distinct_auction = rank3_bids
         .map(|(day, (auction, _price, _bidder))| (*day, *auction))
-        .distinct::<()>()
+        .distinct()
         .index();
 
     // Compute bids per day.
     let count_total_bids: Stream<_, OrdIndexedZSet<OrdinalDate, isize, _>> = bids
         .index()
-        .aggregate_linear::<(), _, _>(|_, _| -> isize { 1 });
+        .aggregate_linear(|_, _| -> isize { 1 });
     let count_rank1_bids: Stream<_, OrdIndexedZSet<OrdinalDate, isize, _>> = rank1_bids
         .index()
-        .aggregate_linear::<(), _, _>(|_, _| -> isize { 1 });
+        .aggregate_linear(|_, _| -> isize { 1 });
     let count_rank2_bids: Stream<_, OrdIndexedZSet<OrdinalDate, isize, _>> = rank2_bids
         .index()
-        .aggregate_linear::<(), _, _>(|_, _| -> isize { 1 });
+        .aggregate_linear(|_, _| -> isize { 1 });
     let count_rank3_bids: Stream<_, OrdIndexedZSet<OrdinalDate, isize, _>> = rank3_bids
         .index()
-        .aggregate_linear::<(), _, _>(|_, _| -> isize { 1 });
+        .aggregate_linear(|_, _| -> isize { 1 });
 
     // Count unique bidders per day.
     let count_total_bidders: Stream<_, OrdIndexedZSet<OrdinalDate, isize, _>> =
-        distinct_bidder.aggregate_linear::<(), _, _>(|_, _| -> isize { 1 });
+        distinct_bidder.aggregate_linear(|_, _| -> isize { 1 });
     let count_rank1_bidders: Stream<_, OrdIndexedZSet<OrdinalDate, isize, _>> =
-        rank1_distinct_bidder.aggregate_linear::<(), _, _>(|_, _| -> isize { 1 });
+        rank1_distinct_bidder.aggregate_linear(|_, _| -> isize { 1 });
     let count_rank2_bidders: Stream<_, OrdIndexedZSet<OrdinalDate, isize, _>> =
-        rank2_distinct_bidder.aggregate_linear::<(), _, _>(|_, _| -> isize { 1 });
+        rank2_distinct_bidder.aggregate_linear(|_, _| -> isize { 1 });
     let count_rank3_bidders: Stream<_, OrdIndexedZSet<OrdinalDate, isize, _>> =
-        rank3_distinct_bidder.aggregate_linear::<(), _, _>(|_, _| -> isize { 1 });
+        rank3_distinct_bidder.aggregate_linear(|_, _| -> isize { 1 });
 
     // Count unique auctions per day.
     let count_total_auctions: Stream<_, OrdIndexedZSet<OrdinalDate, isize, _>> =
-        distinct_auction.aggregate_linear::<(), _, _>(|_, _| -> isize { 1 });
+        distinct_auction.aggregate_linear(|_, _| -> isize { 1 });
     let count_rank1_auctions: Stream<_, OrdIndexedZSet<OrdinalDate, isize, _>> =
-        rank1_distinct_auction.aggregate_linear::<(), _, _>(|_, _| -> isize { 1 });
+        rank1_distinct_auction.aggregate_linear(|_, _| -> isize { 1 });
     let count_rank2_auctions: Stream<_, OrdIndexedZSet<OrdinalDate, isize, _>> =
-        rank2_distinct_auction.aggregate_linear::<(), _, _>(|_, _| -> isize { 1 });
+        rank2_distinct_auction.aggregate_linear(|_, _| -> isize { 1 });
     let count_rank3_auctions: Stream<_, OrdIndexedZSet<OrdinalDate, isize, _>> =
-        rank3_distinct_auction.aggregate_linear::<(), _, _>(|_, _| -> isize { 1 });
+        rank3_distinct_auction.aggregate_linear(|_, _| -> isize { 1 });
 
     // The following abomination simply joins all aggregates computed above into a
     // single output stream.

--- a/crates/nexmark/src/queries/q18.rs
+++ b/crates/nexmark/src/queries/q18.rs
@@ -2,7 +2,7 @@ use super::NexmarkStream;
 use dbsp::{
     algebra::UnimplementedSemigroup,
     operator::{FilterMap, Fold},
-    Circuit, OrdZSet, Stream,
+    RootCircuit, OrdZSet, Stream,
 };
 use crate::model::{Bid, Event};
 
@@ -32,7 +32,7 @@ use crate::model::{Bid, Event};
 ///  WHERE rank_number <= 1;
 /// ```
 
-type Q18Stream = Stream<Circuit<()>, OrdZSet<Bid, isize>>;
+type Q18Stream = Stream<RootCircuit, OrdZSet<Bid, isize>>;
 
 pub fn q18(input: NexmarkStream) -> Q18Stream {
     let bids_by_auction_bidder = input.flat_map_index(|event| match event {
@@ -41,7 +41,7 @@ pub fn q18(input: NexmarkStream) -> Q18Stream {
     });
 
     bids_by_auction_bidder
-        .aggregate::<(), _>(<Fold<_, UnimplementedSemigroup<_>, _, _>>::new(Bid::default(), |top: &mut Bid, val: &Bid, _w| {
+        .aggregate(<Fold<_, UnimplementedSemigroup<_>, _, _>>::new(Bid::default(), |top: &mut Bid, val: &Bid, _w| {
             if val.date_time > top.date_time {
                 *top = val.clone();
             }
@@ -376,7 +376,7 @@ mod tests {
             .into_iter()
             .map(|batch| batch.into_iter().map(|b| (Event::Bid(b), 1)).collect());
 
-        let (circuit, mut input_handle) = Circuit::build(move |circuit| {
+        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let output = q18(stream);

--- a/crates/nexmark/src/queries/q19.rs
+++ b/crates/nexmark/src/queries/q19.rs
@@ -2,7 +2,7 @@ use super::NexmarkStream;
 use dbsp::{
     algebra::UnimplementedSemigroup,
     operator::{FilterMap, Fold},
-    Circuit, OrdZSet, Stream,
+    RootCircuit, OrdZSet, Stream,
 };
 use crate::model::{Bid, Event};
 use std::collections::VecDeque;
@@ -33,7 +33,7 @@ use std::collections::VecDeque;
 /// WHERE rank_number <= 10;
 /// ```
 
-type Q19Stream = Stream<Circuit<()>, OrdZSet<Bid, isize>>;
+type Q19Stream = Stream<RootCircuit, OrdZSet<Bid, isize>>;
 
 const TOP_BIDS: usize = 10;
 
@@ -44,7 +44,7 @@ pub fn q19(input: NexmarkStream) -> Q19Stream {
     });
 
     bids_by_auction
-        .aggregate::<(), _>(<Fold<_, UnimplementedSemigroup<_>, _, _>>::new(
+        .aggregate(<Fold<_, UnimplementedSemigroup<_>, _, _>>::new(
             VecDeque::with_capacity(TOP_BIDS),
             |top: &mut VecDeque<Bid>, (_price, bid): &(usize, Bid), _w| {
                 if top.len() >= TOP_BIDS {
@@ -280,7 +280,7 @@ mod tests {
                 .collect()
         });
 
-        let (circuit, mut input_handle) = Circuit::build(move |circuit| {
+        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let output = q19(stream);

--- a/crates/nexmark/src/queries/q2.rs
+++ b/crates/nexmark/src/queries/q2.rs
@@ -1,6 +1,6 @@
 use super::NexmarkStream;
 use crate::model::Event;
-use dbsp::{operator::FilterMap, Circuit, OrdZSet, Stream};
+use dbsp::{operator::FilterMap, RootCircuit, OrdZSet, Stream};
 
 /// Selection
 ///
@@ -19,7 +19,7 @@ use dbsp::{operator::FilterMap, Circuit, OrdZSet, Stream};
 /// SELECT auction, price FROM bid WHERE MOD(auction, 123) = 0;
 const AUCTION_ID_MODULO: u64 = 123;
 
-pub fn q2(input: NexmarkStream) -> Stream<Circuit<()>, OrdZSet<(u64, usize), isize>> {
+pub fn q2(input: NexmarkStream) -> Stream<RootCircuit, OrdZSet<(u64, usize), isize>> {
     input.flat_map(|event| match event {
         Event::Bid(b) => match b.auction % AUCTION_ID_MODULO == 0 {
             true => Some((b.auction, b.price)),
@@ -36,7 +36,7 @@ mod tests {
         generator::tests::make_bid,
         model::{Bid, Event},
     };
-    use dbsp::{trace::Batch, Circuit, OrdZSet};
+    use dbsp::{trace::Batch, RootCircuit, OrdZSet};
 
     #[test]
     fn test_q2() {
@@ -87,7 +87,7 @@ mod tests {
             ],
         ];
 
-        let (circuit, mut input_handle) = Circuit::build(move |circuit| {
+        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let output = q2(stream);

--- a/crates/nexmark/src/queries/q20.rs
+++ b/crates/nexmark/src/queries/q20.rs
@@ -2,7 +2,7 @@ use super::NexmarkStream;
 use crate::model::{Auction, Bid, Event};
 use dbsp::{
     operator::FilterMap,
-    Circuit, OrdZSet, Stream,
+    RootCircuit, OrdZSet, Stream,
 };
 
 ///
@@ -50,7 +50,7 @@ use dbsp::{
 // WHERE A.category = 10;
 //
 
-type Q20Stream = Stream<Circuit<()>, OrdZSet<(Bid, Auction), isize>>;
+type Q20Stream = Stream<RootCircuit, OrdZSet<(Bid, Auction), isize>>;
 
 const FILTERED_CATEGORY: usize = 10;
 
@@ -68,7 +68,7 @@ pub fn q20(input: NexmarkStream) -> Q20Stream {
         _ => None,
     });
 
-    bids_by_auction.join::<(), _, _, _>(&auctions_indexed, |_, bid, auction| {
+    bids_by_auction.join(&auctions_indexed, |_, bid, auction| {
         (bid.clone(), auction.clone())
     })
 }
@@ -232,7 +232,7 @@ mod tests {
             .into_iter()
             .map(|batch| batch.into_iter().map(|e| (e, 1)).collect());
 
-        let (circuit, mut input_handle) = Circuit::build(move |circuit| {
+        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let output = q20(stream);

--- a/crates/nexmark/src/queries/q21.rs
+++ b/crates/nexmark/src/queries/q21.rs
@@ -1,5 +1,5 @@
 use super::NexmarkStream;
-use dbsp::{operator::FilterMap, Circuit, OrdZSet, Stream};
+use dbsp::{operator::FilterMap, RootCircuit, OrdZSet, Stream};
 use crate::model::Event;
 use arcstr::ArcStr;
 use regex::Regex;
@@ -37,7 +37,7 @@ use regex::Regex;
 /// ```
 
 type Q21Set = OrdZSet<(u64, u64, usize, ArcStr, ArcStr), isize>;
-type Q21Stream = Stream<Circuit<()>, Q21Set>;
+type Q21Stream = Stream<RootCircuit, Q21Set>;
 
 pub fn q21(input: NexmarkStream) -> Q21Stream {
     let channel_regex = Regex::new(r"channel_id=([^&]*)").unwrap();
@@ -121,7 +121,7 @@ mod tests {
             .into_iter()
             .map(|batch| batch.into_iter().map(|e| (e, 1)).collect());
 
-        let (circuit, mut input_handle) = Circuit::build(move |circuit| {
+        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let output = q21(stream);

--- a/crates/nexmark/src/queries/q22.rs
+++ b/crates/nexmark/src/queries/q22.rs
@@ -1,5 +1,5 @@
 use super::NexmarkStream;
-use dbsp::{operator::FilterMap, Circuit, OrdZSet, Stream};
+use dbsp::{operator::FilterMap, RootCircuit, OrdZSet, Stream};
 use crate::model::Event;
 use arcstr::ArcStr;
 
@@ -31,7 +31,7 @@ use arcstr::ArcStr;
 /// ```
 
 type Q22Set = OrdZSet<(u64, u64, usize, ArcStr, ArcStr, ArcStr, ArcStr), isize>;
-type Q22Stream = Stream<Circuit<()>, Q22Set>;
+type Q22Stream = Stream<RootCircuit, Q22Set>;
 
 pub fn q22(input: NexmarkStream) -> Q22Stream {
     input.flat_map(|event| match event {
@@ -107,7 +107,7 @@ mod tests {
             .into_iter()
             .map(|batch| batch.into_iter().map(|e| (e, 1)).collect());
 
-        let (circuit, mut input_handle) = Circuit::build(move |circuit| {
+        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let output = q22(stream);

--- a/crates/nexmark/src/queries/q3.rs
+++ b/crates/nexmark/src/queries/q3.rs
@@ -1,5 +1,5 @@
 use super::NexmarkStream;
-use dbsp::{operator::FilterMap, Circuit, OrdZSet, Stream};
+use dbsp::{operator::FilterMap, RootCircuit, OrdZSet, Stream};
 use crate::model::Event;
 
 /// Local Item Suggestion
@@ -30,7 +30,7 @@ use crate::model::Event;
 const STATES_OF_INTEREST: &[&str] = &["OR", "ID", "CA"];
 const CATEGORY_OF_INTEREST: usize = 10;
 
-type Q3Stream = Stream<Circuit<()>, OrdZSet<(String, String, String, u64), isize>>;
+type Q3Stream = Stream<RootCircuit, OrdZSet<(String, String, String, u64), isize>>;
 
 pub fn q3(input: NexmarkStream) -> Q3Stream {
     // Select auctions of interest and index them by seller id.
@@ -49,7 +49,7 @@ pub fn q3(input: NexmarkStream) -> Q3Stream {
     });
 
     // In the future, it won't be necessary to specify type arguments to join.
-    auction_by_seller.join::<(), _, _, _>(
+    auction_by_seller.join(
         &person_by_id,
         |_seller, &auction_id, (name, city, state)| {
             (
@@ -69,7 +69,7 @@ mod tests {
         generator::tests::{make_auction, make_person},
         model::{Auction, Person},
     };
-    use dbsp::{trace::Batch, Circuit, OrdZSet};
+    use dbsp::{trace::Batch, RootCircuit, OrdZSet};
 
     #[test]
     fn test_q3_people() {
@@ -163,7 +163,7 @@ mod tests {
             ],
         ];
 
-        let (circuit, mut input_handle) = Circuit::build(move |circuit| {
+        let (circuit, mut input_handle) = RootCircuit::build(move |circuit| {
             let (stream, input_handle) = circuit.add_input_zset::<Event, isize>();
 
             let output = q3(stream);

--- a/crates/pipeline_manager/src/db.rs
+++ b/crates/pipeline_manager/src/db.rs
@@ -179,14 +179,14 @@ pub(crate) struct ProjectDescr {
     ///
     /// The given SQL program:
     ///
-    /// ```no-run
+    /// ```no_run
     /// CREATE TABLE USERS ( name varchar );
     /// CREATE VIEW OUTPUT_USERS as SELECT * FROM USERS;
     /// ```
     ///
     /// Would lead the following JSON string in `schema`:
     ///
-    /// ```no-run
+    /// ```no_run
     /// {
     ///   "inputs": [{
     ///       "name": "USERS",

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -39,7 +39,7 @@ COPY . /database-stream-processor
 # is working on the submodule and wants to build a container with their modified
 # SQL compiler version.
 RUN cd /database-stream-processor && \
-    if [[ ! -d sql-to-dbsp-compiler/.git || -z $(cd sql-to-dbsp-compiler && git branch --show-current) ]]; \
+    if [[ ! -e sql-to-dbsp-compiler/.git || -z $(cd sql-to-dbsp-compiler && git branch --show-current) ]]; \
     then git submodule update --init; fi
 
 RUN cd /database-stream-processor/crates/pipeline_manager \

--- a/scripts/start_manager.sh
+++ b/scripts/start_manager.sh
@@ -10,7 +10,7 @@ MANAGER_DIR="${ROOT_DIR}/crates/pipeline_manager"
 #    exit 1
 # fi
 
-if [[ ! -d ${SQL_COMPILER_DIR}/.git || -z $(cd ${SQL_COMPILER_DIR} && git branch --show-current) ]]
+if [[ ! -e ${SQL_COMPILER_DIR}/.git || -z $(cd ${SQL_COMPILER_DIR} && git branch --show-current) ]]
 then
     git submodule update --init
 fi


### PR DESCRIPTION
We get rid of another piece of technical debt, related to the fact that
circuits did not do their own time keeping.  As a result, any operator that
needed to know the current time had to run its own clock.  More
importantly, any operator that recorded input batches in a trace
had to pick its own timestamp type for the trace.  This choice
bubbled up all the way to the user, so that incremental stateful
operators ended up with an extra generic parameter that had to be
specified manually, making the API more complex and error-prone (since
nothing prevented the user from picking the wrong timestamp type).

The solution implenented in this commit:

- `trait WithClock` - represents an object with a clock whose type is
  given by the associated type `Time`.

- Abstract away the circuit API into a trait `trait Circuit: WithClock`.
  We still only have one implementation of this trait, but this allows
  us to model `Time` and `Parent` as associated types of the trait.

- Derive the timestamp type of all stateful operators from the circuit,
  which eliminates the extra type argument to `join`, `aggregate`,
  `distinct`, etc.  All these operators can now be invoked without
  explicitly type arguments in most cases.

- We setup a fixed hierarchy of timestamp types, induced by the
  `WithClock::Nested` associate type:
  - `()` - root circuit
  - `NestedTimestamp32` - first-level nested circuit
  - `Product<>` - >=2-level nested circuit.
  If this proves too restrictive, we can generalize this architecture
  by allowing the user to explicitly pick a timestamp type when
  instantiating a (nested) circuit.