### PR TITLE
pipeline_manager: Fix rustdoc errors.

### DIFF
--- a/crates/pipeline_manager/src/config.rs
+++ b/crates/pipeline_manager/src/config.rs
@@ -100,7 +100,7 @@ pub(crate) struct ManagerConfig {
     pub unix_daemon: bool,
 
     /// Point to a relational database to use for state management.
-    /// Accepted values are "sqlite" or "postgres://<host>:<port>".
+    /// Accepted values are `sqlite` or `postgres://<host>:<port>`.
     /// For sqlite, we simply create a DB in the current working directory.
     /// For postgres, we use the connection string as provided.
     #[serde(default = "default_db_connection_string")]


### PR DESCRIPTION
Fixes the following:

```
error: unclosed HTML tag `host`
   --> crates/pipeline_manager/src/config.rs:103:53
    |
103 |     /// Accepted values are "sqlite" or "postgres://<host>:<port>".
    |                                                     ^^^^^^
    |
    = note: `-D rustdoc::invalid-html-tags` implied by `-D warnings`

error: unclosed HTML tag `port`
   --> crates/pipeline_manager/src/config.rs:103:60
    |
103 |     /// Accepted values are "sqlite" or "postgres://<host>:<port>".
    |                                                            ^^^^^^
```


CC: Lalith Suresh <lsuresh@vmware.com>
Fixes: 07aa2136b26f ("Add Postgres support")