### PR TITLE
Added the `@dbsp.error.abort()` function and the `unreachable` terminator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2576,7 +2576,7 @@ dependencies = [
  "anyhow",
  "base64 0.21.0",
  "bytecount",
- "clap 4.2.1",
+ "clap 4.2.2",
  "fancy-regex",
  "fraction",
  "getrandom",

--- a/crates/dataflow-jit/TODO.md
+++ b/crates/dataflow-jit/TODO.md
@@ -65,6 +65,7 @@
   - [ ] Proc macro for registering intrinsics
   - [ ] `@dbsp.min()`
   - [ ] `@dbsp.max()`
+  - [x] `@dbsp.error.abort()`
   - [x] `@dbsp.row.vec.push`
   - [ ] `@dbsp.row.vec.reserve`
   - [ ] String manipulation

--- a/crates/dataflow-jit/src/codegen/mod.rs
+++ b/crates/dataflow-jit/src/codegen/mod.rs
@@ -58,6 +58,7 @@ const TRAP_INVALID_BOOL: TrapCode = TrapCode::User(2);
 const TRAP_ASSERT_EQ: TrapCode = TrapCode::User(3);
 const TRAP_CAPACITY_OVERFLOW: TrapCode = TrapCode::User(4);
 const TRAP_DIV_OVERFLOW: TrapCode = TrapCode::User(5);
+const TRAP_ABORT: TrapCode = TrapCode::User(6);
 
 // TODO: Pretty function debugging https://github.com/bjorn3/rustc_codegen_cranelift/blob/master/src/pretty_clif.rs
 
@@ -893,6 +894,14 @@ impl<'a> CodegenCtx<'a> {
             }
 
             Terminator::Branch(branch) => self.branch(branch, stack, builder),
+
+            Terminator::Unreachable => {
+                let unreachable = builder.ins().trap(TrapCode::UnreachableCodeReached);
+
+                if let Some(writer) = self.comment_writer.as_deref() {
+                    writer.borrow_mut().add_comment(unreachable, "unreachable");
+                }
+            }
         }
     }
 

--- a/crates/dataflow-jit/src/codegen/mod.rs
+++ b/crates/dataflow-jit/src/codegen/mod.rs
@@ -1808,8 +1808,20 @@ impl<'a> CodegenCtx<'a> {
                 src
             }
 
+            // f32 to f64
+            (a, b) if a.is_f32() && b.is_f64() => {
+                debug_assert_eq!(to_ty, types::F64);
+                builder.ins().fpromote(to_ty, src)
+            }
+
+            // f64 to f32
+            (a, b) if a.is_f64() && b.is_f32() => {
+                debug_assert_eq!(to_ty, types::F32);
+                builder.ins().fdemote(to_ty, src)
+            }
+
             // Float to int
-            (a, b) if a.is_float() => {
+            (a, b) if a.is_float() && b.is_int() => {
                 if b.is_unsigned_int() {
                     if self.config.saturating_float_to_int_casts {
                         builder.ins().fcvt_to_uint(to_ty, src)
@@ -1827,7 +1839,7 @@ impl<'a> CodegenCtx<'a> {
             }
 
             // Int to float
-            (a, b) if b.is_float() => {
+            (a, b) if a.is_int() && b.is_float() => {
                 if a.is_unsigned_int() {
                     builder.ins().fcvt_from_uint(to_ty, src)
                 } else {

--- a/crates/dataflow-jit/src/dataflow/mod.rs
+++ b/crates/dataflow-jit/src/dataflow/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     ir::{
         graph,
-        literal::{NullableConstant, RowLiteral, StreamLiteral},
+        literal::{NullableConstant, RowLiteral, StreamCollection},
         nodes::{DataflowNode as _, Node, StreamKind, StreamLayout, Subgraph as SubgraphNode},
         Constant, Graph, GraphExt, LayoutId, NodeId,
     },
@@ -837,8 +837,8 @@ impl CompiledDataflow {
                     }
 
                     Node::Constant(constant) => {
-                        let value = match constant.value() {
-                            StreamLiteral::Set(set) => {
+                        let value = match constant.value().value() {
+                            StreamCollection::Set(set) => {
                                 let key_layout = constant.layout().unwrap_set();
                                 let key_vtable = unsafe { &*vtables[&key_layout] };
                                 let key_layout = layout_cache.layout_of(key_layout);
@@ -858,7 +858,7 @@ impl CompiledDataflow {
                                 RowZSet::Set(batcher.seal())
                             }
 
-                            StreamLiteral::Map(map) => {
+                            StreamCollection::Map(map) => {
                                 let (key_layout, value_layout) = constant.layout().unwrap_map();
                                 let (key_vtable, value_vtable) =
                                     unsafe { (&*vtables[&key_layout], &*vtables[&value_layout]) };

--- a/crates/dataflow-jit/src/facade.rs
+++ b/crates/dataflow-jit/src/facade.rs
@@ -1,0 +1,52 @@
+use crate::{
+    codegen::{CodegenConfig, NativeLayoutCache},
+    dataflow::{CompiledDataflow, JitHandle, RowInput, RowOutput},
+    ir::{Graph, GraphExt, NodeId, Validator},
+};
+use dbsp::{DBSPHandle, Runtime};
+use std::collections::BTreeMap;
+
+pub struct DbspCircuit {
+    jit: JitHandle,
+    runtime: DBSPHandle,
+    inputs: BTreeMap<NodeId, RowInput>,
+    outputs: BTreeMap<NodeId, RowOutput>,
+    layout_cache: NativeLayoutCache,
+}
+
+impl DbspCircuit {
+    pub fn new<F>(build: F, optimize: bool, workers: usize, config: CodegenConfig) -> Self
+    where
+        F: FnOnce() -> Graph,
+    {
+        let mut graph = build();
+
+        {
+            let mut validator = Validator::new(graph.layout_cache().clone());
+            validator
+                .validate_graph(&graph)
+                .expect("failed to validate graph before optimization");
+
+            if optimize {
+                graph.optimize();
+                validator
+                    .validate_graph(&graph)
+                    .expect("failed to validate graph after optimization");
+            }
+        }
+
+        let (dataflow, jit, layout_cache) = CompiledDataflow::new(&graph, config);
+
+        let (runtime, (inputs, outputs)) =
+            Runtime::init_circuit(workers, move |circuit| dataflow.construct(circuit))
+                .expect("failed to construct runtime");
+
+        Self {
+            jit,
+            runtime,
+            inputs,
+            outputs,
+            layout_cache,
+        }
+    }
+}

--- a/crates/dataflow-jit/src/facade.rs
+++ b/crates/dataflow-jit/src/facade.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use crate::{
     codegen::{CodegenConfig, NativeLayoutCache},
     dataflow::{CompiledDataflow, JitHandle, RowInput, RowOutput},

--- a/crates/dataflow-jit/src/ir/function/builder.rs
+++ b/crates/dataflow-jit/src/ir/function/builder.rs
@@ -498,6 +498,7 @@ impl FunctionBuilder {
         }
     }
 
+    // TODO: Make sure all params are of correct type and that they exist
     #[track_caller]
     fn validate_terminator(&self, block: BlockId, terminator: &Terminator) {
         match &terminator {
@@ -525,7 +526,7 @@ impl FunctionBuilder {
                 );
             }
 
-            Terminator::Return(_) => {}
+            Terminator::Return(_) | Terminator::Unreachable => {}
         }
     }
 
@@ -571,6 +572,8 @@ impl FunctionBuilder {
                 Terminator::Return(_) => {
                     cfg.add_node(block_id);
                 }
+
+                Terminator::Unreachable => {}
             }
         }
 

--- a/crates/dataflow-jit/src/ir/literal.rs
+++ b/crates/dataflow-jit/src/ir/literal.rs
@@ -1,18 +1,75 @@
-use crate::ir::Constant;
+use crate::ir::{nodes::StreamLayout, Constant};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, JsonSchema)]
-pub enum StreamLiteral {
+pub struct StreamLiteral {
+    /// The literal's layout
+    layout: StreamLayout,
+    /// The values within the stream
+    value: StreamCollection,
+}
+
+impl StreamLiteral {
+    /// Create a new stream literal
+    pub const fn new(layout: StreamLayout, value: StreamCollection) -> Self {
+        Self { layout, value }
+    }
+
+    /// Create an empty stream literal
+    pub const fn empty(layout: StreamLayout) -> Self {
+        let value = match layout {
+            StreamLayout::Set(..) => StreamCollection::Set(Vec::new()),
+            StreamLayout::Map(..) => StreamCollection::Map(Vec::new()),
+        };
+
+        Self { layout, value }
+    }
+
+    pub const fn layout(&self) -> StreamLayout {
+        self.layout
+    }
+
+    pub const fn value(&self) -> &StreamCollection {
+        &self.value
+    }
+
+    pub fn layout_mut(&mut self) -> &mut StreamLayout {
+        &mut self.layout
+    }
+
+    pub fn value_mut(&mut self) -> &mut StreamCollection {
+        &mut self.value
+    }
+
+    pub fn is_set(&self) -> bool {
+        self.layout.is_set()
+    }
+
+    pub fn is_map(&self) -> bool {
+        self.layout.is_map()
+    }
+
+    pub fn len(&self) -> usize {
+        self.value.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.value.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, JsonSchema)]
+pub enum StreamCollection {
     Set(Vec<(RowLiteral, i32)>),
     Map(Vec<(RowLiteral, RowLiteral, i32)>),
 }
 
-impl StreamLiteral {
+impl StreamCollection {
     pub fn len(&self) -> usize {
         match self {
-            StreamLiteral::Set(set) => set.len(),
-            StreamLiteral::Map(map) => map.len(),
+            Self::Set(set) => set.len(),
+            Self::Map(map) => map.len(),
         }
     }
 

--- a/crates/dataflow-jit/src/ir/nodes/aggregate.rs
+++ b/crates/dataflow-jit/src/ir/nodes/aggregate.rs
@@ -49,7 +49,7 @@ impl DataflowNode for Min {
     }
 
     fn validate(&self, _inputs: &[StreamLayout], _layout_cache: &RowLayoutCache) {
-        todo!()
+        // TODO
     }
 
     fn optimize(&mut self, _layout_cache: &RowLayoutCache) {}

--- a/crates/dataflow-jit/src/ir/nodes/filter_map.rs
+++ b/crates/dataflow-jit/src/ir/nodes/filter_map.rs
@@ -64,7 +64,7 @@ impl DataflowNode for Map {
     }
 
     fn validate(&self, _inputs: &[StreamLayout], _layout_cache: &RowLayoutCache) {
-        todo!()
+        // TODO
     }
 
     fn optimize(&mut self, layout_cache: &RowLayoutCache) {
@@ -140,7 +140,7 @@ impl DataflowNode for Filter {
     }
 
     fn validate(&self, _inputs: &[StreamLayout], _layout_cache: &RowLayoutCache) {
-        todo!()
+        // TODO
     }
 
     fn optimize(&mut self, layout_cache: &RowLayoutCache) {
@@ -223,7 +223,7 @@ impl DataflowNode for FilterMap {
     }
 
     fn validate(&self, _inputs: &[StreamLayout], _layout_cache: &RowLayoutCache) {
-        todo!()
+        // TODO
     }
 
     fn optimize(&mut self, layout_cache: &RowLayoutCache) {

--- a/crates/dataflow-jit/src/ir/optimize/dedup.rs
+++ b/crates/dataflow-jit/src/ir/optimize/dedup.rs
@@ -83,7 +83,7 @@ impl MutNodeVisitor for NodeCollector {
 mod tests {
     use crate::{
         ir::{
-            literal::{NullableConstant, RowLiteral},
+            literal::{NullableConstant, RowLiteral, StreamCollection, StreamLiteral},
             nodes::{ConstantStream, StreamLayout},
             ColumnType, Constant, Graph, GraphExt, RowLayoutBuilder,
         },
@@ -108,10 +108,13 @@ mod tests {
         let sink1 = graph.sink(distinct2);
         let sink2 = graph.sink(distinct3);
 
-        let constant = crate::ir::literal::StreamLiteral::Set(vec![(
-            RowLiteral::new(vec![NullableConstant::NonNull(Constant::U32(1))]),
-            1,
-        )]);
+        let constant = StreamLiteral::new(
+            StreamLayout::Set(u32),
+            StreamCollection::Set(vec![(
+                RowLiteral::new(vec![NullableConstant::NonNull(Constant::U32(1))]),
+                1,
+            )]),
+        );
         let empty1 = graph.add_node(ConstantStream::new(
             constant.clone(),
             StreamLayout::Set(u32),

--- a/crates/dataflow-jit/src/ir/optimize/distinct.rs
+++ b/crates/dataflow-jit/src/ir/optimize/distinct.rs
@@ -1,6 +1,6 @@
 //! Remove distinct over distinct streams
 
-use crate::ir::{graph::Subgraph, literal::StreamLiteral, nodes::Node, GraphExt, NodeId};
+use crate::ir::{graph::Subgraph, literal::StreamCollection, nodes::Node, GraphExt, NodeId};
 use petgraph::{
     algo::{toposort, DfsSpace},
     Direction,
@@ -202,9 +202,13 @@ impl Subgraph {
                     if constant.consolidated() && !is_distinct.contains(&node_id) {
                         // If all tuples/rows within the stream have a weight of 1, the stream is
                         // distinct
-                        let constant_is_distinct = match constant.value() {
-                            StreamLiteral::Set(set) => set.iter().all(|&(_, weight)| weight == 1),
-                            StreamLiteral::Map(map) => map.iter().all(|&(.., weight)| weight == 1),
+                        let constant_is_distinct = match constant.value().value() {
+                            StreamCollection::Set(set) => {
+                                set.iter().all(|&(_, weight)| weight == 1)
+                            }
+                            StreamCollection::Map(map) => {
+                                map.iter().all(|&(.., weight)| weight == 1)
+                            }
                         };
 
                         if constant_is_distinct {

--- a/crates/dataflow-jit/src/ir/terminator.rs
+++ b/crates/dataflow-jit/src/ir/terminator.rs
@@ -14,8 +14,8 @@ pub enum Terminator {
     Jump(Jump),
     Branch(Branch),
     Return(Return),
+    Unreachable,
     // TODO: Switch
-    // TODO: Unreachable could be useful in the future
 }
 
 impl Terminator {
@@ -35,6 +35,14 @@ impl Terminator {
     #[must_use]
     pub const fn is_return(&self) -> bool {
         matches!(self, Self::Return(_))
+    }
+
+    /// Returns `true` if the terminator is [`Unreachable`].
+    ///
+    /// [`Unreachable`]: Terminator::Unreachable
+    #[must_use]
+    pub const fn is_unreachable(&self) -> bool {
+        matches!(self, Self::Unreachable)
     }
 
     #[must_use]

--- a/crates/dataflow-jit/src/ir/validate.rs
+++ b/crates/dataflow-jit/src/ir/validate.rs
@@ -650,6 +650,17 @@ impl FunctionValidator {
         assert_eq!(actual_arg_types, call.arg_types());
 
         match call.function() {
+            "dbsp.error.abort" => {
+                if !call.args().is_empty() {
+                    return Err(ValidationError::IncorrectFunctionArgLen {
+                        expr_id,
+                        function: call.function().to_owned(),
+                        expected_args: 0,
+                        args: call.args().len(),
+                    });
+                }
+            }
+
             "dbsp.row.vec.push" => {
                 if call.args().len() != 2 {
                     return Err(ValidationError::IncorrectFunctionArgLen {

--- a/crates/dataflow-jit/src/ir/validate.rs
+++ b/crates/dataflow-jit/src/ir/validate.rs
@@ -135,6 +135,10 @@ impl Validator {
                     self.node_outputs.insert(node_id, constant.layout());
                 }
 
+                Node::Distinct(distinct) => {
+                    self.node_inputs.insert(node_id, vec![distinct.input()]);
+                }
+
                 _ => todo!(),
             }
         }

--- a/crates/dataflow-jit/src/lib.rs
+++ b/crates/dataflow-jit/src/lib.rs
@@ -4,6 +4,7 @@ pub mod ir;
 pub mod row;
 pub mod sqljson;
 
+mod facade;
 mod thin_str;
 mod utils;
 

--- a/crates/dataflow-jit/src/sqljson/mod.rs
+++ b/crates/dataflow-jit/src/sqljson/mod.rs
@@ -153,6 +153,8 @@ impl SqlGraph {
                         Terminator::Return(_) => {
                             cfg.add_node(block_id);
                         }
+
+                        Terminator::Unreachable => {}
                     }
                 }
 


### PR DESCRIPTION
Adds the `@dbsp.error.abort()` function to immediately abort the program and the `unreachable` terminator for terminating blocks with no meaningful branching/return behavior, currently should just be used as
```llvm
call @dbsp.error.abort()
unreachable
```