### PR TITLE
Refactor PgEmbed usage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,20 +114,20 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: ${{ matrix.cargo_args }} --no-run --all-features --features "dev" --target ${{ matrix.target }}
+          args: ${{ matrix.cargo_args }} --no-run --all-features --target ${{ matrix.target }}
 
       - name: Build tests with no features
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: ${{ matrix.cargo_args }} --no-run --no-default-features --features "dev" --target ${{ matrix.target }}
+          args: ${{ matrix.cargo_args }} --no-run --no-default-features --target ${{ matrix.target }}
 
       - name: Run tests
         if: runner.os != 'Windows'
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: ${{ matrix.cargo_args }} ${{ env.ALMOST_ALL_FEATURES }} --features "dev" --target ${{ matrix.target }} -- ${{ matrix.test_flags }}
+          args: ${{ matrix.cargo_args }} ${{ env.ALMOST_ALL_FEATURES }} --target ${{ matrix.target }} -- ${{ matrix.test_flags }}
 
       # Only run basic tests on windows, which tends to run out of resources.
       - name: Run tests on Windows
@@ -264,7 +264,7 @@ jobs:
           EXCLUDE_JIT: "${{ matrix.sanitizer == 'memory' && '--exclude dataflow-jit' || '' }}"
         with:
           command: test
-          args: ${{ env.EXCLUDE_SQLITE3 }} ${{ env.EXCLUDE_JIT }} --workspace ${{ env.ALMOST_ALL_FEATURES }} --features "dev" --target ${{ matrix.target }} -Z build-std -- --skip 'proptest' --skip 'persistent' ${{ env.SKIP_KAFKA }} ${{ env.THREADS }}
+          args: ${{ env.EXCLUDE_SQLITE3 }} ${{ env.EXCLUDE_JIT }} --workspace ${{ env.ALMOST_ALL_FEATURES }} --target ${{ matrix.target }} -Z build-std -- --skip 'proptest' --skip 'persistent' ${{ env.SKIP_KAFKA }} ${{ env.THREADS }}
 
   clippy:
     name: Clippy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,20 +114,20 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: ${{ matrix.cargo_args }} --no-run --all-features  --target ${{ matrix.target }}
+          args: ${{ matrix.cargo_args }} --no-run --all-features --features "dev" --target ${{ matrix.target }}
 
       - name: Build tests with no features
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: ${{ matrix.cargo_args }} --no-run --no-default-features  --target ${{ matrix.target }}
+          args: ${{ matrix.cargo_args }} --no-run --no-default-features --features "dev" --target ${{ matrix.target }}
 
       - name: Run tests
         if: runner.os != 'Windows'
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: ${{ matrix.cargo_args }} ${{ env.ALMOST_ALL_FEATURES }} --target ${{ matrix.target }} -- ${{ matrix.test_flags }}
+          args: ${{ matrix.cargo_args }} ${{ env.ALMOST_ALL_FEATURES }} --features "dev" --target ${{ matrix.target }} -- ${{ matrix.test_flags }}
 
       # Only run basic tests on windows, which tends to run out of resources.
       - name: Run tests on Windows
@@ -264,7 +264,7 @@ jobs:
           EXCLUDE_JIT: "${{ matrix.sanitizer == 'memory' && '--exclude dataflow-jit' || '' }}"
         with:
           command: test
-          args: ${{ env.EXCLUDE_SQLITE3 }} ${{ env.EXCLUDE_JIT }} --workspace ${{ env.ALMOST_ALL_FEATURES }} --target ${{ matrix.target }} -Z build-std -- --skip 'proptest' --skip 'persistent' ${{ env.SKIP_KAFKA }} ${{ env.THREADS }}
+          args: ${{ env.EXCLUDE_SQLITE3 }} ${{ env.EXCLUDE_JIT }} --workspace ${{ env.ALMOST_ALL_FEATURES }} --features "dev" --target ${{ matrix.target }} -Z build-std -- --skip 'proptest' --skip 'persistent' ${{ env.SKIP_KAFKA }} ${{ env.THREADS }}
 
   clippy:
     name: Clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1807,6 +1807,7 @@ dependencies = [
  "clap 4.2.4",
  "daemonize",
  "dbsp_adapters",
+ "dbsp_pipeline_manager",
  "env_logger",
  "fs_extra",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1813,6 +1813,7 @@ dependencies = [
  "futures-util",
  "log",
  "mime",
+ "once_cell",
  "pg-embed",
  "pretty_assertions",
  "proptest",

--- a/crates/pipeline_manager/Cargo.toml
+++ b/crates/pipeline_manager/Cargo.toml
@@ -49,8 +49,11 @@ static-files = "0.2.3"
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
 pretty_assertions = "1.3.0"
+# Workaround to enable dev feature during tests: https://github.com/rust-lang/cargo/issues/2911
+dbsp_pipeline_manager = { path = ".", features = ["dev"]}
 
+[package.metadata.cargo-udeps.ignore]
+development = ["dbsp_pipeline_manager"] # false positive from cargo udeps
 
 [features]
-default = ["dev"]
 dev = ["dep:pg-embed", "dep:once_cell"]

--- a/crates/pipeline_manager/Cargo.toml
+++ b/crates/pipeline_manager/Cargo.toml
@@ -36,7 +36,8 @@ futures = "0.3"
 tokio-postgres = "0.7"
 async-trait = "0.1"
 # Waiting for https://github.com/faokunega/pg-embed/pull/26
-pg-embed = { git = "https://github.com/gz/pg-embed.git", rev = "8906af8" }
+pg-embed = { git = "https://github.com/gz/pg-embed.git", rev = "8906af8", optional = true }
+once_cell = { version = "1.17.1", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 daemonize = { version = "0.4.1" }
@@ -48,3 +49,8 @@ static-files = "0.2.3"
 proptest = "1.0.0"
 proptest-derive = "0.3.0"
 pretty_assertions = "1.3.0"
+
+
+[features]
+default = ["dev"]
+dev = ["dep:pg-embed", "dep:once_cell"]

--- a/crates/pipeline_manager/src/config.rs
+++ b/crates/pipeline_manager/src/config.rs
@@ -24,7 +24,7 @@ fn default_sql_compiler_home() -> String {
 }
 
 fn default_db_connection_string() -> String {
-    "postgres-embed".to_string()
+    "".to_string()
 }
 
 /// Pipeline manager configuration read from a YAML config file or from command
@@ -228,6 +228,7 @@ impl ManagerConfig {
     }
 
     /// Where Postgres embed stores the database.
+    #[cfg(feature = "dev")]
     pub(crate) fn postgres_embed_data_dir(&self) -> PathBuf {
         Path::new(&self.working_directory).join("data")
     }

--- a/crates/pipeline_manager/src/db/mod.rs
+++ b/crates/pipeline_manager/src/db/mod.rs
@@ -1051,7 +1051,7 @@ impl ProjectDB {
         }
 
         debug!("Opening connection to {:?}", connection_str);
-        let (client, conn) = tokio_postgres::connect(&connection_str, NoTls).await?;
+        let (client, conn) = tokio_postgres::connect(connection_str, NoTls).await?;
 
         // The `tokio_postgres` API requires allocating a thread to `connection`,
         // which will handle datbase I/O and should automatically terminate once

--- a/crates/pipeline_manager/src/db/mod.rs
+++ b/crates/pipeline_manager/src/db/mod.rs
@@ -12,7 +12,7 @@ use utoipa::ToSchema;
 #[cfg(test)]
 mod test;
 
-#[cfg(feature = "dev")]
+#[cfg(any(test, feature = "dev"))]
 mod pg_setup;
 pub(crate) mod storage;
 

--- a/crates/pipeline_manager/src/db/mod.rs
+++ b/crates/pipeline_manager/src/db/mod.rs
@@ -12,6 +12,7 @@ use utoipa::ToSchema;
 #[cfg(test)]
 mod test;
 
+#[cfg(feature = "dev")]
 mod pg_setup;
 pub(crate) mod storage;
 
@@ -1023,7 +1024,7 @@ impl ProjectDB {
         #[cfg(feature = "dev")]
         let connection_str = if connection_str.starts_with("postgres-embed") {
             let database_dir = config.postgres_embed_data_dir();
-            let pg = pg_setup::embedded::install(database_dir, true, Some(8082)).await?;
+            let pg = pg_setup::install(database_dir, true, Some(8082)).await?;
             let connection_string = pg.db_uri.to_string();
             let _ = PG.set(pg);
             connection_string

--- a/crates/pipeline_manager/src/db/pg_setup.rs
+++ b/crates/pipeline_manager/src/db/pg_setup.rs
@@ -3,47 +3,50 @@
 //! It caches the downloaded binaries as well. Check the `pg_embed` crate for
 //! more details.
 
-use crate::AnyResult;
-use pg_embed::pg_enums::PgAuthMethod;
-use pg_embed::pg_fetch::{PgFetchSettings, PG_V15};
-use pg_embed::postgres::{PgEmbed, PgSettings};
-use std::path::PathBuf;
+#[cfg(feature = "dev")]
+pub mod embedded {
+    use crate::AnyResult;
+    use pg_embed::pg_enums::PgAuthMethod;
+    use pg_embed::pg_fetch::{PgFetchSettings, PG_V15};
+    use pg_embed::postgres::{PgEmbed, PgSettings};
+    use std::path::PathBuf;
 
-/// Install and start an embedded postgres DB instance. This only runs if the
-/// manager is started with postgres-embedded.
-///
-/// # Arguments
-/// - `database_dir` - Path to the directory where the database files will be
-///   stored.
-/// - `persistent` - If true, the database will be persistent. If false, the
-///   database will be deleted after the process exits.
-/// - `port` - The port on which the database will be available on.
-pub(crate) async fn install(
-    database_dir: PathBuf,
-    persistent: bool,
-    port: Option<u16>,
-) -> AnyResult<PgEmbed> {
-    let pg_settings = PgSettings {
-        database_dir,
-        port: port.unwrap_or(5432),
-        user: "postgres".to_string(),
-        password: "postgres".to_string(),
-        auth_method: PgAuthMethod::Plain,
-        persistent,
-        timeout: None,
-        migration_dir: None,
-    };
+    /// Install and start an embedded postgres DB instance. This only runs if
+    /// the manager is started with postgres-embedded.
+    ///
+    /// # Arguments
+    /// - `database_dir` - Path to the directory where the database files will
+    ///   be stored.
+    /// - `persistent` - If true, the database will be persistent. If false, the
+    ///   database will be deleted after the process exits.
+    /// - `port` - The port on which the database will be available on.
+    pub(crate) async fn install(
+        database_dir: PathBuf,
+        persistent: bool,
+        port: Option<u16>,
+    ) -> AnyResult<PgEmbed> {
+        let pg_settings = PgSettings {
+            database_dir,
+            port: port.unwrap_or(5432),
+            user: "postgres".to_string(),
+            password: "postgres".to_string(),
+            auth_method: PgAuthMethod::Plain,
+            persistent,
+            timeout: None,
+            migration_dir: None,
+        };
 
-    let fetch_settings = PgFetchSettings {
-        version: PG_V15,
-        ..Default::default()
-    };
+        let fetch_settings = PgFetchSettings {
+            version: PG_V15,
+            ..Default::default()
+        };
 
-    let mut pg = PgEmbed::new(pg_settings, fetch_settings).await?;
+        let mut pg = PgEmbed::new(pg_settings, fetch_settings).await?;
 
-    // Download, unpack, create password file and database cluster
-    pg.setup().await?;
-    pg.start_db().await?;
+        // Download, unpack, create password file and database cluster
+        pg.setup().await?;
+        pg.start_db().await?;
 
-    Ok(pg)
+        Ok(pg)
+    }
 }

--- a/crates/pipeline_manager/src/db/pg_setup.rs
+++ b/crates/pipeline_manager/src/db/pg_setup.rs
@@ -3,50 +3,47 @@
 //! It caches the downloaded binaries as well. Check the `pg_embed` crate for
 //! more details.
 
-#[cfg(feature = "dev")]
-pub mod embedded {
-    use crate::AnyResult;
-    use pg_embed::pg_enums::PgAuthMethod;
-    use pg_embed::pg_fetch::{PgFetchSettings, PG_V15};
-    use pg_embed::postgres::{PgEmbed, PgSettings};
-    use std::path::PathBuf;
+use crate::AnyResult;
+use pg_embed::pg_enums::PgAuthMethod;
+use pg_embed::pg_fetch::{PgFetchSettings, PG_V15};
+use pg_embed::postgres::{PgEmbed, PgSettings};
+use std::path::PathBuf;
 
-    /// Install and start an embedded postgres DB instance. This only runs if
-    /// the manager is started with postgres-embedded.
-    ///
-    /// # Arguments
-    /// - `database_dir` - Path to the directory where the database files will
-    ///   be stored.
-    /// - `persistent` - If true, the database will be persistent. If false, the
-    ///   database will be deleted after the process exits.
-    /// - `port` - The port on which the database will be available on.
-    pub(crate) async fn install(
-        database_dir: PathBuf,
-        persistent: bool,
-        port: Option<u16>,
-    ) -> AnyResult<PgEmbed> {
-        let pg_settings = PgSettings {
-            database_dir,
-            port: port.unwrap_or(5432),
-            user: "postgres".to_string(),
-            password: "postgres".to_string(),
-            auth_method: PgAuthMethod::Plain,
-            persistent,
-            timeout: None,
-            migration_dir: None,
-        };
+/// Install and start an embedded postgres DB instance. This only runs if
+/// the manager is started with postgres-embedded.
+///
+/// # Arguments
+/// - `database_dir` - Path to the directory where the database files will be
+///   stored.
+/// - `persistent` - If true, the database will be persistent. If false, the
+///   database will be deleted after the process exits.
+/// - `port` - The port on which the database will be available on.
+pub(crate) async fn install(
+    database_dir: PathBuf,
+    persistent: bool,
+    port: Option<u16>,
+) -> AnyResult<PgEmbed> {
+    let pg_settings = PgSettings {
+        database_dir,
+        port: port.unwrap_or(5432),
+        user: "postgres".to_string(),
+        password: "postgres".to_string(),
+        auth_method: PgAuthMethod::Plain,
+        persistent,
+        timeout: None,
+        migration_dir: None,
+    };
 
-        let fetch_settings = PgFetchSettings {
-            version: PG_V15,
-            ..Default::default()
-        };
+    let fetch_settings = PgFetchSettings {
+        version: PG_V15,
+        ..Default::default()
+    };
 
-        let mut pg = PgEmbed::new(pg_settings, fetch_settings).await?;
+    let mut pg = PgEmbed::new(pg_settings, fetch_settings).await?;
 
-        // Download, unpack, create password file and database cluster
-        pg.setup().await?;
-        pg.start_db().await?;
+    // Download, unpack, create password file and database cluster
+    pg.setup().await?;
+    pg.start_db().await?;
 
-        Ok(pg)
-    }
+    Ok(pg)
 }

--- a/crates/pipeline_manager/src/db/test.rs
+++ b/crates/pipeline_manager/src/db/test.rs
@@ -55,7 +55,7 @@ async fn test_setup() -> DbHandle {
             .map(|l| l.port())
             .unwrap_or(DB_PORT_COUNTER.fetch_add(1, Ordering::Relaxed))
     };
-    let pg = pg_setup::embedded::install(temp_path.into(), false, Some(port))
+    let pg = pg_setup::install(temp_path.into(), false, Some(port))
         .await
         .unwrap();
 

--- a/crates/pipeline_manager/src/db/test.rs
+++ b/crates/pipeline_manager/src/db/test.rs
@@ -3,10 +3,11 @@ use super::{
     storage::Storage, AttachedConnector, ConfigDescr, ConfigId, ConnectorDescr, ConnectorId,
     ConnectorType, PipelineId, ProjectDB, ProjectDescr, ProjectId, ProjectStatus, Version,
 };
-use crate::db::DBError;
+use crate::db::{pg_setup, DBError};
 use anyhow::Result as AnyResult;
 use async_trait::async_trait;
 use chrono::DateTime;
+use pg_embed::postgres::PgEmbed;
 use pretty_assertions::assert_eq;
 use proptest::prelude::*;
 use proptest::test_runner::{Config, TestRunner};
@@ -20,6 +21,7 @@ use tokio::sync::Mutex;
 
 struct DbHandle {
     db: ProjectDB,
+    pg: PgEmbed,
     _temp_dir: TempDir,
 }
 
@@ -29,11 +31,9 @@ impl Drop for DbHandle {
         // shutdown postgres). Otherwise postgres log an error that the
         // directory is already gone during shutdown which could be
         // confusing for a developer.
-        if let Some(pg) = self.db.pg.as_mut() {
-            let _r = async {
-                pg.stop_db().await.unwrap();
-            };
-        }
+        let _r = async {
+            self.pg.stop_db().await.unwrap();
+        };
     }
 }
 
@@ -55,19 +55,17 @@ async fn test_setup() -> DbHandle {
             .map(|l| l.port())
             .unwrap_or(DB_PORT_COUNTER.fetch_add(1, Ordering::Relaxed))
     };
+    let pg = pg_setup::embedded::install(temp_path.into(), false, Some(port))
+        .await
+        .unwrap();
 
-    let conn = ProjectDB::connect_inner(
-        "postgres-embed",
-        &Some("".to_string()),
-        temp_path.into(),
-        false,
-        Some(port),
-    )
-    .await
-    .unwrap();
+    let conn = ProjectDB::connect_inner(&pg.db_uri, &Some("".to_string()))
+        .await
+        .unwrap();
 
     DbHandle {
         db: conn,
+        pg: pg,
         _temp_dir,
     }
 }

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -26,13 +26,13 @@ RUN /root/.cargo/bin/cargo chef prepare --recipe-path recipe.json
 # layer for faster incremental builds of source-code only changes
 FROM chef AS builder
 COPY --from=planner /app/recipe.json recipe.json
-RUN /root/.cargo/bin/cargo chef cook --release --recipe-path recipe.json --bin=dbsp_pipeline_manager
+RUN /root/.cargo/bin/cargo chef cook --release --recipe-path recipe.json --bin=dbsp_pipeline_manager --no-default-features
 COPY . .
 RUN rm /app/crates/dbsp/benches/ldbc-graphalytics.rs \
     && rm /app/crates/dbsp/benches/gdelt.rs \
     && rm /app/crates/nexmark/benches/nexmark.rs \
     && rm /app/crates/nexmark/benches/nexmark-gen.rs
-RUN /root/.cargo/bin/cargo build --release --bin=dbsp_pipeline_manager
+RUN /root/.cargo/bin/cargo build --release --bin=dbsp_pipeline_manager --no-default-features
 
 # Java build can be performed in parallel
 FROM base as javabuild

--- a/scripts/start_manager.sh
+++ b/scripts/start_manager.sh
@@ -37,4 +37,5 @@ cd "${MANAGER_DIR}" && ~/.cargo/bin/cargo run --release -- \
     --sql-compiler-home="${SQL_COMPILER_DIR}" \
     --dbsp-override-path="${ROOT_DIR}" \
     --static-html=static \
-    --unix-daemon
+    --unix-daemon \
+    --db-connection-string="postgres-embed"


### PR DESCRIPTION
* Conditionally build pg-embed use outside tests using a "dev" feature flag, enabled by default
* Separate PgEmbed out from ProjectDB
* Update Docker build to use non-default builds