### PR TITLE
String functions

### DIFF
--- a/crates/dataflow-jit/TODO.md
+++ b/crates/dataflow-jit/TODO.md
@@ -66,14 +66,14 @@
   - [ ] `@dbsp.min()`
   - [ ] `@dbsp.max()`
   - [x] `@dbsp.error.abort()`
-  - [x] `@dbsp.row.vec.push`
-  - [ ] `@dbsp.row.vec.reserve`
+  - [x] `@dbsp.row.vec.push()`
+  - [ ] `@dbsp.row.vec.reserve()`
   - [ ] String manipulation
-    - [x] `@dbsp.str.truncate`
-    - [x] `@dbsp.str.truncate_clone`
-    - [x] `@dbsp.str.clear`
-    - [x] `@dbsp.str.concat`
-    - [x] `@dbsp.str.concat_clone`
+    - [x] `@dbsp.str.truncate()`
+    - [x] `@dbsp.str.truncate_clone()`
+    - [x] `@dbsp.str.clear()`
+    - [x] `@dbsp.str.concat()` (Can now concat an unbounded number of strings)
+    - [x] `@dbsp.str.concat_clone()` (Can now concat an unbounded number of strings)
     - [ ] `@dbsp.str.is_normalized()` (check for NFC, NFD, NFKC or NFKD normalization)
       - [x] `@dbsp.str.is_nfc()`
       - [x] `@dbsp.str.is_nfd()`
@@ -90,6 +90,7 @@
     - [x] `@dbsp.str.is_uppercase()`
     - [ ] `@dbsp.str.to_uppercase()`
     - [ ] `@dbsp.str.make_uppercase()`
+    - [x] `@dbsp.str.is_ascii()`
   - [ ] Vec/Array manipulation
   - [ ] Timestamp manipulation
     - [x] `@dbsp.timestamp.epoch`

--- a/crates/dataflow-jit/TODO.md
+++ b/crates/dataflow-jit/TODO.md
@@ -91,6 +91,7 @@
     - [ ] `@dbsp.str.to_uppercase()`
     - [ ] `@dbsp.str.make_uppercase()`
     - [x] `@dbsp.str.is_ascii()`
+    - [x] `@dbsp.str.write()`
   - [ ] Vec/Array manipulation
   - [ ] Timestamp manipulation
     - [x] `@dbsp.timestamp.epoch`

--- a/crates/dataflow-jit/src/codegen/mod.rs
+++ b/crates/dataflow-jit/src/codegen/mod.rs
@@ -58,7 +58,7 @@ const TRAP_NULL_PTR: TrapCode = TrapCode::User(0);
 const TRAP_UNALIGNED_PTR: TrapCode = TrapCode::User(1);
 const TRAP_INVALID_BOOL: TrapCode = TrapCode::User(2);
 const TRAP_ASSERT_EQ: TrapCode = TrapCode::User(3);
-const TRAP_CAPACITY_OVERFLOW: TrapCode = TrapCode::User(4);
+// const TRAP_CAPACITY_OVERFLOW: TrapCode = TrapCode::User(4);
 const TRAP_DIV_OVERFLOW: TrapCode = TrapCode::User(5);
 const TRAP_ABORT: TrapCode = TrapCode::User(6);
 

--- a/crates/dataflow-jit/src/codegen/vtable/debug.rs
+++ b/crates/dataflow-jit/src/codegen/vtable/debug.rs
@@ -168,26 +168,26 @@ impl Codegen {
 
                             ColumnType::U8 | ColumnType::U16 | ColumnType::U32 => {
                                 value = builder.ins().uextend(types::I64, value);
-                                "uint_debug"
+                                "u64_debug"
                             }
-                            ColumnType::U64 => "uint_debug",
+                            ColumnType::U64 => "u64_debug",
 
-                            ColumnType::Usize if ptr_ty == types::I64 => "uint_debug",
+                            ColumnType::Usize if ptr_ty == types::I64 => "u64_debug",
                             ColumnType::Usize => {
                                 value = builder.ins().uextend(types::I64, value);
-                                "uint_debug"
+                                "u64_debug"
                             }
 
                             ColumnType::I8 | ColumnType::I16 | ColumnType::I32 => {
                                 value = builder.ins().sextend(types::I64, value);
-                                "int_debug"
+                                "i64_debug"
                             }
-                            ColumnType::I64 => "int_debug",
+                            ColumnType::I64 => "i64_debug",
 
-                            ColumnType::Isize if ptr_ty == types::I64 => "int_debug",
+                            ColumnType::Isize if ptr_ty == types::I64 => "i64_debug",
                             ColumnType::Isize => {
                                 value = builder.ins().sextend(types::I64, value);
-                                "int_debug"
+                                "i64_debug"
                             }
 
                             ColumnType::F32 => "f32_debug",

--- a/crates/dataflow-jit/src/ir/validate.rs
+++ b/crates/dataflow-jit/src/ir/validate.rs
@@ -874,6 +874,33 @@ impl FunctionValidator {
                 assert_eq!(call.ret_ty(), ColumnType::Bool);
             }
 
+            "dbsp.str.write" => {
+                if call.args().len() != 2 {
+                    return Err(ValidationError::IncorrectFunctionArgLen {
+                        expr_id,
+                        function: call.function().to_owned(),
+                        expected_args: 2,
+                        args: call.args().len(),
+                    });
+                }
+
+                if actual_arg_types[0] != ArgType::Scalar(ColumnType::String) {
+                    todo!(
+                        "mismatched argument type in {expr_id}, argument 0 should be a string but instead got {:?}",
+                        actual_arg_types[0],
+                    );
+                }
+
+                if !actual_arg_types[1].is_scalar() {
+                    todo!(
+                        "mismatched argument type in {expr_id}, argument 1 should be a scalar but instead got {:?}",
+                        actual_arg_types[1],
+                    );
+                }
+
+                assert_eq!(call.ret_ty(), ColumnType::String);
+            }
+
             "dbsp.timestamp.epoch"
             | "dbsp.timestamp.year"
             | "dbsp.timestamp.month"

--- a/crates/dataflow-jit/src/ir/validate.rs
+++ b/crates/dataflow-jit/src/ir/validate.rs
@@ -703,6 +703,8 @@ impl FunctionValidator {
                         args: call.args().len(),
                     });
                 }
+
+                assert_eq!(call.ret_ty(), ColumnType::Unit);
             }
 
             "dbsp.row.vec.push" => {
@@ -726,6 +728,8 @@ impl FunctionValidator {
                 if actual_arg_types[1].is_scalar() {
                     todo!("passed a scalar as the second argument to `@dbsp.row.vec.push()` in {expr_id} when it should be a row value")
                 }
+
+                assert_eq!(call.ret_ty(), ColumnType::Unit);
             }
 
             "dbsp.str.truncate" => {
@@ -751,6 +755,8 @@ impl FunctionValidator {
                         actual_arg_types[1],
                     );
                 }
+
+                assert_eq!(call.ret_ty(), ColumnType::Unit);
             }
 
             "dbsp.str.truncate_clone" => {
@@ -776,6 +782,8 @@ impl FunctionValidator {
                         actual_arg_types[1],
                     );
                 }
+
+                assert_eq!(call.ret_ty(), ColumnType::String);
             }
 
             "dbsp.str.clear" => {
@@ -794,10 +802,12 @@ impl FunctionValidator {
                         actual_arg_types[0],
                     );
                 }
+
+                assert_eq!(call.ret_ty(), ColumnType::Unit);
             }
 
-            "dbsp.str.concat" => {
-                if call.args().len() != 2 {
+            "dbsp.str.concat" | "dbsp.str.concat_clone" => {
+                if call.args().len() < 2 {
                     return Err(ValidationError::IncorrectFunctionArgLen {
                         expr_id,
                         function: call.function().to_owned(),
@@ -806,44 +816,16 @@ impl FunctionValidator {
                     });
                 }
 
-                if actual_arg_types[0] != ArgType::Scalar(ColumnType::String) {
-                    todo!(
-                        "mismatched argument type in {expr_id}, should be a string but instead got {:?}",
-                        actual_arg_types[0],
-                    );
+                for (idx, arg) in actual_arg_types.iter().enumerate() {
+                    if arg != &ArgType::Scalar(ColumnType::String) {
+                        todo!(
+                            "mismatched argument type in {expr_id}, argument {idx} should be a string but instead got {:?}",
+                            arg,
+                        );
+                    }
                 }
 
-                if actual_arg_types[1] != ArgType::Scalar(ColumnType::String) {
-                    todo!(
-                        "mismatched argument type in {expr_id}, should be a string but instead got {:?}",
-                        actual_arg_types[1],
-                    );
-                }
-            }
-
-            "dbsp.str.concat_clone" => {
-                if call.args().len() != 2 {
-                    return Err(ValidationError::IncorrectFunctionArgLen {
-                        expr_id,
-                        function: call.function().to_owned(),
-                        expected_args: 2,
-                        args: call.args().len(),
-                    });
-                }
-
-                if actual_arg_types[0] != ArgType::Scalar(ColumnType::String) {
-                    todo!(
-                        "mismatched argument type in {expr_id}, should be a string but instead got {:?}",
-                        actual_arg_types[0],
-                    );
-                }
-
-                if actual_arg_types[1] != ArgType::Scalar(ColumnType::String) {
-                    todo!(
-                        "mismatched argument type in {expr_id}, should be a string but instead got {:?}",
-                        actual_arg_types[1],
-                    );
-                }
+                assert_eq!(call.ret_ty(), ColumnType::String);
             }
 
             "dbsp.str.bit_length" | "dbsp.str.char_length" | "dbsp.str.byte_length" => {
@@ -862,6 +844,8 @@ impl FunctionValidator {
                         actual_arg_types[0],
                     );
                 }
+
+                assert_eq!(call.ret_ty(), ColumnType::Usize);
             }
 
             "dbsp.str.is_nfc"
@@ -869,7 +853,8 @@ impl FunctionValidator {
             | "dbsp.str.is_nfkc"
             | "dbsp.str.is_nfkd"
             | "dbsp.str.is_lowercase"
-            | "dbsp.str.is_uppercase" => {
+            | "dbsp.str.is_uppercase"
+            | "dbsp.str.is_ascii" => {
                 if call.args().len() != 1 {
                     return Err(ValidationError::IncorrectFunctionArgLen {
                         expr_id,
@@ -885,6 +870,8 @@ impl FunctionValidator {
                         actual_arg_types[0],
                     );
                 }
+
+                assert_eq!(call.ret_ty(), ColumnType::Bool);
             }
 
             "dbsp.timestamp.epoch"

--- a/crates/dataflow-jit/src/thin_str/mod.rs
+++ b/crates/dataflow-jit/src/thin_str/mod.rs
@@ -194,6 +194,12 @@ impl ThinStr {
         unsafe { ThinStrRef::from_raw(self.buf) }
     }
 
+    pub fn reserve(&mut self, additional: usize) {
+        if additional > self.capacity() - self.len() {
+            self.grow(additional);
+        }
+    }
+
     #[inline]
     fn from_str(string: &str) -> Self {
         if string.is_empty() {

--- a/crates/dataflow-jit/src/thin_str/mod.rs
+++ b/crates/dataflow-jit/src/thin_str/mod.rs
@@ -563,6 +563,18 @@ impl Clone for ThinStr {
     }
 }
 
+impl fmt::Write for ThinStr {
+    fn write_str(&mut self, string: &str) -> fmt::Result {
+        self.push_str(string);
+        Ok(())
+    }
+
+    fn write_char(&mut self, c: char) -> fmt::Result {
+        self.push(c);
+        Ok(())
+    }
+}
+
 impl Drop for ThinStr {
     fn drop(&mut self) {
         if self.capacity() != 0 {

--- a/crates/dataflow-jit/src/thin_str/str_ref.rs
+++ b/crates/dataflow-jit/src/thin_str/str_ref.rs
@@ -16,7 +16,7 @@ use std::{
 #[repr(transparent)]
 pub struct ThinStrRef<'a> {
     buf: NonNull<StrHeader>,
-    __lifetime: PhantomData<&'a ()>,
+    __lifetime: PhantomData<&'a str>,
 }
 
 impl<'a> ThinStrRef<'a> {


### PR DESCRIPTION
- Implemented `@dbsp.str.is_ascii()`
- Made `@dbsp.str.concat()` return a string
- Made `@dbsp.str.concat()` and `@dbsp.str.concat_clone()` variadic, meaning they can take multiple parameters, e.g. `@dbsp.str.concat_clone("foo", " ", "bar", " ", "baz")`
- Implemented `@dbsp.str.write()` which takes a string and a scalar and writes the scalar value to the string, e.g. `@dbsp.str.write("whee", 10i32) -> "whee10"`

cc @mbudiu-vmw for function changes